### PR TITLE
add rect mask content

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,62 @@ Notes:
 - Masks still use a separate mask shader program.
 - Current SDF modes include clip/AA fills, annular (outline) modes, and drop/inset shadow modes used by the renderer.
 
+## Fast Rect Masks
+
+Use `NfClipContent` when a node needs normal clipping semantics. It renders a
+mask and applies it to the node's content, which is flexible but can force the
+backend to flush queued draws around the mask pass.
+
+Use `NfRectMaskContent` when the mask shape is just the node's rounded
+rectangle and the content is small leaf-style UI content, such as cells in a
+list/table, clipped buttons, pills, badges, or compact panels. On Metal this is
+evaluated as a per-fragment rounded-rect SDF mask, so it can avoid the extra
+mask pass for the first active rect mask and keep more draw work batched. Other
+backends fall back to the normal mask behavior, so the flag is safe to use
+before every backend has a fast implementation.
+
+`NfRectMaskContent` also composes with `NfClipContent`: a scroll viewport can
+use `NfClipContent`, while each small child item inside it uses
+`NfRectMaskContent`.
+
+Example:
+
+```nim
+let viewport = result.addRoot(0.ZLevel, Fig(
+  kind: nkRectangle,
+  screenBox: rect(24, 24, w - 48, h - 48),
+  fill: rgba(235, 238, 244, 255),
+  corners: [12'u16, 12'u16, 12'u16, 12'u16],
+  flags: {NfClipContent},
+))
+
+let row = result.addChild(0.ZLevel, viewport, Fig(
+  kind: nkRectangle,
+  screenBox: rect(32, 40, w - 64, 28),
+  fill: rgba(255, 255, 255, 255),
+  corners: [6'u16, 6'u16, 6'u16, 6'u16],
+  flags: {NfRectMaskContent},
+))
+
+# These children can overflow `row`; `NfRectMaskContent` masks them to the
+# row's rounded rectangle.
+discard result.addChild(0.ZLevel, row, Fig(
+  kind: nkRectangle,
+  screenBox: rect(20, 44, w - 40, 8),
+  fill: rgba(43, 159, 234, 255),
+  corners: [3'u16, 3'u16, 3'u16, 3'u16],
+))
+```
+
+To compare the two paths on your machine:
+
+```sh
+nim r examples/windy_clip_mask_benchmark.nim
+```
+
+The benchmark renders a table-like scene and compares `clip + sub-clip` against
+`clip + rect-mask`.
+
 ## Useful Defines
 
 - `-d:figdraw.names=true`: enables `Fig.name` for debugging (enabled for tests in `tests/config.nims`)

--- a/README.md
+++ b/README.md
@@ -313,20 +313,11 @@ Notes:
 
 ## Fast Rect Masks
 
-Use `NfClipContent` when a node needs normal clipping semantics. It renders a
-mask and applies it to the node's content, which is flexible but can force the
-backend to flush queued draws around the mask pass.
+Use `NfClipContent` when a node needs normal clipping semantics. It renders a mask and applies it to the node's content, which is flexible but can force the backend to flush queued draws around the mask pass.
 
-Use `NfRectMaskContent` when the mask shape is just the node's rounded
-rectangle and the content is small leaf-style UI content, such as cells in a
-list/table, clipped buttons, pills, badges, or compact panels. On Metal this is
-evaluated as a per-fragment rounded-rect SDF mask, so it can avoid the extra
-mask pass for the first active rect mask and keep more draw work batched. Other
-backends fall back to the normal mask behavior, so the flag is safe to use
-before every backend has a fast implementation.
+Use `NfRectMaskContent` when the mask shape is just the node's rounded rectangle and the content is small leaf-style UI content, such as cells in a list/table, clipped buttons, pills, badges, or compact panels. On Metal this is evaluated as a per-fragment rounded-rect SDF mask, so it can avoid the extra mask pass for the first active rect mask and keep more draw work batched. Other backends fall back to the normal mask behavior, so the flag is safe to use before every backend has a fast implementation.
 
-`NfRectMaskContent` also composes with `NfClipContent`: a scroll viewport can
-use `NfClipContent`, while each small child item inside it uses
+`NfRectMaskContent` also composes with `NfClipContent`: a scroll viewport can use `NfClipContent`, while each small child item inside it uses
 `NfRectMaskContent`.
 
 Example:

--- a/examples/windy_clip_mask_benchmark.nim
+++ b/examples/windy_clip_mask_benchmark.nim
@@ -256,8 +256,8 @@ when isMainModule:
         BenchRows * BenchCols, " (", BenchRows, " rows x ", BenchCols, " cols)"
       echo "nodes: ", nodeCount
       echo "warmup frames: ", WarmupFrames, " | timed frames: ", TimedFrames
-      if renderer.backendKind() != rbMetal:
-        echo "note: NfRectMaskContent fast path is currently Metal-only; this backend uses fallback behavior."
+      if renderer.backendKind() == rbVulkan:
+        echo "note: this backend uses fallback mask-texture behavior for NfRectMaskContent."
       echo ""
       let
         caseHeader = "case"

--- a/examples/windy_clip_mask_benchmark.nim
+++ b/examples/windy_clip_mask_benchmark.nim
@@ -35,7 +35,7 @@ type
     p95Ms: float64
     maxMs: float64
 
-func elapsedMs(started: MonoTime): float64 =
+proc elapsedMs(started: MonoTime): float64 =
   (getMonoTime() - started).inNanoseconds.float64 / 1_000_000.0
 
 func percentile(sortedSamples: seq[float64], p: float64): float64 =

--- a/examples/windy_clip_mask_benchmark.nim
+++ b/examples/windy_clip_mask_benchmark.nim
@@ -1,0 +1,281 @@
+import std/[algorithm, math, monotimes, strformat, times]
+
+import figdraw/windyshim
+
+import figdraw/commons
+import figdraw/fignodes
+import figdraw/figrender
+
+const BenchRows {.intdefine: "figdraw.bench.rows".} = 180
+const BenchCols {.intdefine: "figdraw.bench.cols".} = 6
+const WarmupFrames {.intdefine: "figdraw.bench.warmup".} = 20
+const TimedFrames {.intdefine: "figdraw.bench.frames".} = 120
+const WindowW {.intdefine: "figdraw.bench.windowW".} = 1200
+const WindowH {.intdefine: "figdraw.bench.windowH".} = 800
+
+static:
+  doAssert BenchRows > 0, "figdraw.bench.rows must be positive"
+  doAssert BenchCols > 0, "figdraw.bench.cols must be positive"
+  doAssert WarmupFrames >= 0, "figdraw.bench.warmup must be non-negative"
+  doAssert TimedFrames > 0, "figdraw.bench.frames must be positive"
+  doAssert WindowW > 0 and WindowH > 0, "benchmark window size must be positive"
+  doAssert 2 + BenchRows * BenchCols * 4 <= high(int16).int,
+    "benchmark render tree exceeds FigIdx int16 capacity"
+
+type
+  BenchKind = enum
+    bkSubClip
+    bkRectMask
+
+  BenchStats = object
+    count: int
+    minMs: float64
+    avgMs: float64
+    p50Ms: float64
+    p95Ms: float64
+    maxMs: float64
+
+func elapsedMs(started: MonoTime): float64 =
+  (getMonoTime() - started).inNanoseconds.float64 / 1_000_000.0
+
+func percentile(sortedSamples: seq[float64], p: float64): float64 =
+  if sortedSamples.len == 0:
+    return 0.0
+
+  let rawIndex = int(round((sortedSamples.len - 1).float64 * p))
+  let idx = min(max(rawIndex, 0), sortedSamples.len - 1)
+  sortedSamples[idx]
+
+proc summarize(samples: seq[float64]): BenchStats =
+  if samples.len == 0:
+    return BenchStats()
+
+  var sortedSamples = samples
+  sortedSamples.sort()
+
+  var total = 0.0
+  for sample in samples:
+    total += sample
+
+  BenchStats(
+    count: samples.len,
+    minMs: sortedSamples[0],
+    avgMs: total / samples.len.float64,
+    p50Ms: percentile(sortedSamples, 0.50),
+    p95Ms: percentile(sortedSamples, 0.95),
+    maxMs: sortedSamples[^1],
+  )
+
+proc addRect(
+    list: var RenderList,
+    parentIdx: FigIdx,
+    rectBox: Rect,
+    color: ColorRGBA,
+    flags: set[FigFlags] = {},
+    corners: uint16 = 0'u16,
+): FigIdx =
+  list.addChild(
+    parentIdx,
+    Fig(
+      kind: nkRectangle,
+      childCount: 0,
+      zlevel: 0.ZLevel,
+      screenBox: rectBox,
+      fill: color,
+      corners: [corners, corners, corners, corners],
+      flags: flags,
+    ),
+  )
+
+proc addRootRect(
+    list: var RenderList,
+    rectBox: Rect,
+    color: ColorRGBA,
+    flags: set[FigFlags] = {},
+    corners: uint16 = 0'u16,
+): FigIdx =
+  list.addRoot(
+    Fig(
+      kind: nkRectangle,
+      childCount: 0,
+      zlevel: 0.ZLevel,
+      screenBox: rectBox,
+      fill: color,
+      corners: [corners, corners, corners, corners],
+      flags: flags,
+    )
+  )
+
+proc addCellContent(
+    list: var RenderList, cellIdx: FigIdx, cellRect: Rect, row, col: int
+) =
+  let
+    tone = uint8(42 + (row * 7 + col * 17) mod 72)
+    accent = rgba(36'u8, uint8(120 + (row * 5) mod 80), 235'u8, 255'u8)
+    spill = rgba(tone, uint8(170 - (col * 11) mod 70), 220'u8, 255'u8)
+    muted = rgba(uint8(190 + (row + col) mod 30), 210'u8, 220'u8, 255'u8)
+
+  discard list.addRect(
+    cellIdx,
+    rect(cellRect.x - 12.0'f32, cellRect.y + 4.0'f32, cellRect.w + 24.0'f32, 5.0'f32),
+    accent,
+    corners = 2'u16,
+  )
+  discard list.addRect(
+    cellIdx,
+    rect(
+      cellRect.x + cellRect.w * 0.38'f32,
+      cellRect.y - 5.0'f32,
+      cellRect.w * 0.74'f32,
+      cellRect.h + 10.0'f32,
+    ),
+    spill,
+    corners = 3'u16,
+  )
+  discard list.addRect(
+    cellIdx,
+    rect(
+      cellRect.x + 7.0'f32,
+      cellRect.y + cellRect.h - 7.0'f32,
+      cellRect.w - 14.0'f32,
+      8.0'f32,
+    ),
+    muted,
+    corners = 2'u16,
+  )
+
+proc makeTableRenderTree(kind: BenchKind, w, h: float32): Renders =
+  let
+    bgColor = rgba(248, 249, 251, 255)
+    viewportColor = rgba(232, 235, 240, 255)
+    cellBase = rgba(255, 255, 255, 255)
+    cellAlt = rgba(242, 246, 250, 255)
+    margin = 22.0'f32
+    gap = 4.0'f32
+    viewport = rect(margin, margin, w - margin * 2.0'f32, h - margin * 2.0'f32)
+    cellH = 22.0'f32
+    cellW = (viewport.w - gap * (BenchCols + 1).float32) / BenchCols.float32
+    scrollY = 37.0'f32
+
+  var list = RenderList()
+  discard list.addRootRect(rect(0.0'f32, 0.0'f32, w, h), bgColor)
+
+  let viewportIdx =
+    list.addRootRect(viewport, viewportColor, flags = {NfClipContent}, corners = 10'u16)
+
+  for row in 0 ..< BenchRows:
+    let y = viewport.y + gap + row.float32 * (cellH + gap) - scrollY
+    for col in 0 ..< BenchCols:
+      let
+        x = viewport.x + gap + col.float32 * (cellW + gap)
+        cellRect = rect(x, y, cellW, cellH)
+        cellFlags =
+          case kind
+          of bkSubClip:
+            {NfClipContent}
+          of bkRectMask:
+            {NfRectMaskContent}
+        cellColor = if (row + col) mod 2 == 0: cellBase else: cellAlt
+
+      let cellIdx = list.addRect(viewportIdx, cellRect, cellColor, cellFlags, 4'u16)
+      list.addCellContent(cellIdx, cellRect, row, col)
+
+  result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
+  result.layers[0.ZLevel] = list
+
+proc drainGpu[BackendState](renderer: FigRenderer[BackendState]) =
+  try:
+    discard renderer.takeScreenshot(rect(0, 0, 1, 1), readFront = false)
+  except CatchableError:
+    discard
+
+proc renderOneFrame[BackendState](
+    renderer: FigRenderer[BackendState], renders: var Renders, frameSize: Vec2
+) =
+  renderer.beginFrame()
+  renderer.renderFrame(renders, frameSize)
+  renderer.endFrame()
+
+proc warmup[BackendState](
+    renderer: FigRenderer[BackendState], renders: var Renders, frameSize: Vec2
+) =
+  for _ in 0 ..< WarmupFrames:
+    pollEvents()
+    renderer.renderOneFrame(renders, frameSize)
+  renderer.drainGpu()
+
+proc benchmarkCase[BackendState](
+    renderer: FigRenderer[BackendState],
+    label: string,
+    renders: var Renders,
+    frameSize: Vec2,
+): BenchStats =
+  renderer.warmup(renders, frameSize)
+
+  var samples = newSeqOfCap[float64](TimedFrames)
+  for _ in 0 ..< TimedFrames:
+    pollEvents()
+    let started = getMonoTime()
+    renderer.renderOneFrame(renders, frameSize)
+    samples.add elapsedMs(started)
+
+  renderer.drainGpu()
+  result = summarize(samples)
+
+  echo fmt"{label:<22} {result.avgMs:>9.3f} {result.p50Ms:>9.3f} " &
+    fmt"{result.p95Ms:>9.3f} {result.minMs:>9.3f} {result.maxMs:>9.3f} " &
+    fmt"{1000.0 / result.avgMs:>9.1f}"
+
+when isMainModule:
+  when defined(emscripten):
+    echo "windy_clip_mask_benchmark is native-only."
+  else:
+    let
+      title = windyWindowTitle("Clip vs Rect Mask Benchmark")
+      size = ivec2(WindowW.int32, WindowH.int32)
+      window = newWindyWindow(size = size, fullscreen = false, title = title)
+
+    setFigUiScale window.contentScale()
+    if size != size.scaled():
+      window.size = size.scaled()
+
+    let renderer = newFigRenderer(atlasSize = 512, backendState = WindyRenderBackend())
+    renderer.setupBackend(window)
+
+    try:
+      pollEvents()
+      let frameSize = window.logicalSize()
+      var subClipRenders = makeTableRenderTree(bkSubClip, frameSize.x, frameSize.y)
+      var rectMaskRenders = makeTableRenderTree(bkRectMask, frameSize.x, frameSize.y)
+      let nodeCount = subClipRenders.layers[0.ZLevel].nodes.len
+
+      echo "FigDraw clip/mask benchmark"
+      echo "backend: ", renderer.backendName()
+      echo "window: ", frameSize.x.int, "x", frameSize.y.int
+      echo "cells: ",
+        BenchRows * BenchCols, " (", BenchRows, " rows x ", BenchCols, " cols)"
+      echo "nodes: ", nodeCount
+      echo "warmup frames: ", WarmupFrames, " | timed frames: ", TimedFrames
+      if renderer.backendKind() != rbMetal:
+        echo "note: NfRectMaskContent fast path is currently Metal-only; this backend uses fallback behavior."
+      echo ""
+      let
+        caseHeader = "case"
+        avgHeader = "avg ms"
+        p50Header = "p50 ms"
+        p95Header = "p95 ms"
+        minHeader = "min ms"
+        maxHeader = "max ms"
+        fpsHeader = "fps"
+      echo fmt"{caseHeader:<22} {avgHeader:>9} {p50Header:>9} " &
+        fmt"{p95Header:>9} {minHeader:>9} {maxHeader:>9} {fpsHeader:>9}"
+
+      let subClipStats =
+        renderer.benchmarkCase("clip + sub-clip", subClipRenders, frameSize)
+      let rectMaskStats =
+        renderer.benchmarkCase("clip + rect-mask", rectMaskRenders, frameSize)
+
+      echo ""
+      echo fmt"rect-mask speedup vs sub-clip: {subClipStats.avgMs / rectMaskStats.avgMs:.2f}x"
+    finally:
+      window.close()

--- a/examples/windy_non_clip_benchmark.nim
+++ b/examples/windy_non_clip_benchmark.nim
@@ -33,7 +33,7 @@ type BenchStats = object
   p95Ms: float64
   maxMs: float64
 
-func elapsedMs(started: MonoTime): float64 =
+proc elapsedMs(started: MonoTime): float64 =
   (getMonoTime() - started).inNanoseconds.float64 / 1_000_000.0
 
 func percentile(sortedSamples: seq[float64], p: float64): float64 =

--- a/examples/windy_non_clip_benchmark.nim
+++ b/examples/windy_non_clip_benchmark.nim
@@ -1,0 +1,216 @@
+import std/[algorithm, math, monotimes, strformat, times]
+
+const Windowed {.booldefine: "figdraw.bench.windowed".} = false
+
+when Windowed:
+  import figdraw/windyshim
+
+import figdraw/commons
+import figdraw/fignodes
+import figdraw/figrender
+
+const BenchRows {.intdefine: "figdraw.bench.rows".} = 180
+const BenchCols {.intdefine: "figdraw.bench.cols".} = 10
+const WarmupFrames {.intdefine: "figdraw.bench.warmup".} = 20
+const TimedFrames {.intdefine: "figdraw.bench.frames".} = 120
+const WindowW {.intdefine: "figdraw.bench.windowW".} = 1200
+const WindowH {.intdefine: "figdraw.bench.windowH".} = 800
+
+static:
+  doAssert BenchRows > 0, "figdraw.bench.rows must be positive"
+  doAssert BenchCols > 0, "figdraw.bench.cols must be positive"
+  doAssert WarmupFrames >= 0, "figdraw.bench.warmup must be non-negative"
+  doAssert TimedFrames > 0, "figdraw.bench.frames must be positive"
+  doAssert WindowW > 0 and WindowH > 0, "benchmark window size must be positive"
+  doAssert 1 + BenchRows * BenchCols <= high(int16).int,
+    "benchmark render tree exceeds FigIdx int16 capacity"
+
+type BenchStats = object
+  count: int
+  minMs: float64
+  avgMs: float64
+  p50Ms: float64
+  p95Ms: float64
+  maxMs: float64
+
+func elapsedMs(started: MonoTime): float64 =
+  (getMonoTime() - started).inNanoseconds.float64 / 1_000_000.0
+
+func percentile(sortedSamples: seq[float64], p: float64): float64 =
+  if sortedSamples.len == 0:
+    return 0.0
+
+  let rawIndex = int(round((sortedSamples.len - 1).float64 * p))
+  let idx = min(max(rawIndex, 0), sortedSamples.len - 1)
+  sortedSamples[idx]
+
+proc summarize(samples: seq[float64]): BenchStats =
+  if samples.len == 0:
+    return BenchStats()
+
+  var sortedSamples = samples
+  sortedSamples.sort()
+
+  var total = 0.0
+  for sample in samples:
+    total += sample
+
+  BenchStats(
+    count: samples.len,
+    minMs: sortedSamples[0],
+    avgMs: total / samples.len.float64,
+    p50Ms: percentile(sortedSamples, 0.50),
+    p95Ms: percentile(sortedSamples, 0.95),
+    maxMs: sortedSamples[^1],
+  )
+
+proc addRootRect(
+    list: var RenderList, rectBox: Rect, color: ColorRGBA, corners: uint16 = 0'u16
+) =
+  discard list.addRoot(
+    Fig(
+      kind: nkRectangle,
+      childCount: 0,
+      zlevel: 0.ZLevel,
+      screenBox: rectBox,
+      fill: color,
+      corners: [corners, corners, corners, corners],
+    )
+  )
+
+proc makeNonClipRenderTree(w, h: float32): Renders =
+  let
+    margin = 18.0'f32
+    gap = 5.0'f32
+    cellW = (w - margin * 2.0'f32 - gap * (BenchCols - 1).float32) / BenchCols.float32
+    cellH = 18.0'f32
+
+  var list = RenderList()
+  list.addRootRect(rect(0.0'f32, 0.0'f32, w, h), rgba(248, 249, 251, 255))
+
+  for row in 0 ..< BenchRows:
+    let y = margin + row.float32 * (cellH + gap)
+    for col in 0 ..< BenchCols:
+      let
+        x = margin + col.float32 * (cellW + gap)
+        shade = uint8(220 + (row * 3 + col * 7) mod 35)
+        accent = uint8(80 + (row * 11 + col * 13) mod 90)
+      list.addRootRect(
+        rect(x, y, cellW, cellH),
+        rgba(shade, uint8(245 - (col mod 5) * 5), accent, 255),
+        corners = 4,
+      )
+
+  result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
+  result.layers[0.ZLevel] = list
+
+proc drainGpu[BackendState](renderer: FigRenderer[BackendState]) =
+  try:
+    discard renderer.takeScreenshot(rect(0, 0, 1, 1), readFront = false)
+  except CatchableError:
+    discard
+
+proc renderOneFrame[BackendState](
+    renderer: FigRenderer[BackendState], renders: var Renders, frameSize: Vec2
+) =
+  when Windowed:
+    renderer.beginFrame()
+  renderer.renderFrame(renders, frameSize)
+  when Windowed:
+    renderer.endFrame()
+
+proc warmup[BackendState](
+    renderer: FigRenderer[BackendState], renders: var Renders, frameSize: Vec2
+) =
+  for _ in 0 ..< WarmupFrames:
+    when Windowed:
+      pollEvents()
+    renderer.renderOneFrame(renders, frameSize)
+  renderer.drainGpu()
+
+proc benchmarkCase[BackendState](
+    renderer: FigRenderer[BackendState],
+    label: string,
+    renders: var Renders,
+    frameSize: Vec2,
+    syncReadback = false,
+): BenchStats =
+  renderer.warmup(renders, frameSize)
+
+  var samples = newSeqOfCap[float64](TimedFrames)
+  for _ in 0 ..< TimedFrames:
+    when Windowed:
+      pollEvents()
+    let started = getMonoTime()
+    renderer.renderOneFrame(renders, frameSize)
+    if syncReadback:
+      renderer.drainGpu()
+    samples.add elapsedMs(started)
+
+  if not syncReadback:
+    renderer.drainGpu()
+  result = summarize(samples)
+
+  echo fmt"{label:<22} {result.avgMs:>9.3f} {result.p50Ms:>9.3f} " &
+    fmt"{result.p95Ms:>9.3f} {result.minMs:>9.3f} {result.maxMs:>9.3f} " &
+    fmt"{1000.0 / result.avgMs:>9.1f}"
+
+proc runBenchmark[BackendState](renderer: FigRenderer[BackendState], frameSize: Vec2) =
+  var renders = makeNonClipRenderTree(frameSize.x, frameSize.y)
+  let nodeCount = renders.layers[0.ZLevel].nodes.len
+
+  echo "FigDraw non-clip benchmark"
+  echo "backend: ", renderer.backendName()
+  when Windowed:
+    echo "mode: windowed"
+  else:
+    echo "mode: offscreen"
+  echo "frame: ", frameSize.x.int, "x", frameSize.y.int
+  echo "cells: ",
+    BenchRows * BenchCols, " (", BenchRows, " rows x ", BenchCols, " cols)"
+  echo "nodes: ", nodeCount
+  echo "warmup frames: ", WarmupFrames, " | timed frames: ", TimedFrames
+  echo ""
+  let
+    caseHeader = "case"
+    avgHeader = "avg ms"
+    p50Header = "p50 ms"
+    p95Header = "p95 ms"
+    minHeader = "min ms"
+    maxHeader = "max ms"
+    fpsHeader = "fps"
+  echo fmt"{caseHeader:<22} {avgHeader:>9} {p50Header:>9} " &
+    fmt"{p95Header:>9} {minHeader:>9} {maxHeader:>9} {fpsHeader:>9}"
+
+  discard renderer.benchmarkCase("async submit", renders, frameSize)
+  discard
+    renderer.benchmarkCase("sync readback", renders, frameSize, syncReadback = true)
+
+when isMainModule:
+  when defined(emscripten):
+    echo "windy_non_clip_benchmark is native-only."
+  else:
+    when Windowed:
+      let
+        title = windyWindowTitle("Non-Clip Benchmark")
+        size = ivec2(WindowW.int32, WindowH.int32)
+        window = newWindyWindow(size = size, fullscreen = false, title = title)
+
+      setFigUiScale window.contentScale()
+      if size != size.scaled():
+        window.size = size.scaled()
+
+      let renderer =
+        newFigRenderer(atlasSize = 512, backendState = WindyRenderBackend())
+      renderer.setupBackend(window)
+
+      try:
+        pollEvents()
+        renderer.runBenchmark(window.logicalSize())
+      finally:
+        window.close()
+    else:
+      let
+        renderer = newFigRenderer(atlasSize = 512)
+        frameSize = vec2(WindowW.float32, WindowH.float32)
+      renderer.runBenchmark(frameSize)

--- a/src/figdraw/figbackend.nim
+++ b/src/figdraw/figbackend.nim
@@ -189,6 +189,15 @@ method endMask*(impl: BackendContext) {.base.} =
 method popMask*(impl: BackendContext) {.base.} =
   raise newException(ValueError, "Backend popMask unavailable")
 
+method beginRectMask*(
+    impl: BackendContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+) {.base.} =
+  impl.beginMask(maskRect, radii)
+  impl.endMask()
+
+method popRectMask*(impl: BackendContext) {.base.} =
+  impl.popMask()
+
 method beginFrame*(
     impl: BackendContext, frameSize: Vec2, clearMain: bool, clearMainColor: Color
 ) {.base.} =

--- a/src/figdraw/figbasics.nim
+++ b/src/figdraw/figbasics.nim
@@ -48,6 +48,7 @@ type
     NfInactive
     NfSelectText
     NfInvertY
+    NfRectMaskContent
 
   ShadowStyle* = enum
     ## Supports drop and inner shadows.

--- a/src/figdraw/figrender.nim
+++ b/src/figdraw/figrender.nim
@@ -944,6 +944,11 @@ proc render(
   finally:
     ctx.popMask()
 
+  ifrender NfRectMaskContent in node.flags:
+    ctx.beginRectMask(node.screenBox.scaled(), node.corners.scaledCorners())
+  finally:
+    ctx.popRectMask()
+
   ifrender true:
     if node.kind == nkText:
       ctx.renderText(node)

--- a/src/figdraw/metal/metal_context.nim
+++ b/src/figdraw/metal/metal_context.nim
@@ -88,6 +88,7 @@ type MetalContext* = ref object of figbackend.BackendContext # Metal objects
   passKind: PassKind
 
   pipelineMain: ObjcOwned[MTLRenderPipelineState]
+  pipelineMainRectMask: ObjcOwned[MTLRenderPipelineState]
   pipelineMask: ObjcOwned[MTLRenderPipelineState]
   pipelineBlit: ObjcOwned[MTLRenderPipelineState]
   pipelineBlur: ObjcOwned[MTLRenderPipelineState]
@@ -115,6 +116,7 @@ type MetalContext* = ref object of figbackend.BackendContext # Metal objects
   proj*: Mat4
   frameSize: Vec2
   frameBegun, maskBegun: bool
+  batchHasRectMask: bool
   pixelate*: bool
   pixelScale*: float32
 
@@ -384,8 +386,8 @@ proc ensureMaskPass(ctx: MetalContext, clear: bool, clearColor: MTLClearColor) =
 
 proc ensureDeviceAndPipelines(ctx: MetalContext) =
   if not ctx.device.isNil and not ctx.queue.isNil and not ctx.pipelineMain.isNil and
-      not ctx.pipelineMask.isNil and not ctx.pipelineBlit.isNil and
-      not ctx.pipelineBlur.isNil:
+      not ctx.pipelineMainRectMask.isNil and not ctx.pipelineMask.isNil and
+      not ctx.pipelineBlit.isNil and not ctx.pipelineBlur.isNil:
     return
 
   withAutoreleasePool:
@@ -418,8 +420,18 @@ proc ensureDeviceAndPipelines(ctx: MetalContext) =
     let vsMain = fromRetained(
       newFunctionWithName(library.borrow, NSString.withUTF8String(cstring("vs_main")))
     )
+    let vsRectMask = fromRetained(
+      newFunctionWithName(
+        library.borrow, NSString.withUTF8String(cstring("vs_rect_mask"))
+      )
+    )
     let fsMain = fromRetained(
       newFunctionWithName(library.borrow, NSString.withUTF8String(cstring("fs_main")))
+    )
+    let fsRectMask = fromRetained(
+      newFunctionWithName(
+        library.borrow, NSString.withUTF8String(cstring("fs_rect_mask"))
+      )
     )
     let fsMask = fromRetained(
       newFunctionWithName(library.borrow, NSString.withUTF8String(cstring("fs_mask")))
@@ -433,8 +445,8 @@ proc ensureDeviceAndPipelines(ctx: MetalContext) =
     let fsBlur = fromRetained(
       newFunctionWithName(library.borrow, NSString.withUTF8String(cstring("fs_blur")))
     )
-    if vsMain.isNil or fsMain.isNil or fsMask.isNil or vsBlit.isNil or fsBlit.isNil or
-        fsBlur.isNil:
+    if vsMain.isNil or vsRectMask.isNil or fsMain.isNil or fsRectMask.isNil or
+        fsMask.isNil or vsBlit.isNil or fsBlit.isNil or fsBlur.isNil:
       raise newException(ValueError, "Failed to find Metal shader functions")
 
     proc configureBlend(att: MTLRenderPipelineColorAttachmentDescriptor) =
@@ -461,6 +473,22 @@ proc ensureDeviceAndPipelines(ctx: MetalContext) =
         if not err.isNil:
           error "Failed to create Metal main pipeline", error = $err
         raise newException(ValueError, "Failed to create Metal main pipeline")
+
+    # Main pipeline with per-vertex rect mask data (offscreen BGRA8).
+    block:
+      let pd = fromRetained(MTLRenderPipelineDescriptor.alloc().init())
+      setVertexFunction(pd.borrow, vsRectMask.borrow)
+      setFragmentFunction(pd.borrow, fsRectMask.borrow)
+      let ca0 = objectAtIndexedSubscript(colorAttachments(pd.borrow), 0)
+      setPixelFormat(ca0, MTLPixelFormatBGRA8Unorm)
+      configureBlend(ca0)
+      ctx.pipelineMainRectMask.resetRetained(
+        newRenderPipelineStateWithDescriptor(ctx.device.borrow, pd.borrow, addr err)
+      )
+      if ctx.pipelineMainRectMask.isNil:
+        if not err.isNil:
+          error "Failed to create Metal rect-mask pipeline", error = $err
+        raise newException(ValueError, "Failed to create Metal rect-mask pipeline")
 
     # Mask pipeline (R8).
     block:
@@ -532,26 +560,27 @@ proc upload(ctx: MetalContext) =
   copyToBuf(
     ctx.sdfFactors.buffer.borrow, ctx.sdfFactors.data, vertexCount * 2 * sizeof(float32)
   )
-  copyToBuf(
-    ctx.rectMaskParams.buffer.borrow,
-    ctx.rectMaskParams.data,
-    vertexCount * 4 * sizeof(float32),
-  )
-  copyToBuf(
-    ctx.rectMaskRadii.buffer.borrow,
-    ctx.rectMaskRadii.data,
-    vertexCount * 4 * sizeof(float32),
-  )
-  copyToBuf(
-    ctx.rectMaskMatX.buffer.borrow,
-    ctx.rectMaskMatX.data,
-    vertexCount * 4 * sizeof(float32),
-  )
-  copyToBuf(
-    ctx.rectMaskMatY.buffer.borrow,
-    ctx.rectMaskMatY.data,
-    vertexCount * 4 * sizeof(float32),
-  )
+  if ctx.batchHasRectMask:
+    copyToBuf(
+      ctx.rectMaskParams.buffer.borrow,
+      ctx.rectMaskParams.data,
+      vertexCount * 4 * sizeof(float32),
+    )
+    copyToBuf(
+      ctx.rectMaskRadii.buffer.borrow,
+      ctx.rectMaskRadii.data,
+      vertexCount * 4 * sizeof(float32),
+    )
+    copyToBuf(
+      ctx.rectMaskMatX.buffer.borrow,
+      ctx.rectMaskMatX.data,
+      vertexCount * 4 * sizeof(float32),
+    )
+    copyToBuf(
+      ctx.rectMaskMatY.buffer.borrow,
+      ctx.rectMaskMatY.data,
+      vertexCount * 4 * sizeof(float32),
+    )
 
 proc grow(ctx: MetalContext) =
   ctx.flush()
@@ -699,9 +728,30 @@ proc makeRectMask(
     matY: vec4(invMat[0, 1], invMat[1, 1], invMat[3, 1], 0.0'f32),
   )
 
-proc setRectMaskVert4(ctx: MetalContext, offset: int) =
-  var
+proc setRectMaskVert4(ctx: MetalContext, offset: int, params, radii, matX, matY: Vec4) =
+  for i in 0 ..< 4:
+    ctx.rectMaskParams.data.setVert4(offset + i, params)
+    ctx.rectMaskRadii.data.setVert4(offset + i, radii)
+    ctx.rectMaskMatX.data.setVert4(offset + i, matX)
+    ctx.rectMaskMatY.data.setVert4(offset + i, matY)
+
+proc setDisabledRectMaskVerts(ctx: MetalContext, firstVertex, vertexCount: int) =
+  let
     params = vec4(0.0'f32, 0.0'f32, -1.0'f32, -1.0'f32)
+    zero4 = vec4(0.0'f32)
+  for i in firstVertex ..< firstVertex + vertexCount:
+    ctx.rectMaskParams.data.setVert4(i, params)
+    ctx.rectMaskRadii.data.setVert4(i, zero4)
+    ctx.rectMaskMatX.data.setVert4(i, zero4)
+    ctx.rectMaskMatY.data.setVert4(i, zero4)
+
+proc setRectMaskVert4(ctx: MetalContext, offset: int) =
+  if ctx.maskBegun:
+    return
+
+  var
+    hasRectMask = false
+    params = vec4(0.0'f32)
     radii = vec4(0.0'f32)
     matX = vec4(0.0'f32)
     matY = vec4(0.0'f32)
@@ -710,17 +760,24 @@ proc setRectMaskVert4(ctx: MetalContext, offset: int) =
     for i in countdown(ctx.rectMaskStack.len - 1, 0):
       let rectMask = ctx.rectMaskStack[i]
       if rectMask.kind == rmkFast:
+        hasRectMask = true
         params = rectMask.params
         radii = rectMask.radii
         matX = rectMask.matX
         matY = rectMask.matY
         break
 
-  for i in 0 ..< 4:
-    ctx.rectMaskParams.data.setVert4(offset + i, params)
-    ctx.rectMaskRadii.data.setVert4(offset + i, radii)
-    ctx.rectMaskMatX.data.setVert4(offset + i, matX)
-    ctx.rectMaskMatY.data.setVert4(offset + i, matY)
+  if hasRectMask:
+    if not ctx.batchHasRectMask:
+      ctx.setDisabledRectMaskVerts(0, offset)
+      ctx.batchHasRectMask = true
+    ctx.setRectMaskVert4(offset, params, radii, matX, matY)
+  elif ctx.batchHasRectMask:
+    ctx.setDisabledRectMaskVerts(offset, 4)
+
+template setRectMaskVert4IfNeeded(ctx: MetalContext, offset: int) =
+  if not ctx.maskBegun and (ctx.batchHasRectMask or ctx.rectMaskStack.len > 0):
+    ctx.setRectMaskVert4(offset)
 
 func `*`*(m: Mat4, v: Vec2): Vec2 =
   (m * vec3(v.x, v.y, 0.0)).xy
@@ -771,7 +828,7 @@ proc drawQuad*(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
-  ctx.setRectMaskVert4(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -841,7 +898,7 @@ proc drawUvRectAtlasSdf(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
-  ctx.setRectMaskVert4(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -969,7 +1026,7 @@ proc drawUvRect(ctx: MetalContext, at, to: Vec2, uvAt, uvTo: Vec2, color: Color)
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
-  ctx.setRectMaskVert4(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -1031,7 +1088,7 @@ proc drawUvRect(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
-  ctx.setRectMaskVert4(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -1266,7 +1323,7 @@ method drawRoundedRectSdf*(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
-  ctx.setRectMaskVert4(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -1454,6 +1511,7 @@ proc beginFrame*(
   ctx.maskBegun = false
   ctx.maskTextureWrite = 0
   ctx.rectMaskStack.setLen(0)
+  ctx.batchHasRectMask = false
 
   ctx.proj = proj
   ctx.frameSize = frameSize
@@ -1664,8 +1722,17 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   if enc.isNil:
     raise newException(ValueError, "Metal render encoder is nil")
 
+  let useRectMaskPipeline = not ctx.maskBegun and ctx.batchHasRectMask
   setRenderPipelineState(
-    enc, (if ctx.maskBegun: ctx.pipelineMask.borrow else: ctx.pipelineMain.borrow)
+    enc,
+    (
+      if ctx.maskBegun:
+        ctx.pipelineMask.borrow
+      elif useRectMaskPipeline:
+        ctx.pipelineMainRectMask.borrow
+      else:
+        ctx.pipelineMain.borrow
+    ),
   )
 
   if ctx.activeArena < 0 or ctx.activeArena >= ctx.frameArenas.len:
@@ -1680,10 +1747,6 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   let sdfRadiiBytes = vertexCount * 4 * sizeof(float32)
   let sdfModeBytes = vertexCount * sizeof(SdfModeData)
   let sdfFactorsBytes = vertexCount * 2 * sizeof(float32)
-  let rectMaskParamsBytes = vertexCount * 4 * sizeof(float32)
-  let rectMaskRadiiBytes = vertexCount * 4 * sizeof(float32)
-  let rectMaskMatXBytes = vertexCount * 4 * sizeof(float32)
-  let rectMaskMatYBytes = vertexCount * 4 * sizeof(float32)
 
   var arena = addr ctx.frameArenas[ctx.activeArena]
   if arena[].flushBufferCursor >= arena[].flushBuffers.len:
@@ -1712,22 +1775,32 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   ctx.ensureFlushBufferCapacity(
     flushBuffers[].sdfFactors, flushBuffers[].sdfFactorsCapacity, sdfFactorsBytes
   )
-  ctx.ensureFlushBufferCapacity(
-    flushBuffers[].rectMaskParams,
-    flushBuffers[].rectMaskParamsCapacity,
-    rectMaskParamsBytes,
-  )
-  ctx.ensureFlushBufferCapacity(
-    flushBuffers[].rectMaskRadii,
-    flushBuffers[].rectMaskRadiiCapacity,
-    rectMaskRadiiBytes,
-  )
-  ctx.ensureFlushBufferCapacity(
-    flushBuffers[].rectMaskMatX, flushBuffers[].rectMaskMatXCapacity, rectMaskMatXBytes
-  )
-  ctx.ensureFlushBufferCapacity(
-    flushBuffers[].rectMaskMatY, flushBuffers[].rectMaskMatYCapacity, rectMaskMatYBytes
-  )
+  if useRectMaskPipeline:
+    let
+      rectMaskParamsBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskRadiiBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskMatXBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskMatYBytes = vertexCount * 4 * sizeof(float32)
+    ctx.ensureFlushBufferCapacity(
+      flushBuffers[].rectMaskParams,
+      flushBuffers[].rectMaskParamsCapacity,
+      rectMaskParamsBytes,
+    )
+    ctx.ensureFlushBufferCapacity(
+      flushBuffers[].rectMaskRadii,
+      flushBuffers[].rectMaskRadiiCapacity,
+      rectMaskRadiiBytes,
+    )
+    ctx.ensureFlushBufferCapacity(
+      flushBuffers[].rectMaskMatX,
+      flushBuffers[].rectMaskMatXCapacity,
+      rectMaskMatXBytes,
+    )
+    ctx.ensureFlushBufferCapacity(
+      flushBuffers[].rectMaskMatY,
+      flushBuffers[].rectMaskMatYCapacity,
+      rectMaskMatYBytes,
+    )
 
   copyToBuf(flushBuffers[].positions.borrow, ctx.positions.data, positionsBytes)
   copyToBuf(flushBuffers[].uvs.borrow, ctx.uvs.data, uvsBytes)
@@ -1736,18 +1809,24 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   copyToBuf(flushBuffers[].sdfRadii.borrow, ctx.sdfRadii.data, sdfRadiiBytes)
   copyToBuf(flushBuffers[].sdfModeAttr.borrow, ctx.sdfModeAttr.data, sdfModeBytes)
   copyToBuf(flushBuffers[].sdfFactors.borrow, ctx.sdfFactors.data, sdfFactorsBytes)
-  copyToBuf(
-    flushBuffers[].rectMaskParams.borrow, ctx.rectMaskParams.data, rectMaskParamsBytes
-  )
-  copyToBuf(
-    flushBuffers[].rectMaskRadii.borrow, ctx.rectMaskRadii.data, rectMaskRadiiBytes
-  )
-  copyToBuf(
-    flushBuffers[].rectMaskMatX.borrow, ctx.rectMaskMatX.data, rectMaskMatXBytes
-  )
-  copyToBuf(
-    flushBuffers[].rectMaskMatY.borrow, ctx.rectMaskMatY.data, rectMaskMatYBytes
-  )
+  if useRectMaskPipeline:
+    let
+      rectMaskParamsBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskRadiiBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskMatXBytes = vertexCount * 4 * sizeof(float32)
+      rectMaskMatYBytes = vertexCount * 4 * sizeof(float32)
+    copyToBuf(
+      flushBuffers[].rectMaskParams.borrow, ctx.rectMaskParams.data, rectMaskParamsBytes
+    )
+    copyToBuf(
+      flushBuffers[].rectMaskRadii.borrow, ctx.rectMaskRadii.data, rectMaskRadiiBytes
+    )
+    copyToBuf(
+      flushBuffers[].rectMaskMatX.borrow, ctx.rectMaskMatX.data, rectMaskMatXBytes
+    )
+    copyToBuf(
+      flushBuffers[].rectMaskMatY.borrow, ctx.rectMaskMatY.data, rectMaskMatYBytes
+    )
 
   setVertexBuffer(enc, flushBuffers[].positions.borrow, 0, 0)
   setVertexBuffer(enc, flushBuffers[].uvs.borrow, 0, 1)
@@ -1756,16 +1835,19 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   setVertexBuffer(enc, flushBuffers[].sdfRadii.borrow, 0, 4)
   setVertexBuffer(enc, flushBuffers[].sdfModeAttr.borrow, 0, 5)
   setVertexBuffer(enc, flushBuffers[].sdfFactors.borrow, 0, 6)
-  setVertexBuffer(enc, flushBuffers[].rectMaskParams.borrow, 0, 7)
-  setVertexBuffer(enc, flushBuffers[].rectMaskRadii.borrow, 0, 8)
-  setVertexBuffer(enc, flushBuffers[].rectMaskMatX.borrow, 0, 9)
-  setVertexBuffer(enc, flushBuffers[].rectMaskMatY.borrow, 0, 10)
+  if useRectMaskPipeline:
+    setVertexBuffer(enc, flushBuffers[].rectMaskParams.borrow, 0, 7)
+    setVertexBuffer(enc, flushBuffers[].rectMaskRadii.borrow, 0, 8)
+    setVertexBuffer(enc, flushBuffers[].rectMaskMatX.borrow, 0, 9)
+    setVertexBuffer(enc, flushBuffers[].rectMaskMatY.borrow, 0, 10)
 
   type VSUniforms = object
     proj: Mat4
 
   var vsu = VSUniforms(proj: ctx.proj)
-  setVertexBytes(enc, addr vsu, NSUInteger(sizeof(VSUniforms)), 11)
+  setVertexBytes(
+    enc, addr vsu, NSUInteger(sizeof(VSUniforms)), (if useRectMaskPipeline: 11 else: 7)
+  )
 
   type FSUniforms = object
     windowFrame: Vec2
@@ -1794,6 +1876,7 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   )
 
   ctx.quadCount = 0
+  ctx.batchHasRectMask = false
 
 proc newContext*(
     atlasSize = 1024,

--- a/src/figdraw/metal/metal_context.nim
+++ b/src/figdraw/metal/metal_context.nim
@@ -36,6 +36,17 @@ type PassKind = enum
 
 type SdfModeData = uint16
 
+type RectMaskKind = enum
+  rmkFast
+  rmkMask
+
+type RectMask = object
+  kind: RectMaskKind
+  params: Vec4
+  radii: Vec4
+  matX: Vec4
+  matY: Vec4
+
 type FlushBuffers = object
   positions: ObjcOwned[MTLBuffer]
   positionsCapacity: int
@@ -51,6 +62,14 @@ type FlushBuffers = object
   sdfModeAttrCapacity: int
   sdfFactors: ObjcOwned[MTLBuffer]
   sdfFactorsCapacity: int
+  rectMaskParams: ObjcOwned[MTLBuffer]
+  rectMaskParamsCapacity: int
+  rectMaskRadii: ObjcOwned[MTLBuffer]
+  rectMaskRadiiCapacity: int
+  rectMaskMatX: ObjcOwned[MTLBuffer]
+  rectMaskMatXCapacity: int
+  rectMaskMatY: ObjcOwned[MTLBuffer]
+  rectMaskMatYCapacity: int
 
 type FrameArena = object
   flushBuffers: seq[FlushBuffers]
@@ -108,6 +127,11 @@ type MetalContext* = ref object of figbackend.BackendContext # Metal objects
   sdfRadii: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
   sdfModeAttr: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[SdfModeData]]
   sdfFactors: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
+  rectMaskParams: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
+  rectMaskRadii: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
+  rectMaskMatX: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
+  rectMaskMatY: tuple[buffer: ObjcOwned[MTLBuffer], data: seq[float32]]
+  rectMaskStack: seq[RectMask]
 
   # SDF shader uniform (global)
   aaFactor: float32
@@ -508,6 +532,26 @@ proc upload(ctx: MetalContext) =
   copyToBuf(
     ctx.sdfFactors.buffer.borrow, ctx.sdfFactors.data, vertexCount * 2 * sizeof(float32)
   )
+  copyToBuf(
+    ctx.rectMaskParams.buffer.borrow,
+    ctx.rectMaskParams.data,
+    vertexCount * 4 * sizeof(float32),
+  )
+  copyToBuf(
+    ctx.rectMaskRadii.buffer.borrow,
+    ctx.rectMaskRadii.data,
+    vertexCount * 4 * sizeof(float32),
+  )
+  copyToBuf(
+    ctx.rectMaskMatX.buffer.borrow,
+    ctx.rectMaskMatX.data,
+    vertexCount * 4 * sizeof(float32),
+  )
+  copyToBuf(
+    ctx.rectMaskMatY.buffer.borrow,
+    ctx.rectMaskMatY.data,
+    vertexCount * 4 * sizeof(float32),
+  )
 
 proc grow(ctx: MetalContext) =
   ctx.flush()
@@ -613,6 +657,71 @@ proc setVertColor(buf: var seq[uint8], i: int, color: ColorRGBA) =
   buf[i * 4 + 2] = color.b
   buf[i * 4 + 3] = color.a
 
+func roundedRadiiVec(radii: array[DirectionCorners, float32], halfExtents: Vec2): Vec4 =
+  let maxRadius = min(halfExtents.x, halfExtents.y)
+  let radiiClamped = [
+    dcTopLeft: (
+      if radii[dcTopLeft] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcTopLeft], maxRadius)).round()
+    ),
+    dcTopRight: (
+      if radii[dcTopRight] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcTopRight], maxRadius)).round()
+    ),
+    dcBottomLeft: (
+      if radii[dcBottomLeft] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcBottomLeft], maxRadius)).round()
+    ),
+    dcBottomRight: (
+      if radii[dcBottomRight] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcBottomRight], maxRadius)).round()
+    ),
+  ]
+  vec4(
+    radiiClamped[dcTopRight],
+    radiiClamped[dcBottomRight],
+    radiiClamped[dcTopLeft],
+    radiiClamped[dcBottomLeft],
+  )
+
+proc makeRectMask(
+    ctx: MetalContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+): RectMask =
+  let
+    halfExtents = maskRect.wh * 0.5'f32
+    center = maskRect.xy + halfExtents
+    invMat = ctx.mat.inverse()
+  RectMask(
+    kind: rmkFast,
+    params: vec4(center.x, center.y, halfExtents.x, halfExtents.y),
+    radii: roundedRadiiVec(radii, halfExtents),
+    matX: vec4(invMat[0, 0], invMat[1, 0], invMat[3, 0], 1.0'f32),
+    matY: vec4(invMat[0, 1], invMat[1, 1], invMat[3, 1], 0.0'f32),
+  )
+
+proc setRectMaskVert4(ctx: MetalContext, offset: int) =
+  var
+    params = vec4(0.0'f32, 0.0'f32, -1.0'f32, -1.0'f32)
+    radii = vec4(0.0'f32)
+    matX = vec4(0.0'f32)
+    matY = vec4(0.0'f32)
+
+  if ctx.rectMaskStack.len > 0:
+    for i in countdown(ctx.rectMaskStack.len - 1, 0):
+      let rectMask = ctx.rectMaskStack[i]
+      if rectMask.kind == rmkFast:
+        params = rectMask.params
+        radii = rectMask.radii
+        matX = rectMask.matX
+        matY = rectMask.matY
+        break
+
+  for i in 0 ..< 4:
+    ctx.rectMaskParams.data.setVert4(offset + i, params)
+    ctx.rectMaskRadii.data.setVert4(offset + i, radii)
+    ctx.rectMaskMatX.data.setVert4(offset + i, matX)
+    ctx.rectMaskMatY.data.setVert4(offset + i, matY)
+
 func `*`*(m: Mat4, v: Vec2): Vec2 =
   (m * vec3(v.x, v.y, 0.0)).xy
 
@@ -662,6 +771,7 @@ proc drawQuad*(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
+  ctx.setRectMaskVert4(offset)
 
   inc ctx.quadCount
 
@@ -731,6 +841,7 @@ proc drawUvRectAtlasSdf(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
+  ctx.setRectMaskVert4(offset)
 
   inc ctx.quadCount
 
@@ -858,6 +969,7 @@ proc drawUvRect(ctx: MetalContext, at, to: Vec2, uvAt, uvTo: Vec2, color: Color)
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
+  ctx.setRectMaskVert4(offset)
 
   inc ctx.quadCount
 
@@ -919,6 +1031,7 @@ proc drawUvRect(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
+  ctx.setRectMaskVert4(offset)
 
   inc ctx.quadCount
 
@@ -1093,31 +1206,7 @@ method drawRoundedRectSdf*(
         vec4(
           quadHalfExtents.x, quadHalfExtents.y, shapeHalfExtents.x, shapeHalfExtents.y
         )
-    maxRadius = min(shapeHalfExtents.x, shapeHalfExtents.y)
-    radiiClamped = [
-      dcTopLeft: (
-        if radii[dcTopLeft] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcTopLeft], maxRadius)).round()
-      ),
-      dcTopRight: (
-        if radii[dcTopRight] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcTopRight], maxRadius)).round()
-      ),
-      dcBottomLeft: (
-        if radii[dcBottomLeft] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcBottomLeft], maxRadius)).round()
-      ),
-      dcBottomRight: (
-        if radii[dcBottomRight] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcBottomRight], maxRadius)).round()
-      ),
-    ]
-    r4 = vec4(
-      radiiClamped[dcTopRight],
-      radiiClamped[dcBottomRight],
-      radiiClamped[dcTopLeft],
-      radiiClamped[dcBottomLeft],
-    )
+    r4 = roundedRadiiVec(radii, shapeHalfExtents)
 
   assert ctx.quadCount < ctx.maxQuads
 
@@ -1177,6 +1266,7 @@ method drawRoundedRectSdf*(
   ctx.sdfModeAttr.data[offset + 1] = modeVal
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
+  ctx.setRectMaskVert4(offset)
 
   inc ctx.quadCount
 
@@ -1289,6 +1379,25 @@ method popMask*(ctx: MetalContext) =
   ctx.flush()
   dec ctx.maskTextureWrite
 
+method beginRectMask*(
+    ctx: MetalContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+) =
+  assert ctx.frameBegun == true, "ctx.beginFrame has not been called."
+  assert ctx.maskBegun == false, "ctx.beginRectMask cannot start inside a mask."
+
+  if ctx.rectMaskStack.len == 0 and maskRect.w > 0.0'f32 and maskRect.h > 0.0'f32:
+    ctx.rectMaskStack.add(ctx.makeRectMask(maskRect, radii))
+  else:
+    ctx.beginMask(maskRect, radii)
+    ctx.endMask()
+    ctx.rectMaskStack.add(RectMask(kind: rmkMask))
+
+method popRectMask*(ctx: MetalContext) =
+  assert ctx.rectMaskStack.len > 0, "No rect mask has been pushed."
+  let rectMask = ctx.rectMaskStack.pop()
+  if rectMask.kind == rmkMask:
+    ctx.popMask()
+
 proc reapCompletedFrames(ctx: MetalContext) =
   if ctx.inFlightFrames.len == 0:
     return
@@ -1344,6 +1453,7 @@ proc beginFrame*(
 
   ctx.maskBegun = false
   ctx.maskTextureWrite = 0
+  ctx.rectMaskStack.setLen(0)
 
   ctx.proj = proj
   ctx.frameSize = frameSize
@@ -1390,6 +1500,7 @@ method beginFrame*(
 method endFrame*(ctx: MetalContext) =
   assert ctx.frameBegun == true, "ctx.beginFrame was not called first."
   assert ctx.maskTextureWrite == 0, "Not all masks have been popped."
+  assert ctx.rectMaskStack.len == 0, "Not all rect masks have been popped."
   ctx.frameBegun = false
 
   ctx.flush()
@@ -1569,6 +1680,10 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   let sdfRadiiBytes = vertexCount * 4 * sizeof(float32)
   let sdfModeBytes = vertexCount * sizeof(SdfModeData)
   let sdfFactorsBytes = vertexCount * 2 * sizeof(float32)
+  let rectMaskParamsBytes = vertexCount * 4 * sizeof(float32)
+  let rectMaskRadiiBytes = vertexCount * 4 * sizeof(float32)
+  let rectMaskMatXBytes = vertexCount * 4 * sizeof(float32)
+  let rectMaskMatYBytes = vertexCount * 4 * sizeof(float32)
 
   var arena = addr ctx.frameArenas[ctx.activeArena]
   if arena[].flushBufferCursor >= arena[].flushBuffers.len:
@@ -1597,6 +1712,22 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   ctx.ensureFlushBufferCapacity(
     flushBuffers[].sdfFactors, flushBuffers[].sdfFactorsCapacity, sdfFactorsBytes
   )
+  ctx.ensureFlushBufferCapacity(
+    flushBuffers[].rectMaskParams,
+    flushBuffers[].rectMaskParamsCapacity,
+    rectMaskParamsBytes,
+  )
+  ctx.ensureFlushBufferCapacity(
+    flushBuffers[].rectMaskRadii,
+    flushBuffers[].rectMaskRadiiCapacity,
+    rectMaskRadiiBytes,
+  )
+  ctx.ensureFlushBufferCapacity(
+    flushBuffers[].rectMaskMatX, flushBuffers[].rectMaskMatXCapacity, rectMaskMatXBytes
+  )
+  ctx.ensureFlushBufferCapacity(
+    flushBuffers[].rectMaskMatY, flushBuffers[].rectMaskMatYCapacity, rectMaskMatYBytes
+  )
 
   copyToBuf(flushBuffers[].positions.borrow, ctx.positions.data, positionsBytes)
   copyToBuf(flushBuffers[].uvs.borrow, ctx.uvs.data, uvsBytes)
@@ -1605,6 +1736,18 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   copyToBuf(flushBuffers[].sdfRadii.borrow, ctx.sdfRadii.data, sdfRadiiBytes)
   copyToBuf(flushBuffers[].sdfModeAttr.borrow, ctx.sdfModeAttr.data, sdfModeBytes)
   copyToBuf(flushBuffers[].sdfFactors.borrow, ctx.sdfFactors.data, sdfFactorsBytes)
+  copyToBuf(
+    flushBuffers[].rectMaskParams.borrow, ctx.rectMaskParams.data, rectMaskParamsBytes
+  )
+  copyToBuf(
+    flushBuffers[].rectMaskRadii.borrow, ctx.rectMaskRadii.data, rectMaskRadiiBytes
+  )
+  copyToBuf(
+    flushBuffers[].rectMaskMatX.borrow, ctx.rectMaskMatX.data, rectMaskMatXBytes
+  )
+  copyToBuf(
+    flushBuffers[].rectMaskMatY.borrow, ctx.rectMaskMatY.data, rectMaskMatYBytes
+  )
 
   setVertexBuffer(enc, flushBuffers[].positions.borrow, 0, 0)
   setVertexBuffer(enc, flushBuffers[].uvs.borrow, 0, 1)
@@ -1613,12 +1756,16 @@ proc flush(ctx: MetalContext, maskTextureRead: int = ctx.maskTextureWrite) =
   setVertexBuffer(enc, flushBuffers[].sdfRadii.borrow, 0, 4)
   setVertexBuffer(enc, flushBuffers[].sdfModeAttr.borrow, 0, 5)
   setVertexBuffer(enc, flushBuffers[].sdfFactors.borrow, 0, 6)
+  setVertexBuffer(enc, flushBuffers[].rectMaskParams.borrow, 0, 7)
+  setVertexBuffer(enc, flushBuffers[].rectMaskRadii.borrow, 0, 8)
+  setVertexBuffer(enc, flushBuffers[].rectMaskMatX.borrow, 0, 9)
+  setVertexBuffer(enc, flushBuffers[].rectMaskMatY.borrow, 0, 10)
 
   type VSUniforms = object
     proj: Mat4
 
   var vsu = VSUniforms(proj: ctx.proj)
-  setVertexBytes(enc, addr vsu, NSUInteger(sizeof(VSUniforms)), 7)
+  setVertexBytes(enc, addr vsu, NSUInteger(sizeof(VSUniforms)), 11)
 
   type FSUniforms = object
     windowFrame: Vec2
@@ -1693,6 +1840,11 @@ proc newContext*(
     result.sdfRadii.data = newSeq[float32](4 * maxQuads * 4)
     result.sdfModeAttr.data = newSeq[SdfModeData](1 * maxQuads * 4)
     result.sdfFactors.data = newSeq[float32](2 * maxQuads * 4)
+    result.rectMaskParams.data = newSeq[float32](4 * maxQuads * 4)
+    result.rectMaskRadii.data = newSeq[float32](4 * maxQuads * 4)
+    result.rectMaskMatX.data = newSeq[float32](4 * maxQuads * 4)
+    result.rectMaskMatY.data = newSeq[float32](4 * maxQuads * 4)
+    result.rectMaskStack = @[]
 
     # Allocate GPU buffers.
     result.positions.buffer.resetRetained(
@@ -1741,6 +1893,34 @@ proc newContext*(
       newBufferWithLength(
         result.device.borrow,
         NSUInteger(result.sdfFactors.data.len * sizeof(float32)),
+        MTLResourceOptions(0),
+      )
+    )
+    result.rectMaskParams.buffer.resetRetained(
+      newBufferWithLength(
+        result.device.borrow,
+        NSUInteger(result.rectMaskParams.data.len * sizeof(float32)),
+        MTLResourceOptions(0),
+      )
+    )
+    result.rectMaskRadii.buffer.resetRetained(
+      newBufferWithLength(
+        result.device.borrow,
+        NSUInteger(result.rectMaskRadii.data.len * sizeof(float32)),
+        MTLResourceOptions(0),
+      )
+    )
+    result.rectMaskMatX.buffer.resetRetained(
+      newBufferWithLength(
+        result.device.borrow,
+        NSUInteger(result.rectMaskMatX.data.len * sizeof(float32)),
+        MTLResourceOptions(0),
+      )
+    )
+    result.rectMaskMatY.buffer.resetRetained(
+      newBufferWithLength(
+        result.device.borrow,
+        NSUInteger(result.rectMaskMatY.data.len * sizeof(float32)),
         MTLResourceOptions(0),
       )
     )

--- a/src/figdraw/metal/metal_shaders.metal
+++ b/src/figdraw/metal/metal_shaders.metal
@@ -10,6 +10,17 @@ struct VSOut {
   float4 sdfRadii;
   float sdfMode;
   float2 sdfFactors;
+};
+
+struct RectMaskVSOut {
+  float4 position [[position]];
+  float2 pos;
+  float2 uv;
+  float4 color;
+  float4 sdfParams;
+  float4 sdfRadii;
+  float sdfMode;
+  float2 sdfFactors;
   float4 rectMaskParams;
   float4 rectMaskRadii;
   float4 rectMaskMatX;
@@ -95,12 +106,35 @@ vertex VSOut vs_main(
     const device float4* sdfRadii [[buffer(4)]],
     const device ushort* sdfMode [[buffer(5)]],
     const device float2* sdfFactors [[buffer(6)]],
+    constant VSUniforms& u [[buffer(7)]]) {
+  VSOut out;
+  float2 p = positions[vid];
+  out.position = u.proj * float4(p.x, p.y, 0.0, 1.0);
+  out.pos = p;
+  out.uv = uvs[vid];
+  out.color = float4(colors[vid]) / 255.0;
+  out.sdfParams = sdfParams[vid];
+  out.sdfRadii = sdfRadii[vid];
+  out.sdfMode = float(sdfMode[vid]);
+  out.sdfFactors = sdfFactors[vid];
+  return out;
+}
+
+vertex RectMaskVSOut vs_rect_mask(
+    uint vid [[vertex_id]],
+    const device float2* positions [[buffer(0)]],
+    const device float2* uvs [[buffer(1)]],
+    const device uchar4* colors [[buffer(2)]],
+    const device float4* sdfParams [[buffer(3)]],
+    const device float4* sdfRadii [[buffer(4)]],
+    const device ushort* sdfMode [[buffer(5)]],
+    const device float2* sdfFactors [[buffer(6)]],
     const device float4* rectMaskParams [[buffer(7)]],
     const device float4* rectMaskRadii [[buffer(8)]],
     const device float4* rectMaskMatX [[buffer(9)]],
     const device float4* rectMaskMatY [[buffer(10)]],
     constant VSUniforms& u [[buffer(11)]]) {
-  VSOut out;
+  RectMaskVSOut out;
   float2 p = positions[vid];
   out.position = u.proj * float4(p.x, p.y, 0.0, 1.0);
   out.pos = p;
@@ -117,12 +151,18 @@ vertex VSOut vs_main(
   return out;
 }
 
-fragment float4 fs_main(
-    VSOut in [[stage_in]],
-    constant FSUniforms& u [[buffer(0)]],
-    texture2d<float> atlasTex [[texture(0)]],
-    texture2d<float> maskTex [[texture(1)]],
-    texture2d<float> backdropTex [[texture(2)]]) {
+float4 evalMainFragment(
+    float2 pos,
+    float2 uv,
+    float4 color,
+    float4 sdfParams,
+    float4 sdfRadii,
+    float sdfMode,
+    float2 sdfFactors,
+    constant FSUniforms& u,
+    texture2d<float> atlasTex,
+    texture2d<float> maskTex,
+    texture2d<float> backdropTex) {
   const int sdfModeAtlas = 0;
   const int sdfModeClipAA = 3;
   const int sdfModeDropShadow = 7;
@@ -136,30 +176,30 @@ fragment float4 fs_main(
   const int sdfModeMtsdfAnnular = 16;
   const int sdfModeBackdropBlur = 17;
 
-  int sdfModeInt = int(in.sdfMode);
-  float2 quadHalfExtents = in.sdfParams.xy;
+  int sdfModeInt = int(sdfMode);
+  float2 quadHalfExtents = sdfParams.xy;
   bool insetMode = (sdfModeInt == sdfModeInsetShadow);
-  float2 shapeHalfExtents = insetMode ? quadHalfExtents : in.sdfParams.zw;
+  float2 shapeHalfExtents = insetMode ? quadHalfExtents : sdfParams.zw;
 
   float2 p = float2(
-    (in.uv.x - 0.5) * 2.0 * quadHalfExtents.x,
-    (in.uv.y - 0.5) * 2.0 * quadHalfExtents.y
+    (uv.x - 0.5) * 2.0 * quadHalfExtents.x,
+    (uv.y - 0.5) * 2.0 * quadHalfExtents.y
   );
 
-  float dist = sdRoundedBox(float2(p.x, -p.y), shapeHalfExtents, in.sdfRadii);
+  float dist = sdRoundedBox(float2(p.x, -p.y), shapeHalfExtents, sdfRadii);
 
-  float sdfFactor = in.sdfFactors.x;
-  float sdfSpread = in.sdfFactors.y;
+  float sdfFactor = sdfFactors.x;
+  float sdfSpread = sdfFactors.y;
 
   float4 fragColor;
   float alpha = 0.0;
   if (sdfModeInt == sdfModeAtlas) {
-    float4 tex = atlasTex.sample(s, in.uv);
+    float4 tex = atlasTex.sample(s, uv);
     fragColor = float4(
-      tex.x * in.color.x,
-      tex.y * in.color.y,
-      tex.z * in.color.z,
-      tex.w * in.color.w
+      tex.x * color.x,
+      tex.y * color.y,
+      tex.z * color.z,
+      tex.w * color.w
     );
   } else if (
     sdfModeInt == sdfModeMsdf ||
@@ -167,25 +207,25 @@ fragment float4 fs_main(
     sdfModeInt == sdfModeMsdfAnnular ||
     sdfModeInt == sdfModeMtsdfAnnular
   ) {
-    float pxRange = in.sdfFactors.x;
-    float sdThreshold = in.sdfFactors.y;
+    float pxRange = sdfFactors.x;
+    float sdThreshold = sdfFactors.y;
 
-    float4 tex = atlasTex.sample(s, in.uv, level(0.0));
+    float4 tex = atlasTex.sample(s, uv, level(0.0));
     bool isMtsdf = (sdfModeInt == sdfModeMtsdf || sdfModeInt == sdfModeMtsdfAnnular);
     bool isStroke =
       (sdfModeInt == sdfModeMsdfAnnular || sdfModeInt == sdfModeMtsdfAnnular);
     float sd = isMtsdf ? tex.w : median(tex.x, tex.y, tex.z);
     float screenPxDistance =
-      msdfScreenPxRange(atlasTex, in.uv, pxRange) * (sd - sdThreshold);
+      msdfScreenPxRange(atlasTex, uv, pxRange) * (sd - sdThreshold);
 
     if (isStroke) {
-      float strokeW = max(in.sdfParams.y, 0.0);
+      float strokeW = max(sdfParams.y, 0.0);
       float halfW = strokeW * 0.5;
       alpha = clamp(halfW - abs(screenPxDistance) + 0.5, 0.0, 1.0);
     } else {
       alpha = clamp(screenPxDistance + 0.5, 0.0, 1.0);
     }
-    fragColor = float4(in.color.xyz, in.color.w * alpha);
+    fragColor = float4(color.xyz, color.w * alpha);
   } else {
     switch (sdfModeInt) {
       case sdfModeAnnular: {
@@ -217,11 +257,11 @@ fragment float4 fs_main(
       }
       case sdfModeInsetShadow: {
         float2 qClip = float2(p.x, -p.y);
-        float2 shadowOffset = float2(in.sdfParams.z, -in.sdfParams.w);
+        float2 shadowOffset = float2(sdfParams.z, -sdfParams.w);
         float2 qShadow = qClip - shadowOffset;
-        float clipDist = sdRoundedBox(qClip, quadHalfExtents, in.sdfRadii);
+        float clipDist = sdRoundedBox(qClip, quadHalfExtents, sdfRadii);
         float clipAlpha = 1.0 - clamp(u.aaFactor * clipDist + 0.5, 0.0, 1.0);
-        float shadowDist = sdRoundedBox(qShadow, quadHalfExtents, in.sdfRadii);
+        float shadowDist = sdRoundedBox(qShadow, quadHalfExtents, sdfRadii);
         float sd = shadowDist + sdfSpread;
         float a = shadowProfile(sd, sdfFactor);
         float insetAlpha = (sd < 0.0) ? min(a, 1.0) : 1.0;
@@ -231,7 +271,7 @@ fragment float4 fs_main(
       case sdfModeBackdropBlur: {
         float cl = clamp(u.aaFactor * dist + 0.5, 0.0, 1.0);
         alpha = 1.0 - cl;
-        float2 normalizedPos = float2(in.pos.x / u.windowFrame.x, in.pos.y / u.windowFrame.y);
+        float2 normalizedPos = float2(pos.x / u.windowFrame.x, pos.y / u.windowFrame.y);
         float4 blur = backdropTex.sample(s, normalizedPos);
         fragColor = float4(blur.xyz, blur.w * alpha);
         break;
@@ -244,15 +284,58 @@ fragment float4 fs_main(
     }
 
     if (sdfModeInt != sdfModeBackdropBlur) {
-      fragColor = float4(in.color.x, in.color.y, in.color.z, in.color.w * alpha);
+      fragColor = float4(color.x, color.y, color.z, color.w * alpha);
     }
   }
 
   float2 normalizedPos =
-    float2(in.pos.x / u.windowFrame.x, in.pos.y / u.windowFrame.y);
+    float2(pos.x / u.windowFrame.x, pos.y / u.windowFrame.y);
   if (u.maskTexEnabled != 0) {
     fragColor.w *= maskTex.sample(s, normalizedPos).x;
   }
+  return fragColor;
+}
+
+fragment float4 fs_main(
+    VSOut in [[stage_in]],
+    constant FSUniforms& u [[buffer(0)]],
+    texture2d<float> atlasTex [[texture(0)]],
+    texture2d<float> maskTex [[texture(1)]],
+    texture2d<float> backdropTex [[texture(2)]]) {
+  return evalMainFragment(
+    in.pos,
+    in.uv,
+    in.color,
+    in.sdfParams,
+    in.sdfRadii,
+    in.sdfMode,
+    in.sdfFactors,
+    u,
+    atlasTex,
+    maskTex,
+    backdropTex
+  );
+}
+
+fragment float4 fs_rect_mask(
+    RectMaskVSOut in [[stage_in]],
+    constant FSUniforms& u [[buffer(0)]],
+    texture2d<float> atlasTex [[texture(0)]],
+    texture2d<float> maskTex [[texture(1)]],
+    texture2d<float> backdropTex [[texture(2)]]) {
+  float4 fragColor = evalMainFragment(
+    in.pos,
+    in.uv,
+    in.color,
+    in.sdfParams,
+    in.sdfRadii,
+    in.sdfMode,
+    in.sdfFactors,
+    u,
+    atlasTex,
+    maskTex,
+    backdropTex
+  );
   fragColor.w *= rectMaskAlpha(
     in.pos,
     in.rectMaskParams,

--- a/src/figdraw/metal/metal_shaders.metal
+++ b/src/figdraw/metal/metal_shaders.metal
@@ -10,6 +10,10 @@ struct VSOut {
   float4 sdfRadii;
   float sdfMode;
   float2 sdfFactors;
+  float4 rectMaskParams;
+  float4 rectMaskRadii;
+  float4 rectMaskMatX;
+  float4 rectMaskMatY;
 };
 
 struct VSUniforms {
@@ -62,6 +66,26 @@ float shadowProfile(float sd, float blurRadius) {
   return exp(-0.5 * z * z);
 }
 
+float rectMaskAlpha(
+    float2 pos,
+    float4 params,
+    float4 radii,
+    float4 matX,
+    float4 matY,
+    float aaFactor) {
+  if (params.z < 0.0 || params.w < 0.0) {
+    return 1.0;
+  }
+
+  float2 local = float2(
+    dot(matX.xy, pos) + matX.z,
+    dot(matY.xy, pos) + matY.z
+  );
+  float2 q = local - params.xy;
+  float dist = sdRoundedBox(float2(q.x, -q.y), params.zw, radii);
+  return 1.0 - clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+}
+
 vertex VSOut vs_main(
     uint vid [[vertex_id]],
     const device float2* positions [[buffer(0)]],
@@ -71,7 +95,11 @@ vertex VSOut vs_main(
     const device float4* sdfRadii [[buffer(4)]],
     const device ushort* sdfMode [[buffer(5)]],
     const device float2* sdfFactors [[buffer(6)]],
-    constant VSUniforms& u [[buffer(7)]]) {
+    const device float4* rectMaskParams [[buffer(7)]],
+    const device float4* rectMaskRadii [[buffer(8)]],
+    const device float4* rectMaskMatX [[buffer(9)]],
+    const device float4* rectMaskMatY [[buffer(10)]],
+    constant VSUniforms& u [[buffer(11)]]) {
   VSOut out;
   float2 p = positions[vid];
   out.position = u.proj * float4(p.x, p.y, 0.0, 1.0);
@@ -82,6 +110,10 @@ vertex VSOut vs_main(
   out.sdfRadii = sdfRadii[vid];
   out.sdfMode = float(sdfMode[vid]);
   out.sdfFactors = sdfFactors[vid];
+  out.rectMaskParams = rectMaskParams[vid];
+  out.rectMaskRadii = rectMaskRadii[vid];
+  out.rectMaskMatX = rectMaskMatX[vid];
+  out.rectMaskMatY = rectMaskMatY[vid];
   return out;
 }
 
@@ -221,6 +253,14 @@ fragment float4 fs_main(
   if (u.maskTexEnabled != 0) {
     fragColor.w *= maskTex.sample(s, normalizedPos).x;
   }
+  fragColor.w *= rectMaskAlpha(
+    in.pos,
+    in.rectMaskParams,
+    in.rectMaskRadii,
+    in.rectMaskMatX,
+    in.rectMaskMatY,
+    u.aaFactor
+  );
   return fragColor;
 }
 

--- a/src/figdraw/opengl/glcontext.nim
+++ b/src/figdraw/opengl/glcontext.nim
@@ -31,8 +31,19 @@ when defined(emscripten):
 else:
   type SdfModeData = uint16
 
+type RectMaskKind = enum
+  rmkFast
+  rmkMask
+
+type RectMask = object
+  kind: RectMaskKind
+  params: Vec4
+  radii: Vec4
+  matX: Vec4
+  matY: Vec4
+
 type OpenGlContext* = ref object of figbackend.BackendContext
-  mainShader, maskShader, blurShader, activeShader: Shader
+  mainShader, rectMaskShader, maskShader, blurShader, activeShader: Shader
   atlasTexture: Texture
   backdropTexture: Texture
   backdropBlurTempTexture: Texture
@@ -48,8 +59,10 @@ type OpenGlContext* = ref object of figbackend.BackendContext
   heights: seq[uint16] ## Height map of the free space in the atlas
   proj*: Mat4
   frameSize: Vec2 ## Dimensions of the window frame
-  vertexArrayId, blurVertexArrayId, maskFramebufferId, blurFramebufferId: GLuint
+  vertexArrayId, rectMaskVertexArrayId, maskVertexArrayId, blurVertexArrayId: GLuint
+  maskFramebufferId, blurFramebufferId: GLuint
   frameBegun, maskBegun: bool
+  batchHasRectMask: bool
   pixelate*: bool ## Makes texture look pixelated, like a pixel game.
   pixelScale*: float32 ## Multiple scaling factor.
   textLcdFilteringEnabled: bool
@@ -69,6 +82,11 @@ type OpenGlContext* = ref object of figbackend.BackendContext
   sdfModeAttr: tuple[buffer: Buffer, data: seq[SdfModeData]] ## SDFMode value
   sdfFactors: tuple[buffer: Buffer, data: seq[float32]] ## Vec2: (factor, spread)
   subpixelShifts: tuple[buffer: Buffer, data: seq[float32]] ## Scalar shift in px
+  rectMaskParams: tuple[buffer: Buffer, data: seq[float32]]
+  rectMaskRadii: tuple[buffer: Buffer, data: seq[float32]]
+  rectMaskMatX: tuple[buffer: Buffer, data: seq[float32]]
+  rectMaskMatY: tuple[buffer: Buffer, data: seq[float32]]
+  rectMaskStack: seq[RectMask]
 
   # SDF shader uniforms (global)
   aaFactor: float32
@@ -106,6 +124,16 @@ proc upload(ctx: OpenGlContext) =
   bindBufferData(ctx.sdfModeAttr.buffer.addr, ctx.sdfModeAttr.data[0].addr)
   bindBufferData(ctx.sdfFactors.buffer.addr, ctx.sdfFactors.data[0].addr)
   bindBufferData(ctx.subpixelShifts.buffer.addr, ctx.subpixelShifts.data[0].addr)
+
+proc uploadRectMasks(ctx: OpenGlContext) =
+  ctx.rectMaskParams.buffer.count = ctx.quadCount * 4
+  ctx.rectMaskRadii.buffer.count = ctx.quadCount * 4
+  ctx.rectMaskMatX.buffer.count = ctx.quadCount * 4
+  ctx.rectMaskMatY.buffer.count = ctx.quadCount * 4
+  bindBufferData(ctx.rectMaskParams.buffer.addr, ctx.rectMaskParams.data[0].addr)
+  bindBufferData(ctx.rectMaskRadii.buffer.addr, ctx.rectMaskRadii.data[0].addr)
+  bindBufferData(ctx.rectMaskMatX.buffer.addr, ctx.rectMaskMatX.data[0].addr)
+  bindBufferData(ctx.rectMaskMatY.buffer.addr, ctx.rectMaskMatY.data[0].addr)
 
 proc setUpMaskFramebuffer(ctx: OpenGlContext) =
   glBindFramebuffer(GL_FRAMEBUFFER, ctx.maskFramebufferId)
@@ -239,12 +267,17 @@ proc newContext*(
       newShaderStatic("glsl/emscripten/atlas.vert", "glsl/emscripten/mask.frag")
     result.mainShader =
       newShaderStatic("glsl/emscripten/atlas.vert", "glsl/emscripten/atlas.frag")
+    result.rectMaskShader = newShaderStatic(
+      "glsl/emscripten/atlas_rect_mask.vert", "glsl/emscripten/atlas_rect_mask.frag"
+    )
     result.blurShader =
       newShaderStatic("glsl/emscripten/blur.vert", "glsl/emscripten/blur.frag")
   else:
     try:
       result.maskShader = newShaderStatic("glsl/atlas.vert", "glsl/mask.frag")
       result.mainShader = newShaderStatic("glsl/atlas.vert", "glsl/atlas.frag")
+      result.rectMaskShader =
+        newShaderStatic("glsl/atlas_rect_mask.vert", "glsl/atlas_rect_mask.frag")
       result.blurShader = newShaderStatic("glsl/blur.vert", "glsl/blur.frag")
     except ShaderCompilationError:
       info "OpenGL 3.30 failed, trying GLSL ES fallback"
@@ -252,6 +285,9 @@ proc newContext*(
         newShaderStatic("glsl/emscripten/atlas.vert", "glsl/emscripten/mask.frag")
       result.mainShader =
         newShaderStatic("glsl/emscripten/atlas.vert", "glsl/emscripten/atlas.frag")
+      result.rectMaskShader = newShaderStatic(
+        "glsl/emscripten/atlas_rect_mask.vert", "glsl/emscripten/atlas_rect_mask.frag"
+      )
       result.blurShader =
         newShaderStatic("glsl/emscripten/blur.vert", "glsl/emscripten/blur.frag")
 
@@ -314,6 +350,34 @@ proc newContext*(
   result.subpixelShifts.buffer.usage = GL_STREAM_DRAW
   result.subpixelShifts.data = newSeq[float32](maxQuads * 4)
 
+  result.rectMaskParams.buffer.componentType = cGL_FLOAT
+  result.rectMaskParams.buffer.kind = bkVEC4
+  result.rectMaskParams.buffer.target = GL_ARRAY_BUFFER
+  result.rectMaskParams.buffer.usage = GL_STREAM_DRAW
+  result.rectMaskParams.data =
+    newSeq[float32](result.rectMaskParams.buffer.kind.componentCount() * maxQuads * 4)
+
+  result.rectMaskRadii.buffer.componentType = cGL_FLOAT
+  result.rectMaskRadii.buffer.kind = bkVEC4
+  result.rectMaskRadii.buffer.target = GL_ARRAY_BUFFER
+  result.rectMaskRadii.buffer.usage = GL_STREAM_DRAW
+  result.rectMaskRadii.data =
+    newSeq[float32](result.rectMaskRadii.buffer.kind.componentCount() * maxQuads * 4)
+
+  result.rectMaskMatX.buffer.componentType = cGL_FLOAT
+  result.rectMaskMatX.buffer.kind = bkVEC4
+  result.rectMaskMatX.buffer.target = GL_ARRAY_BUFFER
+  result.rectMaskMatX.buffer.usage = GL_STREAM_DRAW
+  result.rectMaskMatX.data =
+    newSeq[float32](result.rectMaskMatX.buffer.kind.componentCount() * maxQuads * 4)
+
+  result.rectMaskMatY.buffer.componentType = cGL_FLOAT
+  result.rectMaskMatY.buffer.kind = bkVEC4
+  result.rectMaskMatY.buffer.target = GL_ARRAY_BUFFER
+  result.rectMaskMatY.buffer.usage = GL_STREAM_DRAW
+  result.rectMaskMatY.data =
+    newSeq[float32](result.rectMaskMatY.buffer.kind.componentCount() * maxQuads * 4)
+
   result.indices.buffer.componentType = GL_UNSIGNED_SHORT
   result.indices.buffer.kind = bkSCALAR
   result.indices.buffer.target = GL_ELEMENT_ARRAY_BUFFER
@@ -337,13 +401,13 @@ proc newContext*(
   bindBufferData(result.indices.buffer.addr, result.indices.data[0].addr)
 
   result.upload()
+  result.uploadRectMasks()
 
   result.activeShader = result.mainShader
 
+  # Main shader (atlas + SDF).
   glGenVertexArrays(1, result.vertexArrayId.addr)
   glBindVertexArray(result.vertexArrayId)
-
-  # Main shader (atlas + SDF).
   result.mainShader.bindAttrib("vertexPos", result.positions.buffer)
   result.mainShader.bindAttrib("vertexColor", result.colors.buffer)
   result.mainShader.bindAttrib("vertexUv", result.uvs.buffer)
@@ -353,7 +417,25 @@ proc newContext*(
   result.mainShader.bindAttrib("vertexSdfFactors", result.sdfFactors.buffer)
   result.mainShader.bindAttrib("vertexSubpixelShift", result.subpixelShifts.buffer)
 
+  # Main shader with per-vertex fast rect masks.
+  glGenVertexArrays(1, result.rectMaskVertexArrayId.addr)
+  glBindVertexArray(result.rectMaskVertexArrayId)
+  result.rectMaskShader.bindAttrib("vertexPos", result.positions.buffer)
+  result.rectMaskShader.bindAttrib("vertexColor", result.colors.buffer)
+  result.rectMaskShader.bindAttrib("vertexUv", result.uvs.buffer)
+  result.rectMaskShader.bindAttrib("vertexSdfParams", result.sdfParams.buffer)
+  result.rectMaskShader.bindAttrib("vertexSdfRadii", result.sdfRadii.buffer)
+  result.rectMaskShader.bindAttrib("vertexSdfMode", result.sdfModeAttr.buffer)
+  result.rectMaskShader.bindAttrib("vertexSdfFactors", result.sdfFactors.buffer)
+  result.rectMaskShader.bindAttrib("vertexSubpixelShift", result.subpixelShifts.buffer)
+  result.rectMaskShader.bindAttrib("vertexRectMaskParams", result.rectMaskParams.buffer)
+  result.rectMaskShader.bindAttrib("vertexRectMaskRadii", result.rectMaskRadii.buffer)
+  result.rectMaskShader.bindAttrib("vertexRectMaskMatX", result.rectMaskMatX.buffer)
+  result.rectMaskShader.bindAttrib("vertexRectMaskMatY", result.rectMaskMatY.buffer)
+
   # Mask shader.
+  glGenVertexArrays(1, result.maskVertexArrayId.addr)
+  glBindVertexArray(result.maskVertexArrayId)
   result.maskShader.bindAttrib("vertexPos", result.positions.buffer)
   result.maskShader.bindAttrib("vertexColor", result.colors.buffer)
   result.maskShader.bindAttrib("vertexUv", result.uvs.buffer)
@@ -514,10 +596,28 @@ proc flush(ctx: OpenGlContext, maskTextureRead: int = ctx.maskTextureWrite) =
   if ctx.quadCount == 0:
     return
 
+  let useRectMaskShader = not ctx.maskBegun and ctx.batchHasRectMask
+  ctx.activeShader =
+    if ctx.maskBegun:
+      ctx.maskShader
+    elif useRectMaskShader:
+      ctx.rectMaskShader
+    else:
+      ctx.mainShader
+
   ctx.upload()
+  if useRectMaskShader:
+    ctx.uploadRectMasks()
 
   glUseProgram(ctx.activeShader.programId)
-  glBindVertexArray(ctx.vertexArrayId)
+  glBindVertexArray(
+    if ctx.maskBegun:
+      ctx.maskVertexArrayId
+    elif useRectMaskShader:
+      ctx.rectMaskVertexArrayId
+    else:
+      ctx.vertexArrayId
+  )
 
   if ctx.activeShader.hasUniform("windowFrame"):
     ctx.activeShader.setUniform("windowFrame", ctx.frameSize.x, ctx.frameSize.y)
@@ -562,6 +662,7 @@ proc flush(ctx: OpenGlContext, maskTextureRead: int = ctx.maskTextureWrite) =
   )
 
   ctx.quadCount = 0
+  ctx.batchHasRectMask = false
 
 proc checkBatch(ctx: OpenGlContext) =
   if ctx.quadCount == ctx.maxQuads:
@@ -590,6 +691,33 @@ proc setVertColor(buf: var seq[uint8], i: int, color: ColorRGBA) =
   buf[i * 4 + 2] = color.b
   buf[i * 4 + 3] = color.a
 
+func roundedRadiiVec(radii: array[DirectionCorners, float32], halfExtents: Vec2): Vec4 =
+  let maxRadius = min(halfExtents.x, halfExtents.y)
+  let radiiClamped = [
+    dcTopLeft: (
+      if radii[dcTopLeft] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcTopLeft], maxRadius)).round()
+    ),
+    dcTopRight: (
+      if radii[dcTopRight] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcTopRight], maxRadius)).round()
+    ),
+    dcBottomLeft: (
+      if radii[dcBottomLeft] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcBottomLeft], maxRadius)).round()
+    ),
+    dcBottomRight: (
+      if radii[dcBottomRight] <= 0.0'f32: 0.0'f32
+      else: max(1.0'f32, min(radii[dcBottomRight], maxRadius)).round()
+    ),
+  ]
+  vec4(
+    radiiClamped[dcTopRight],
+    radiiClamped[dcBottomRight],
+    radiiClamped[dcTopLeft],
+    radiiClamped[dcBottomLeft],
+  )
+
 proc activeSubpixelShift(ctx: OpenGlContext): float32 =
   if not ctx.textSubpixelPositioningEnabled:
     return 0.0'f32
@@ -601,6 +729,74 @@ proc setQuadSubpixelShift(ctx: OpenGlContext, offset: int) =
   ctx.subpixelShifts.data.setVert1(offset + 1, shift)
   ctx.subpixelShifts.data.setVert1(offset + 2, shift)
   ctx.subpixelShifts.data.setVert1(offset + 3, shift)
+
+proc makeRectMask(
+    ctx: OpenGlContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+): RectMask =
+  let
+    halfExtents = maskRect.wh * 0.5'f32
+    center = maskRect.xy + halfExtents
+    invMat = ctx.mat.inverse()
+  RectMask(
+    kind: rmkFast,
+    params: vec4(center.x, center.y, halfExtents.x, halfExtents.y),
+    radii: roundedRadiiVec(radii, halfExtents),
+    matX: vec4(invMat[0, 0], invMat[1, 0], invMat[3, 0], 1.0'f32),
+    matY: vec4(invMat[0, 1], invMat[1, 1], invMat[3, 1], 0.0'f32),
+  )
+
+proc setRectMaskVert4(
+    ctx: OpenGlContext, offset: int, params, radii, matX, matY: Vec4
+) =
+  for i in 0 ..< 4:
+    ctx.rectMaskParams.data.setVert4(offset + i, params)
+    ctx.rectMaskRadii.data.setVert4(offset + i, radii)
+    ctx.rectMaskMatX.data.setVert4(offset + i, matX)
+    ctx.rectMaskMatY.data.setVert4(offset + i, matY)
+
+proc setDisabledRectMaskVerts(ctx: OpenGlContext, firstVertex, vertexCount: int) =
+  let
+    params = vec4(0.0'f32, 0.0'f32, -1.0'f32, -1.0'f32)
+    zero4 = vec4(0.0'f32)
+  for i in firstVertex ..< firstVertex + vertexCount:
+    ctx.rectMaskParams.data.setVert4(i, params)
+    ctx.rectMaskRadii.data.setVert4(i, zero4)
+    ctx.rectMaskMatX.data.setVert4(i, zero4)
+    ctx.rectMaskMatY.data.setVert4(i, zero4)
+
+proc setRectMaskVert4(ctx: OpenGlContext, offset: int) =
+  if ctx.maskBegun:
+    return
+
+  var
+    hasRectMask = false
+    params = vec4(0.0'f32)
+    radii = vec4(0.0'f32)
+    matX = vec4(0.0'f32)
+    matY = vec4(0.0'f32)
+
+  if ctx.rectMaskStack.len > 0:
+    for i in countdown(ctx.rectMaskStack.len - 1, 0):
+      let rectMask = ctx.rectMaskStack[i]
+      if rectMask.kind == rmkFast:
+        hasRectMask = true
+        params = rectMask.params
+        radii = rectMask.radii
+        matX = rectMask.matX
+        matY = rectMask.matY
+        break
+
+  if hasRectMask:
+    if not ctx.batchHasRectMask:
+      ctx.setDisabledRectMaskVerts(0, offset)
+      ctx.batchHasRectMask = true
+    ctx.setRectMaskVert4(offset, params, radii, matX, matY)
+  elif ctx.batchHasRectMask:
+    ctx.setDisabledRectMaskVerts(offset, 4)
+
+template setRectMaskVert4IfNeeded(ctx: OpenGlContext, offset: int) =
+  if not ctx.maskBegun and (ctx.batchHasRectMask or ctx.rectMaskStack.len > 0):
+    ctx.setRectMaskVert4(offset)
 
 func `*`*(m: Mat4, v: Vec2): Vec2 =
   (m * vec3(v.x, v.y, 0.0)).xy
@@ -656,6 +852,7 @@ proc drawQuad*(
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
   ctx.setQuadSubpixelShift(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -730,6 +927,7 @@ proc drawUvRectAtlasSdf(
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
   ctx.setQuadSubpixelShift(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -863,6 +1061,7 @@ proc drawUvRect(ctx: OpenGlContext, at, to: Vec2, uvAt, uvTo: Vec2, color: Color
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
   ctx.setQuadSubpixelShift(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -930,6 +1129,7 @@ proc drawUvRect(
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
   ctx.setQuadSubpixelShift(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -1112,32 +1312,7 @@ method drawRoundedRectSdf*(
         vec4(
           quadHalfExtents.x, quadHalfExtents.y, shapeHalfExtents.x, shapeHalfExtents.y
         )
-    maxRadius = min(shapeHalfExtents.x, shapeHalfExtents.y)
-    radiiClamped = [
-      dcTopLeft: (
-        if radii[dcTopLeft] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcTopLeft], maxRadius)).round()
-      ),
-      dcTopRight: (
-        if radii[dcTopRight] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcTopRight], maxRadius)).round()
-      ),
-      dcBottomLeft: (
-        if radii[dcBottomLeft] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcBottomLeft], maxRadius)).round()
-      ),
-      dcBottomRight: (
-        if radii[dcBottomRight] <= 0.0'f32: 0.0'f32
-        else: max(1.0'f32, min(radii[dcBottomRight], maxRadius)).round()
-      ),
-    ]
-    # (top-right, bottom-right, top-left, bottom-left)
-    r4 = vec4(
-      radiiClamped[dcTopRight],
-      radiiClamped[dcBottomRight],
-      radiiClamped[dcTopLeft],
-      radiiClamped[dcBottomLeft],
-    )
+    r4 = roundedRadiiVec(radii, shapeHalfExtents)
 
   assert ctx.quadCount < ctx.maxQuads
 
@@ -1201,6 +1376,7 @@ method drawRoundedRectSdf*(
   ctx.sdfModeAttr.data[offset + 2] = modeVal
   ctx.sdfModeAttr.data[offset + 3] = modeVal
   ctx.setQuadSubpixelShift(offset)
+  ctx.setRectMaskVert4IfNeeded(offset)
 
   inc ctx.quadCount
 
@@ -1356,9 +1532,9 @@ method beginMask*(
   ## Starts drawing into a mask.
   assert ctx.frameBegun == true, "ctx.beginFrame has not been called."
   assert ctx.maskBegun == false, "ctx.beginMask has already been called."
-  ctx.maskBegun = true
 
   ctx.flush(ctx.maskTextureWrite)
+  ctx.maskBegun = true
 
   inc ctx.maskTextureWrite
   if ctx.maskTextureWrite >= ctx.maskTextures.len:
@@ -1385,9 +1561,9 @@ method beginMask*(
 method endMask*(ctx: OpenGlContext) =
   ## Stops drawing into the mask.
   assert ctx.maskBegun == true, "ctx.maskBegun has not been called."
-  ctx.maskBegun = false
 
   ctx.flush(ctx.maskTextureWrite - 1)
+  ctx.maskBegun = false
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0)
 
@@ -1398,10 +1574,31 @@ method popMask*(ctx: OpenGlContext) =
 
   dec ctx.maskTextureWrite
 
+method beginRectMask*(
+    ctx: OpenGlContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+) =
+  assert ctx.frameBegun == true, "ctx.beginFrame has not been called."
+  assert ctx.maskBegun == false, "ctx.beginRectMask cannot start inside a mask."
+
+  if ctx.rectMaskStack.len == 0 and maskRect.w > 0.0'f32 and maskRect.h > 0.0'f32:
+    ctx.rectMaskStack.add(ctx.makeRectMask(maskRect, radii))
+  else:
+    ctx.beginMask(maskRect, radii)
+    ctx.endMask()
+    ctx.rectMaskStack.add(RectMask(kind: rmkMask))
+
+method popRectMask*(ctx: OpenGlContext) =
+  assert ctx.rectMaskStack.len > 0, "No rect mask has been pushed."
+  let rectMask = ctx.rectMaskStack.pop()
+  if rectMask.kind == rmkMask:
+    ctx.popMask()
+
 proc beginFrameProj(ctx: OpenGlContext, frameSize: Vec2, proj: Mat4) =
   ## Starts a new frame.
   assert ctx.frameBegun == false, "ctx.beginFrame has already been called."
   ctx.frameBegun = true
+  ctx.rectMaskStack.setLen(0)
+  ctx.batchHasRectMask = false
 
   ctx.proj = proj
   ctx.frameSize = frameSize
@@ -1431,6 +1628,7 @@ method endFrame*(ctx: OpenGlContext) =
   ## Ends a frame.
   assert ctx.frameBegun == true, "ctx.beginFrame was not called first."
   assert ctx.maskTextureWrite == 0, "Not all masks have been popped."
+  assert ctx.rectMaskStack.len == 0, "Not all rect masks have been popped."
   ctx.frameBegun = false
 
   ctx.flush()

--- a/src/figdraw/opengl/glsl/atlas_rect_mask.frag
+++ b/src/figdraw/opengl/glsl/atlas_rect_mask.frag
@@ -1,0 +1,210 @@
+#version 330
+
+in vec2 pos;
+in vec2 uv;
+in vec4 color;
+in vec4 sdfParams;
+in vec4 sdfRadii;
+in float sdfMode;
+in vec2 sdfFactors;
+in float subpixelShift;
+in vec4 rectMaskParams;
+in vec4 rectMaskRadii;
+in vec4 rectMaskMatX;
+in vec4 rectMaskMatY;
+
+uniform vec2 windowFrame;
+uniform sampler2D atlasTex;
+uniform sampler2D maskTex;
+uniform sampler2D backdropTex;
+uniform vec2 atlasTexelSize;
+uniform float aaFactor;
+uniform bool maskTexEnabled;
+uniform bool subpixelPositioningEnabled;
+
+out vec4 fragColor;
+
+const int sdfModeAtlas = 0;
+const int sdfModeClipAA = 3;
+const int sdfModeDropShadow = 7;
+const int sdfModeDropShadowAA = 8;
+const int sdfModeInsetShadow = 9;
+const int sdfModeAnnular = 11;
+const int sdfModeAnnularAA = 12;
+const int sdfModeMsdf = 13;
+const int sdfModeMtsdf = 14;
+const int sdfModeMsdfAnnular = 15;
+const int sdfModeMtsdfAnnular = 16;
+const int sdfModeBackdropBlur = 17;
+
+float median(float a, float b, float c) {
+  return max(min(a, b), min(max(a, b), c));
+}
+
+float msdfScreenPxRange(float pxRange) {
+  vec2 unitRange = vec2(pxRange) / vec2(textureSize(atlasTex, 0));
+  vec2 screenTexSize = vec2(1.0) / fwidth(uv);
+  return max(0.5 * dot(unitRange, screenTexSize), 1.0);
+}
+
+float sdRoundedBox(vec2 p, vec2 b, vec4 r) {
+  float rr;
+  if (p.x > 0.0) {
+    if (p.y > 0.0) {
+      rr = r.x;
+    } else {
+      rr = r.y;
+    }
+  } else {
+    if (p.y > 0.0) {
+      rr = r.z;
+    } else {
+      rr = r.w;
+    }
+  }
+
+  vec2 q = abs(p) - b + vec2(rr, rr);
+  return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - rr;
+}
+
+float shadowProfile(float sd, float blurRadius) {
+  // CSS-like calibration: sigma ~= blurRadius / 2
+  float sigma = max(0.5 * blurRadius, 0.5);
+  float z = sd / sigma;
+  return exp(-0.5 * z * z);
+}
+
+float rectMaskAlpha(vec2 pixelPos) {
+  if (rectMaskParams.z < 0.0 || rectMaskParams.w < 0.0) {
+    return 1.0;
+  }
+
+  vec2 local = vec2(
+    dot(rectMaskMatX.xy, pixelPos) + rectMaskMatX.z,
+    dot(rectMaskMatY.xy, pixelPos) + rectMaskMatY.z
+  );
+  vec2 q = local - rectMaskParams.xy;
+  float dist = sdRoundedBox(vec2(q.x, -q.y), rectMaskParams.zw, rectMaskRadii);
+  return 1.0 - clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+}
+
+void main() {
+  int sdfModeInt = int(sdfMode);
+  vec2 quadHalfExtents = sdfParams.xy;
+  bool insetMode = (sdfModeInt == sdfModeInsetShadow);
+  vec2 shapeHalfExtents = insetMode ? quadHalfExtents : sdfParams.zw;
+
+  vec2 p = vec2(
+    (uv.x - 0.5) * 2.0 * quadHalfExtents.x,
+    (uv.y - 0.5) * 2.0 * quadHalfExtents.y
+  );
+
+  float dist = sdRoundedBox(vec2(p.x, -p.y), shapeHalfExtents, sdfRadii);
+
+  float sdfFactor = sdfFactors.x;
+  float sdfSpread = sdfFactors.y;
+
+  float alpha = 0.0;
+  if (sdfModeInt == sdfModeAtlas) {
+    vec2 atlasUv = uv;
+    if (subpixelPositioningEnabled) {
+      atlasUv.x -= subpixelShift * atlasTexelSize.x;
+    }
+    vec4 tex = texture(atlasTex, atlasUv);
+    fragColor = vec4(
+      tex.x * color.x,
+      tex.y * color.y,
+      tex.z * color.z,
+      tex.w * color.w
+    );
+  } else if (
+    sdfModeInt == sdfModeMsdf ||
+    sdfModeInt == sdfModeMtsdf ||
+    sdfModeInt == sdfModeMsdfAnnular ||
+    sdfModeInt == sdfModeMtsdfAnnular
+  ) {
+    float pxRange = sdfFactors.x;
+    float sdThreshold = sdfFactors.y;
+
+    vec4 tex = textureLod(atlasTex, uv, 0.0);
+    bool isMtsdf = (sdfModeInt == sdfModeMtsdf || sdfModeInt == sdfModeMtsdfAnnular);
+    bool isStroke = (sdfModeInt == sdfModeMsdfAnnular || sdfModeInt == sdfModeMtsdfAnnular);
+    float sd = isMtsdf ? tex.w : median(tex.x, tex.y, tex.z);
+    float screenPxDistance = msdfScreenPxRange(pxRange) * (sd - sdThreshold);
+
+    if (isStroke) {
+      float strokeW = max(sdfParams.y, 0.0);
+      float halfW = strokeW * 0.5;
+      alpha = clamp(halfW - abs(screenPxDistance) + 0.5, 0.0, 1.0);
+    } else {
+      alpha = clamp(screenPxDistance + 0.5, 0.0, 1.0);
+    }
+    fragColor = vec4(color.xyz, color.w * alpha);
+  } else {
+    switch (sdfModeInt) {
+      case sdfModeAnnular: {
+        float f = sdfFactor * 0.5;
+        float sd = abs(dist + f) - f;
+        alpha = (sd < 0.0) ? 1.0 : 0.0;
+        break;
+      }
+      case sdfModeAnnularAA: {
+        float f = sdfFactor * 0.5;
+        float sd = abs(dist + f) - f;
+        float cl = clamp(aaFactor * sd + 0.5, 0.0, 1.0);
+        alpha = 1.0 - cl;
+        break;
+      }
+      case sdfModeDropShadow: {
+        float sd = dist - sdfSpread;
+        float a = shadowProfile(sd, sdfFactor);
+        alpha = (sd > 0.0) ? min(a, 1.0) : 1.0;
+        break;
+      }
+      case sdfModeDropShadowAA: {
+        float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+        float insideAlpha = 1.0 - cl;
+        float sd = dist - sdfSpread;
+        float a = shadowProfile(sd, sdfFactor);
+        alpha = (sd >= 0.0) ? min(a, 1.0) : insideAlpha;
+        break;
+      }
+      case sdfModeInsetShadow: {
+        vec2 qClip = vec2(p.x, -p.y);
+        vec2 shadowOffset = vec2(sdfParams.z, -sdfParams.w);
+        vec2 qShadow = qClip - shadowOffset;
+        float clipDist = sdRoundedBox(qClip, quadHalfExtents, sdfRadii);
+        float clipAlpha = 1.0 - clamp(aaFactor * clipDist + 0.5, 0.0, 1.0);
+        float shadowDist = sdRoundedBox(qShadow, quadHalfExtents, sdfRadii);
+        float sd = shadowDist + sdfSpread;
+        float a = shadowProfile(sd, sdfFactor);
+        float insetAlpha = (sd < 0.0) ? min(a, 1.0) : 1.0;
+        alpha = clipAlpha * insetAlpha;
+        break;
+      }
+      case sdfModeBackdropBlur: {
+        float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+        alpha = 1.0 - cl;
+        vec2 normalizedPos = vec2(pos.x / windowFrame.x, 1.0 - pos.y / windowFrame.y);
+        vec4 blur = texture(backdropTex, normalizedPos);
+        fragColor = vec4(blur.rgb, blur.a * alpha);
+        break;
+      }
+      default: {
+        float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+        alpha = 1.0 - cl;
+        break;
+      }
+    }
+
+    if (sdfModeInt != sdfModeBackdropBlur) {
+      fragColor = vec4(color.x, color.y, color.z, color.w * alpha);
+    }
+  }
+
+  vec2 normalizedPos = vec2(pos.x / windowFrame.x, 1.0 - pos.y / windowFrame.y);
+  if (maskTexEnabled) {
+    fragColor.w *= texture(maskTex, normalizedPos).x;
+  }
+  fragColor.w *= rectMaskAlpha(pos);
+}

--- a/src/figdraw/opengl/glsl/atlas_rect_mask.vert
+++ b/src/figdraw/opengl/glsl/atlas_rect_mask.vert
@@ -1,0 +1,45 @@
+#version 330
+
+in vec2 vertexPos;
+in vec2 vertexUv;
+in vec4 vertexColor;
+in vec4 vertexSdfParams;
+in vec4 vertexSdfRadii;
+in float vertexSdfMode;
+in vec2 vertexSdfFactors;
+in float vertexSubpixelShift;
+in vec4 vertexRectMaskParams;
+in vec4 vertexRectMaskRadii;
+in vec4 vertexRectMaskMatX;
+in vec4 vertexRectMaskMatY;
+
+uniform mat4 proj;
+
+out vec2 pos;
+out vec2 uv;
+out vec4 color;
+out vec4 sdfParams;
+out vec4 sdfRadii;
+out float sdfMode;
+out vec2 sdfFactors;
+out float subpixelShift;
+out vec4 rectMaskParams;
+out vec4 rectMaskRadii;
+out vec4 rectMaskMatX;
+out vec4 rectMaskMatY;
+
+void main() {
+  pos = vertexPos;
+  uv = vertexUv;
+  color = vertexColor;
+  sdfParams = vertexSdfParams;
+  sdfRadii = vertexSdfRadii;
+  sdfMode = vertexSdfMode;
+  sdfFactors = vertexSdfFactors;
+  subpixelShift = vertexSubpixelShift;
+  rectMaskParams = vertexRectMaskParams;
+  rectMaskRadii = vertexRectMaskRadii;
+  rectMaskMatX = vertexRectMaskMatX;
+  rectMaskMatY = vertexRectMaskMatY;
+  gl_Position = proj * vec4(vertexPos.x, vertexPos.y, 0.0, 1.0);
+}

--- a/src/figdraw/opengl/glsl/emscripten/atlas_rect_mask.frag
+++ b/src/figdraw/opengl/glsl/emscripten/atlas_rect_mask.frag
@@ -1,0 +1,199 @@
+#version 100
+
+#extension GL_OES_standard_derivatives : enable
+precision highp float;
+
+varying vec2 pos;
+varying vec2 uv;
+varying vec4 color;
+varying vec4 sdfParams;
+varying vec4 sdfRadii;
+varying float sdfMode;
+varying vec2 sdfFactors;
+varying float subpixelShift;
+varying vec4 rectMaskParams;
+varying vec4 rectMaskRadii;
+varying vec4 rectMaskMatX;
+varying vec4 rectMaskMatY;
+
+uniform vec2 windowFrame;
+uniform sampler2D atlasTex;
+uniform sampler2D maskTex;
+uniform sampler2D backdropTex;
+uniform vec2 atlasTexelSize;
+uniform float aaFactor;
+uniform bool maskTexEnabled;
+uniform bool subpixelPositioningEnabled;
+
+const int sdfModeAtlas = 0;
+const int sdfModeClipAA = 3;
+const int sdfModeDropShadow = 7;
+const int sdfModeDropShadowAA = 8;
+const int sdfModeInsetShadow = 9;
+const int sdfModeAnnular = 11;
+const int sdfModeAnnularAA = 12;
+const int sdfModeMsdf = 13;
+const int sdfModeMtsdf = 14;
+const int sdfModeMsdfAnnular = 15;
+const int sdfModeMtsdfAnnular = 16;
+const int sdfModeBackdropBlur = 17;
+
+float median(float a, float b, float c) {
+  return max(min(a, b), min(max(a, b), c));
+}
+
+float msdfScreenPxRange(float pxRange) {
+  float atlasSize = sdfParams.x;
+  vec2 unitRange = vec2(pxRange / atlasSize);
+  vec2 screenTexSize = vec2(1.0) / fwidth(uv);
+  return max(0.5 * dot(unitRange, screenTexSize), 1.0);
+}
+
+float sdRoundedBox(vec2 p, vec2 b, vec4 r) {
+  float rr;
+  if (p.x > 0.0) {
+    if (p.y > 0.0) {
+      rr = r.x;
+    } else {
+      rr = r.y;
+    }
+  } else {
+    if (p.y > 0.0) {
+      rr = r.z;
+    } else {
+      rr = r.w;
+    }
+  }
+
+  vec2 q = abs(p) - b + vec2(rr, rr);
+  return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - rr;
+}
+
+float shadowProfile(float sd, float blurRadius) {
+  // CSS-like calibration: sigma ~= blurRadius / 2
+  float sigma = max(0.5 * blurRadius, 0.5);
+  float z = sd / sigma;
+  return exp(-0.5 * z * z);
+}
+
+float rectMaskAlpha(vec2 pixelPos) {
+  if (rectMaskParams.z < 0.0 || rectMaskParams.w < 0.0) {
+    return 1.0;
+  }
+
+  vec2 local = vec2(
+    dot(rectMaskMatX.xy, pixelPos) + rectMaskMatX.z,
+    dot(rectMaskMatY.xy, pixelPos) + rectMaskMatY.z
+  );
+  vec2 q = local - rectMaskParams.xy;
+  float dist = sdRoundedBox(vec2(q.x, -q.y), rectMaskParams.zw, rectMaskRadii);
+  return 1.0 - clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+}
+
+void main() {
+  int sdfModeInt = int(sdfMode);
+  vec2 quadHalfExtents = sdfParams.xy;
+  bool insetMode = (sdfModeInt == sdfModeInsetShadow);
+  vec2 shapeHalfExtents = insetMode ? quadHalfExtents : sdfParams.zw;
+
+  vec2 p = vec2(
+    (uv.x - 0.5) * 2.0 * quadHalfExtents.x,
+    (uv.y - 0.5) * 2.0 * quadHalfExtents.y
+  );
+
+  float dist = sdRoundedBox(vec2(p.x, -p.y), shapeHalfExtents, sdfRadii);
+
+  float sdfFactor = sdfFactors.x;
+  float sdfSpread = sdfFactors.y;
+
+  float alpha = 0.0;
+  vec4 fragColor;
+  if (sdfModeInt == sdfModeAtlas) {
+    vec2 atlasUv = uv;
+    if (subpixelPositioningEnabled) {
+      atlasUv.x -= subpixelShift * atlasTexelSize.x;
+    }
+    vec4 tex = texture2D(atlasTex, atlasUv);
+    fragColor = vec4(
+      tex.x * color.x,
+      tex.y * color.y,
+      tex.z * color.z,
+      tex.w * color.w
+    );
+  } else if (
+    sdfModeInt == sdfModeMsdf ||
+    sdfModeInt == sdfModeMtsdf ||
+    sdfModeInt == sdfModeMsdfAnnular ||
+    sdfModeInt == sdfModeMtsdfAnnular
+  ) {
+    float pxRange = sdfFactors.x;
+    float sdThreshold = sdfFactors.y;
+
+    vec4 tex = texture2D(atlasTex, uv);
+    bool isMtsdf = (sdfModeInt == sdfModeMtsdf || sdfModeInt == sdfModeMtsdfAnnular);
+    bool isStroke = (sdfModeInt == sdfModeMsdfAnnular || sdfModeInt == sdfModeMtsdfAnnular);
+    float sd = isMtsdf ? tex.w : median(tex.x, tex.y, tex.z);
+    float screenPxDistance = msdfScreenPxRange(pxRange) * (sd - sdThreshold);
+
+    if (isStroke) {
+      float strokeW = max(sdfParams.y, 0.0);
+      float halfW = strokeW * 0.5;
+      alpha = clamp(halfW - abs(screenPxDistance) + 0.5, 0.0, 1.0);
+    } else {
+      alpha = clamp(screenPxDistance + 0.5, 0.0, 1.0);
+    }
+    fragColor = vec4(color.rgb, color.a * alpha);
+  } else {
+    if (sdfModeInt == sdfModeAnnular) {
+      float f = sdfFactor * 0.5;
+      float sd = abs(dist + f) - f;
+      alpha = (sd < 0.0) ? 1.0 : 0.0;
+    } else if (sdfModeInt == sdfModeAnnularAA) {
+      float f = sdfFactor * 0.5;
+      float sd = abs(dist + f) - f;
+      float cl = clamp(aaFactor * sd + 0.5, 0.0, 1.0);
+      alpha = 1.0 - cl;
+    } else if (sdfModeInt == sdfModeDropShadow) {
+      float sd = dist - sdfSpread;
+      float a = shadowProfile(sd, sdfFactor);
+      alpha = (sd > 0.0) ? min(a, 1.0) : 1.0;
+    } else if (sdfModeInt == sdfModeDropShadowAA) {
+      float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+      float insideAlpha = 1.0 - cl;
+      float sd = dist - sdfSpread;
+      float a = shadowProfile(sd, sdfFactor);
+      alpha = (sd >= 0.0) ? min(a, 1.0) : insideAlpha;
+    } else if (sdfModeInt == sdfModeInsetShadow) {
+      vec2 qClip = vec2(p.x, -p.y);
+      vec2 shadowOffset = vec2(sdfParams.z, -sdfParams.w);
+      vec2 qShadow = qClip - shadowOffset;
+      float clipDist = sdRoundedBox(qClip, quadHalfExtents, sdfRadii);
+      float clipAlpha = 1.0 - clamp(aaFactor * clipDist + 0.5, 0.0, 1.0);
+      float shadowDist = sdRoundedBox(qShadow, quadHalfExtents, sdfRadii);
+      float sd = shadowDist + sdfSpread;
+      float a = shadowProfile(sd, sdfFactor);
+      float insetAlpha = (sd < 0.0) ? min(a, 1.0) : 1.0;
+      alpha = clipAlpha * insetAlpha;
+    } else if (sdfModeInt == sdfModeBackdropBlur) {
+      float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+      alpha = 1.0 - cl;
+      vec2 normalizedPos = vec2(pos.x / windowFrame.x, 1.0 - pos.y / windowFrame.y);
+      vec4 blur = texture2D(backdropTex, normalizedPos);
+      fragColor = vec4(blur.rgb, blur.a * alpha);
+    } else {
+      float cl = clamp(aaFactor * dist + 0.5, 0.0, 1.0);
+      alpha = 1.0 - cl;
+    }
+
+    if (sdfModeInt != sdfModeBackdropBlur) {
+      fragColor = vec4(color.x, color.y, color.z, color.w * alpha);
+    }
+  }
+
+  vec2 normalizedPos = vec2(pos.x / windowFrame.x, 1.0 - pos.y / windowFrame.y);
+  if (maskTexEnabled) {
+    fragColor.a *= texture2D(maskTex, normalizedPos).r;
+  }
+  fragColor.a *= rectMaskAlpha(pos);
+  gl_FragColor = fragColor;
+}

--- a/src/figdraw/opengl/glsl/emscripten/atlas_rect_mask.vert
+++ b/src/figdraw/opengl/glsl/emscripten/atlas_rect_mask.vert
@@ -1,0 +1,47 @@
+#version 100
+
+precision highp float;
+
+attribute vec2 vertexPos;
+attribute vec2 vertexUv;
+attribute vec4 vertexColor;
+attribute vec4 vertexSdfParams;
+attribute vec4 vertexSdfRadii;
+attribute float vertexSdfMode;
+attribute vec2 vertexSdfFactors;
+attribute float vertexSubpixelShift;
+attribute vec4 vertexRectMaskParams;
+attribute vec4 vertexRectMaskRadii;
+attribute vec4 vertexRectMaskMatX;
+attribute vec4 vertexRectMaskMatY;
+
+uniform mat4 proj;
+
+varying vec2 pos;
+varying vec2 uv;
+varying vec4 color;
+varying vec4 sdfParams;
+varying vec4 sdfRadii;
+varying float sdfMode;
+varying vec2 sdfFactors;
+varying float subpixelShift;
+varying vec4 rectMaskParams;
+varying vec4 rectMaskRadii;
+varying vec4 rectMaskMatX;
+varying vec4 rectMaskMatY;
+
+void main() {
+  pos = vertexPos;
+  uv = vertexUv;
+  color = vertexColor;
+  sdfParams = vertexSdfParams;
+  sdfRadii = vertexSdfRadii;
+  sdfMode = vertexSdfMode;
+  sdfFactors = vertexSdfFactors;
+  subpixelShift = vertexSubpixelShift;
+  rectMaskParams = vertexRectMaskParams;
+  rectMaskRadii = vertexRectMaskRadii;
+  rectMaskMatX = vertexRectMaskMatX;
+  rectMaskMatY = vertexRectMaskMatY;
+  gl_Position = proj * vec4(vertexPos.x, vertexPos.y, 0.0, 1.0);
+}

--- a/src/figdraw/vulkan/vulkan_context.nim
+++ b/src/figdraw/vulkan/vulkan_context.nim
@@ -2958,6 +2958,15 @@ method popMask*(ctx: VulkanContext) =
     discard ctx.clipRects.pop()
   ctx.applyClipScissor()
 
+method beginRectMask*(
+    ctx: VulkanContext, maskRect: Rect, radii: array[DirectionCorners, float32]
+) =
+  ctx.beginMask(maskRect, radii)
+  ctx.endMask()
+
+method popRectMask*(ctx: VulkanContext) =
+  ctx.popMask()
+
 proc beginFrame*(
     ctx: VulkanContext,
     frameSize: Vec2,

--- a/tests/trender_layers_clip.nim
+++ b/tests/trender_layers_clip.nim
@@ -25,6 +25,7 @@ proc addRect(
     z: ZLevel,
     clip: bool = false,
     rectMask: bool = false,
+    corners: uint16 = 10'u16,
 ) =
   var flags: set[FigFlags] = {}
   if clip:
@@ -40,7 +41,7 @@ proc addRect(
       zlevel: z,
       screenBox: rectBox,
       fill: color,
-      corners: [10'u16, 10'u16, 10'u16, 10'u16],
+      corners: [corners, corners, corners, corners],
       flags: flags,
     ),
   )
@@ -52,6 +53,7 @@ proc addRootRect(
     z: ZLevel,
     clip: bool = false,
     rectMask: bool = false,
+    corners: uint16 = 10'u16,
 ): FigIdx =
   var flags: set[FigFlags] = {}
   if clip:
@@ -66,7 +68,7 @@ proc addRootRect(
       zlevel: z,
       screenBox: rectBox,
       fill: color,
-      corners: [10'u16, 10'u16, 10'u16, 10'u16],
+      corners: [corners, corners, corners, corners],
       flags: flags,
     )
   )
@@ -176,6 +178,44 @@ proc makeClipRenderTree(w, h: float32): Renders =
 proc makeRectMaskRenderTree(w, h: float32): Renders =
   makeRenderTree(w, h, rectMask = true)
 
+proc makeMixedRectMaskBatchRenderTree(w, h: float32): Renders =
+  var list = RenderList()
+  discard list.addRootRect(
+    rect(0.0'f32, 0.0'f32, w, h), rgba(255, 255, 255, 255), 0.ZLevel, corners = 0
+  )
+
+  discard list.addRootRect(
+    rect(32.0'f32, 48.0'f32, 96.0'f32, 80.0'f32),
+    rgba(230, 70, 52, 255),
+    0.ZLevel,
+    corners = 0,
+  )
+
+  let maskIdx = list.addRootRect(
+    rect(180.0'f32, 48.0'f32, 80.0'f32, 80.0'f32),
+    rgba(218, 218, 218, 255),
+    0.ZLevel,
+    rectMask = true,
+    corners = 0,
+  )
+  list.addRect(
+    maskIdx,
+    rect(150.0'f32, 72.0'f32, 150.0'f32, 34.0'f32),
+    rgba(56, 168, 88, 255),
+    0.ZLevel,
+    corners = 0,
+  )
+
+  discard list.addRootRect(
+    rect(310.0'f32, 48.0'f32, 96.0'f32, 80.0'f32),
+    rgba(54, 118, 230, 255),
+    0.ZLevel,
+    corners = 0,
+  )
+
+  result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
+  result.layers[0.ZLevel] = list
+
 suite "opengl layer + clip render":
   test "renders figuro-style layers + clip layout":
     setFigUiScale(1.0)
@@ -283,3 +323,31 @@ suite "opengl layer + clip render":
       if diffScore > diffThreshold:
         diffImg.writeFile(joinPath(outDir, "render_layers_rect_mask.diff.png"))
       check diffScore <= diffThreshold
+
+  test "keeps unmasked siblings visible around rect mask in one batch":
+    setFigUiScale(1.0)
+    let outDir = ensureTestOutputDir()
+    let outPath = outDir / "render_rect_mask_mixed_batch.png"
+    if fileExists(outPath):
+      removeFile(outPath)
+    block renderOnce:
+      var rendered: Image
+      try:
+        rendered = renderAndScreenshotOnce(
+          makeRenders = makeMixedRectMaskBatchRenderTree,
+          outputPath = outPath,
+          windowW = 480,
+          windowH = 180,
+          title = "figdraw test: mixed rect mask batch",
+        )
+      except WindyError:
+        skip()
+        break renderOnce
+
+      check fileExists(outPath)
+      check getFileSize(outPath) > 0
+
+      assertColor(rendered, 74, 88, 230, 70, 52)
+      assertColor(rendered, 160, 88, 255, 255, 255)
+      assertColor(rendered, 204, 88, 56, 168, 88)
+      assertColor(rendered, 336, 88, 54, 118, 230)

--- a/tests/trender_layers_clip.nim
+++ b/tests/trender_layers_clip.nim
@@ -24,7 +24,14 @@ proc addRect(
     color: ColorRGBA,
     z: ZLevel,
     clip: bool = false,
+    rectMask: bool = false,
 ) =
+  var flags: set[FigFlags] = {}
+  if clip:
+    flags.incl NfClipContent
+  if rectMask:
+    flags.incl NfRectMaskContent
+
   discard list.addChild(
     parentIdx,
     Fig(
@@ -34,17 +41,24 @@ proc addRect(
       screenBox: rectBox,
       fill: color,
       corners: [10'u16, 10'u16, 10'u16, 10'u16],
-      flags:
-        if clip:
-          {NfClipContent}
-        else:
-          {},
+      flags: flags,
     ),
   )
 
 proc addRootRect(
-    list: var RenderList, rectBox: Rect, color: ColorRGBA, z: ZLevel, clip: bool = false
+    list: var RenderList,
+    rectBox: Rect,
+    color: ColorRGBA,
+    z: ZLevel,
+    clip: bool = false,
+    rectMask: bool = false,
 ): FigIdx =
+  var flags: set[FigFlags] = {}
+  if clip:
+    flags.incl NfClipContent
+  if rectMask:
+    flags.incl NfRectMaskContent
+
   list.addRoot(
     Fig(
       kind: nkRectangle,
@@ -53,15 +67,11 @@ proc addRootRect(
       screenBox: rectBox,
       fill: color,
       corners: [10'u16, 10'u16, 10'u16, 10'u16],
-      flags:
-        if clip:
-          {NfClipContent}
-        else:
-          {},
+      flags: flags,
     )
   )
 
-proc makeRenderTree(w, h: float32): Renders =
+proc makeRenderTree(w, h: float32, rectMask = false): Renders =
   let bgColor = rgba(255, 255, 255, 255)
   let containerColor = rgba(208, 208, 208, 255)
   let buttonColor = rgba(43, 159, 234, 255)
@@ -102,7 +112,8 @@ proc makeRenderTree(w, h: float32): Renders =
     rect(containerRightX, containerY, containerW, containerH),
     containerColor,
     0.ZLevel,
-    clip = true,
+    clip = not rectMask,
+    rectMask = rectMask,
   )
 
   addRect(
@@ -159,6 +170,12 @@ proc makeRenderTree(w, h: float32): Renders =
       cmp(x[0], y[0])
   )
 
+proc makeClipRenderTree(w, h: float32): Renders =
+  makeRenderTree(w, h)
+
+proc makeRectMaskRenderTree(w, h: float32): Renders =
+  makeRenderTree(w, h, rectMask = true)
+
 suite "opengl layer + clip render":
   test "renders figuro-style layers + clip layout":
     setFigUiScale(1.0)
@@ -170,7 +187,7 @@ suite "opengl layer + clip render":
       var img: Image
       try:
         img = renderAndScreenshotOnce(
-          makeRenders = makeRenderTree,
+          makeRenders = makeClipRenderTree,
           outputPath = outPath,
           windowW = 800,
           windowH = 375,
@@ -230,3 +247,39 @@ suite "opengl layer + clip render":
       assertColor(
         rendered, (containerRightX + containerW * 0.5'f32).int, lowY, 208, 208, 208
       )
+
+  test "renders figuro-style layers with rect mask layout":
+    setFigUiScale(1.0)
+    let outDir = ensureTestOutputDir()
+    let outPath = outDir / "render_layers_rect_mask.png"
+    if fileExists(outPath):
+      removeFile(outPath)
+    block renderOnce:
+      var img: Image
+      try:
+        img = renderAndScreenshotOnce(
+          makeRenders = makeRectMaskRenderTree,
+          outputPath = outPath,
+          windowW = 800,
+          windowH = 375,
+          title = "figdraw test: layers + rect mask",
+        )
+      except WindyError:
+        skip()
+        break renderOnce
+
+      check fileExists(outPath)
+      check getFileSize(outPath) > 0
+
+      let expectedPath = "tests" / "expected" / "render_layers_clip.png"
+      check fileExists(expectedPath)
+      let expected = pixie.readImage(expectedPath)
+      var rendered = img
+      if rendered.width != expected.width or rendered.height != expected.height:
+        rendered = rendered.resize(expected.width, expected.height)
+      let (diffScore, diffImg) = expected.diff(rendered)
+      echo "Got rect mask image difference of: ", diffScore
+      let diffThreshold = 1.0'f32
+      if diffScore > diffThreshold:
+        diffImg.writeFile(joinPath(outDir, "render_layers_rect_mask.diff.png"))
+      check diffScore <= diffThreshold


### PR DESCRIPTION
Adds `NfRectMaskContent`, a new content flag for rounded-rect clipping behavior that can be evaluated as a fast SDF mask by backends that support it.

This is particularly useful for the case in GUIs where you have lots of small widgets that you want to clip but are simple enough for a SDF mask.

- Adds the `NfRectMaskContent` flag and render path.
- Implements fast rounded-rect mask support for Metal and OpenGL.
- Adds OpenGL desktop and Emscripten rect-mask shaders.
- Adds Vulkan fallback behavior by treating `NfRectMaskContent` like the existing mask/clip path.
- Avoids rect-mask overhead for normal batches when no rect mask is active.
- Documents when and how to use `NfRectMaskContent` in the README.
- Adds benchmarks for clip-vs-mask table/list-style scenes and normal non-clip rendering.
- Adds regression render coverage for mixed batches: unmasked sibling, rect-masked sibling, then unmasked sibling again.

## Notes

`NfRectMaskContent` composes with `NfClipContent`: for example, a scroll viewport can still use `NfClipContent`, while small rounded child rows/cells inside it use `NfRectMaskContent` to avoid extra mask passes on supported backends.
