### PR TITLE
Harden font shaping and raster handling

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -15,6 +15,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04
@@ -49,8 +50,9 @@ jobs:
           - os: windows-2022
             nimversion: '2.2.10'
             display: none
-            renderer: native
-            nimflags: '-d:figdraw.vulkan=off'
+            renderer: opengl
+            nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off'
+            force_opengl: '1'
     steps:
     - uses: actions/checkout@v1
 
@@ -241,6 +243,8 @@ jobs:
       if: runner.os == 'Windows'
       env:
         NIMFLAGS: ${{ matrix.nimflags }}
+        FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
+        FIGDRAW_REQUIRE_GRAPHICS: '1'
       run: |
         nim test
 

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -51,7 +51,7 @@ jobs:
             nimversion: '2.2.10'
             display: none
             renderer: opengl
-            nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off'
+            nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '1'
     steps:
     - uses: actions/checkout@v1
@@ -63,6 +63,14 @@ jobs:
         version: '26.0.3'
         build-type: 'release-msvc'
         deployment-choice: '1'
+
+    - name: Install Windows text shaping dependencies
+      if: runner.os == 'Windows'
+      run: |
+        C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed \
+          mingw-w64-x86_64-harfbuzz \
+          mingw-w64-x86_64-fribidi
+        echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
 
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'
@@ -257,6 +265,7 @@ jobs:
         LIBGL_ALWAYS_SOFTWARE: '1'
       run: |
         nim test
+        nim r -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
 
     - name: Build Tests (Vulkan Compile Check)
       if: runner.os == 'Windows'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -9,28 +9,48 @@ on:
 
 jobs:
   tests:
+    name: ${{ matrix.os }}-${{ matrix.display }}-${{ matrix.renderer }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
     strategy:
       matrix:
-        nimversion:
-          - '2.2.10'
-        os:
-          - ubuntu-24.04
-          - macos-14
-          - windows-2022
-        display:
-          - none
-        exclude:
-          - os: ubuntu-24.04
-            display: none
         include:
           - os: ubuntu-24.04
+            nimversion: '2.2.10'
             display: x11
+            renderer: opengl
+            nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off'
+            force_opengl: '1'
           - os: ubuntu-24.04
+            nimversion: '2.2.10'
+            display: x11
+            renderer: vulkan
+            nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on'
+            force_opengl: '0'
+          - os: ubuntu-24.04
+            nimversion: '2.2.10'
             display: wayland
+            renderer: opengl
+            nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off'
+            force_opengl: '1'
+          - os: ubuntu-24.04
+            nimversion: '2.2.10'
+            display: wayland
+            renderer: vulkan
+            nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on'
+            force_opengl: '0'
+          - os: macos-14
+            nimversion: '2.2.10'
+            display: none
+            renderer: native
+            nimflags: ''
+          - os: windows-2022
+            nimversion: '2.2.10'
+            display: none
+            renderer: native
+            nimflags: '-d:figdraw.vulkan=off'
     steps:
     - uses: actions/checkout@v1
 
@@ -102,7 +122,7 @@ jobs:
         fi
 
     - name: Vulkan diagnostics
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.renderer == 'vulkan'
       run: |
         ls -la /usr/share/vulkan/icd.d || true
         vulkaninfo --summary || true
@@ -140,7 +160,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: deps/
-        key: ${{ runner.os }}-${{ matrix.display }}-${{ hashFiles('figdraw.nimble') }}
+        key: ${{ runner.os }}-${{ matrix.display }}-${{ matrix.renderer }}-${{ hashFiles('figdraw.nimble') }}
 
     - name: Install Deps
       run: atlas install -t:8 --features:windy,sdl2,siwin,sharedlib,harfbuzz
@@ -160,18 +180,25 @@ jobs:
       if: runner.os == 'Linux' && matrix.display == 'x11'
       env:
         XDG_SESSION_TYPE: "x11"
+        FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
+        FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
+        NIMFLAGS: ${{ matrix.nimflags }}
         GALLIUM_DRIVER: "llvmpipe"
         LIBGL_ALWAYS_SOFTWARE: "1"
         MESA_GL_VERSION_OVERRIDE: "3.3"
         MESA_GLSL_VERSION_OVERRIDE: "330"
       run: |
         xvfb-run -a nim test
+        nim r -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
 
     - name: Build Tests
       if: runner.os == 'Linux' && matrix.display == 'wayland'
       env:
         XDG_SESSION_TYPE: "wayland"
         WAYLAND_DISPLAY: "wayland-1"
+        FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
+        FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
+        NIMFLAGS: ${{ matrix.nimflags }}
         GALLIUM_DRIVER: "llvmpipe"
         LIBGL_ALWAYS_SOFTWARE: "1"
         MESA_GL_VERSION_OVERRIDE: "3.3"
@@ -199,8 +226,11 @@ jobs:
         done
         [[ -S "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]] || (cat "${RUNNER_TEMP}/weston.log" && exit 1)
 
-        vulkaninfo --summary || true
+        if [[ "${{ matrix.renderer }}" == "vulkan" ]]; then
+          vulkaninfo --summary || true
+        fi
         nim test
+        nim r -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
 
     - name: Build Tests
       if: runner.os == 'macOS'
@@ -210,12 +240,12 @@ jobs:
     - name: Build Tests
       if: runner.os == 'Windows'
       env:
-        NIMFLAGS: "-d:figdraw.vulkan=off"
+        NIMFLAGS: ${{ matrix.nimflags }}
       run: |
         nim test
 
     - name: Build Tests (Vulkan Compile Check)
-      if: runner.os == 'Linux' || runner.os == 'Windows'
+      if: runner.os == 'Windows'
       env:
         NIMFLAGS: "-d:figdraw.opengl=off -d:figdraw.vulkan=on"
       run: |
@@ -225,7 +255,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: tests-output-${{ runner.os }}-${{ matrix.display }}-nim${{ matrix.nimversion }}
+        name: tests-output-${{ runner.os }}-${{ matrix.display }}-${{ matrix.renderer }}-nim${{ matrix.nimversion }}
         path: |
           tests/output/
           ${{ runner.temp }}/weston.log

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -265,7 +265,7 @@ jobs:
         LIBGL_ALWAYS_SOFTWARE: '1'
       run: |
         nim test
-        nim r -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
+        nim r $NIMFLAGS -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
 
     - name: Build Tests (Vulkan Compile Check)
       if: runner.os == 'Windows'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -56,6 +56,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Setup software OpenGL (Mesa)
+      if: runner.os == 'Windows'
+      uses: ssciwr/setup-mesa-dist-win@v3.0.0
+      with:
+        version: '26.0.3'
+        build-type: 'release-msvc'
+        deployment-choice: '1'
+
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'
       timeout-minutes: 15
@@ -245,6 +253,8 @@ jobs:
         NIMFLAGS: ${{ matrix.nimflags }}
         FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
         FIGDRAW_REQUIRE_GRAPHICS: '1'
+        GALLIUM_DRIVER: 'llvmpipe'
+        LIBGL_ALWAYS_SOFTWARE: '1'
       run: |
         nim test
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,10 @@ Install the optional Harfbuzzy dependency when trying the repo:
 atlas install --feature:windy --feature:harfbuzz
 ```
 
+The pure glyph-id raster backend requires HarfBuzz 7.0 or newer plus FriBidi.
+For example, install `libharfbuzz-dev libfribidi-dev` on Ubuntu or
+`harfbuzz fribidi` with Homebrew before compiling it.
+
 Add the `harfbuzz` feature when using FigDraw from another project:
 
 ```nim
@@ -604,6 +608,11 @@ Use the source-aware helpers for selection, hit testing, and carets:
 - `sourceRuneRangeAt(point)`: source range under a local text-layout point.
 - `caretPositionsFor(sourceRune)`: visual caret rectangles for a source
   insertion index, including split positions at bidi boundaries.
+
+Font collection paths (`.ttc` and `.otc`) are supported; FigDraw selects the
+face whose name best matches the requested font and carries that face index
+through shaping and rasterization. The current Harfbuzzy raster path renders
+monochrome outlines, not color bitmap, SVG, or COLR glyph paint data.
 
 See [docs/font_shaping.md](docs/font_shaping.md) for the data model details and
 [examples/windy_text_shaping_demo.nim](examples/windy_text_shaping_demo.nim) for

--- a/config.nims
+++ b/config.nims
@@ -111,32 +111,47 @@ task test, "run unit test":
   let enableSdl2 =
     getEnv("FIGDRAW_TEST_SDL2").strip().toLowerAscii() in ["1", "true", "yes", "on"]
 
+  var testRuns = 0
   for platformArg in platforms():
     if platformArg != "":
       echo "Running platform args: ", platformArg
     for file in listFiles("tests"):
-      if file.startsWith("tests/t") and file.endsWith(".nim"):
+      let name = file.extractFilename()
+      if name.startsWith("t") and name.endsWith(".nim"):
+        inc testRuns
         nimExec("r", file, platform = platformArg)
 
+  if testRuns == 0:
+    quit "No test files were discovered"
+  echo "Ran ", testRuns, " test files"
+
   for file in listFiles("examples"):
-    if file.startsWith("examples/windy_") and file.endsWith(".nim"):
+    let name = file.extractFilename()
+    if name.startsWith("windy_") and name.endsWith(".nim"):
       nimExec("c", file)
-    elif file.startsWith("examples/siwin_") and file.endsWith(".nim"):
+    elif name.startsWith("siwin_") and name.endsWith(".nim"):
       nimExec("c", file)
-    elif file.startsWith("examples/sdl2_") and file.endsWith(".nim"):
+    elif name.startsWith("sdl2_") and name.endsWith(".nim"):
       if enableSdl2:
         nimExec("c", file, "-d:figdraw.metal=off -d:figdraw.vulkan=off")
       else:
         echo "Skipping SDL2 example (set FIGDRAW_TEST_SDL2=1 to enable): ", file
 
 task test_compile, "compile unit tests without running":
+  var testCount = 0
   for file in listFiles("tests"):
-    if file.startsWith("tests/t") and file.endsWith(".nim"):
+    let name = file.extractFilename()
+    if name.startsWith("t") and name.endsWith(".nim"):
+      inc testCount
       nimExec("c", file)
+  if testCount == 0:
+    quit "No test files were discovered"
+  echo "Compiled ", testCount, " test files"
 
 task test_emscripten, "build emscripten examples":
   for file in listFiles("examples"):
-    if file.startsWith("examples/windy_") and file.endsWith(".nim"):
+    let name = file.extractFilename()
+    if name.startsWith("windy_") and name.endsWith(".nim"):
       nimExec("c", file, "-d:emscripten")
 
 task bindings, "Generate bindings":

--- a/config.nims
+++ b/config.nims
@@ -85,25 +85,25 @@ proc platforms(): seq[string] =
       hasX11Display = getEnv("DISPLAY").len != 0
       testRenderer = getEnv("FIGDRAW_TEST_RENDERER").strip().toLowerAscii()
 
-    proc addPlatform(sessionType: string) =
+    proc addPlatform(platformArgs: var seq[string], sessionType: string) =
       case testRenderer
       of "opengl":
-        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 "
+        platformArgs.add("XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 ")
       of "vulkan":
-        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 "
+        platformArgs.add("XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 ")
       else:
-        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 "
-        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 "
+        platformArgs.add("XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 ")
+        platformArgs.add("XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 ")
 
     if sessionType == "wayland":
-      addPlatform("wayland")
+      addPlatform(result, "wayland")
     elif sessionType == "x11":
-      addPlatform("x11")
+      addPlatform(result, "x11")
     else:
       if hasWaylandDisplay:
-        addPlatform("wayland")
+        addPlatform(result, "wayland")
       if hasX11Display:
-        addPlatform("x11")
+        addPlatform(result, "x11")
   else:
     @[""]
 

--- a/config.nims
+++ b/config.nims
@@ -19,7 +19,8 @@ when defined(macosx) and defined(figdraw.moltenvkBrew):
 when defined(linux):
   proc pkgConfigFlags(kind: string, packages: openArray[string]): string =
     for pkg in packages:
-      let exists = gorgeEx("sh -c 'pkg-config --exists " & pkg & " && printf yes'").output.strip()
+      let exists =
+        gorgeEx("sh -c 'pkg-config --exists " & pkg & " && printf yes'").output.strip()
       if exists == "yes":
         let flags = gorgeEx("pkg-config --" & kind & " " & pkg).output.strip()
         if flags.len > 0:
@@ -51,10 +52,16 @@ when defined(linux):
     WaylandDependencies = "wayland-client wayland-egl wayland-egl-backend"
     AuxDependencies = "gl glesv2 egl"
 
-  let linuxCflags =
-    pkgConfigFlags("cflags", XorgDependencies.splitWhitespace() & WaylandDependencies.splitWhitespace() & AuxDependencies.splitWhitespace())
-  let linuxLibs =
-    pkgConfigFlags("libs", XorgDependencies.splitWhitespace() & WaylandDependencies.splitWhitespace() & AuxDependencies.splitWhitespace())
+  let linuxCflags = pkgConfigFlags(
+    "cflags",
+    XorgDependencies.splitWhitespace() & WaylandDependencies.splitWhitespace() &
+      AuxDependencies.splitWhitespace(),
+  )
+  let linuxLibs = pkgConfigFlags(
+    "libs",
+    XorgDependencies.splitWhitespace() & WaylandDependencies.splitWhitespace() &
+      AuxDependencies.splitWhitespace(),
+  )
   if linuxCflags.len > 0:
     switch("passC", linuxCflags)
   if linuxLibs.len > 0:
@@ -76,19 +83,27 @@ proc platforms(): seq[string] =
       sessionType = getEnv("XDG_SESSION_TYPE").toLowerAscii()
       hasWaylandDisplay = getEnv("WAYLAND_DISPLAY").len != 0
       hasX11Display = getEnv("DISPLAY").len != 0
+      testRenderer = getEnv("FIGDRAW_TEST_RENDERER").strip().toLowerAscii()
+
+    proc addPlatform(sessionType: string) =
+      case testRenderer
+      of "opengl":
+        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 "
+      of "vulkan":
+        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 "
+      else:
+        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=0 "
+        result.add "XDG_SESSION_TYPE=" & sessionType & " FIGDRAW_FORCE_OPENGL=1 "
+
     if sessionType == "wayland":
-      result.add "XDG_SESSION_TYPE=wayland FIGDRAW_FORCE_OPENGL=0 "
-      result.add "XDG_SESSION_TYPE=wayland FIGDRAW_FORCE_OPENGL=1 "
+      addPlatform("wayland")
     elif sessionType == "x11":
-      result.add "XDG_SESSION_TYPE=x11 FIGDRAW_FORCE_OPENGL=0 "
-      result.add "XDG_SESSION_TYPE=x11 FIGDRAW_FORCE_OPENGL=1 "
+      addPlatform("x11")
     else:
       if hasWaylandDisplay:
-        result.add "XDG_SESSION_TYPE=wayland FIGDRAW_FORCE_OPENGL=0 "
-        result.add "XDG_SESSION_TYPE=wayland FIGDRAW_FORCE_OPENGL=1 "
+        addPlatform("wayland")
       if hasX11Display:
-        result.add "XDG_SESSION_TYPE=x11 FIGDRAW_FORCE_OPENGL=0 "
-        result.add "XDG_SESSION_TYPE=x11 FIGDRAW_FORCE_OPENGL=1 "
+        addPlatform("x11")
   else:
     @[""]
 

--- a/docs/font_ownership.md
+++ b/docs/font_ownership.md
@@ -21,9 +21,10 @@ image ownership by font.
 - OpenType feature settings
 - variable font coordinates
 
-`FigFont.hash` includes these fields, and `FontId` is derived from that hash.
-The Pixie path also folds `figUiScale()` into the cached font id so raster
-entries are separated by scale.
+`FigFont.hash` includes these fields for layout identity. `FontId` is a raster
+identity derived from the resolved typeface, size, case transform, variable
+coordinates, and `figUiScale()`, so shaping-only settings do not duplicate
+identical glyph images.
 
 Glyph cache identity is currently:
 

--- a/docs/font_shaping.md
+++ b/docs/font_shaping.md
@@ -67,9 +67,11 @@ Important fields:
 - `variations`: OpenType variable-axis coordinates such as
   `fontVariation("wght", 650.0'f32)`.
 
-These fields are part of `FigFont` hashing, so shaped layout, glyph cache ids,
-and glyph-id rasterization stay separated by fallback chain, feature set, and
-variable-font coordinates.
+These fields remain part of layout hashing. Raster font ids are narrower: they
+use the resolved typeface, size, case transform, variable coordinates, and UI
+scale. The shaped glyph id distinguishes feature-dependent output without
+duplicating raster images for fallback chains, decoration, or line-height
+changes.
 
 `GlyphPosition`, yielded by `glyphs(arrangement)`, mirrors the glyph-id-first
 shape used by render code:
@@ -192,6 +194,8 @@ The Harfbuzzy adapter converts shaped runs into FigDraw data:
 - `glyph.cluster` is retained for source mapping and break logic.
 - The adapter shapes through a Harfbuzzy `ShapeContext` built from the primary
   typeface plus `FigFont.fallbackTypefaceIds`.
+- Adjacent spans with the same shaping font are shaped together even when their
+  fills differ, preserving contextual shaping across paint-only boundaries.
 - OpenType features from `FigFont.features` are passed to paragraph shaping.
 - Variable axes from `FigFont.variations` are applied to each Harfbuzzy font
   before shaping.
@@ -208,8 +212,9 @@ The Harfbuzzy adapter converts shaped runs into FigDraw data:
 The backend wraps greedily over shaped glyphs. It prefers whitespace clusters
 when the next shaped glyph is safe to break before, recognizes soft hyphen,
 zero-width space, hyphen-like separators, and common CJK/Kana/Hangul adjacent
-break opportunities, and falls back to hard shaped-glyph boundaries for
-overlong text. It never splits inside a shaped glyph.
+break opportunities, and otherwise uses only safe cluster boundaries. A cluster
+without a safe boundary is allowed to overflow instead of being split without
+reshaping.
 
 Line slices are aligned after wrapping. Vertical alignment is applied to the
 whole arrangement. When `minContent` is enabled, Harfbuzzy expands the alignment
@@ -234,6 +239,10 @@ Raster dispatch follows the selected backend:
 
 Selection and hit testing use source ranges, not glyph ids.
 
+The glyph-id raster provider requires HarfBuzz 7.0 or newer. It currently
+extracts monochrome outlines; color bitmap, SVG, and COLR paint data require a
+separate color-font raster path.
+
 ## Regression Coverage
 
 The test suite covers:
@@ -242,6 +251,10 @@ The test suite covers:
 - Ligature source mapping and source-rune iteration.
 - Wrapping at shaped glyph boundaries.
 - Preserving ligature ranges on one line.
+- Preserving shaping across paint-only span boundaries.
+- Consecutive hard breaks and zero-width line placeholders.
+- Original source mapping after font-case transforms.
+- `noKerningAdjustments` translation to the OpenType `kern` feature.
 - CJK wrapping without whitespace using the dependency test font.
 - Combining marks and Hebrew marks through source-range selection and hit
   testing.

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -1,4 +1,4 @@
-version = "0.27.1"
+version = "0.27.2"
 author = "Jaremy Creechley"
 description = "UI Engine for Nim"
 license = "MIT"

--- a/src/figdraw/common/fontglyphs.nim
+++ b/src/figdraw/common/fontglyphs.nim
@@ -14,6 +14,18 @@ import ./textrasters/pixie_raster
 
 export applyLcdFilter
 
+proc clearGlyphRasterFontCache*(fontId: FontId) =
+  when figdrawTextBackend == "harfbuzzy":
+    clearGlyphIdFontCache(fontId)
+  else:
+    discard
+
+proc clearGlyphRasterTypefaceCache*(typefaceId: TypefaceId) =
+  when figdrawTextBackend == "harfbuzzy":
+    clearGlyphIdTypefaceCache(typefaceId)
+  else:
+    discard
+
 type GlyphPosition* = ref object ## Represents a glyph position after typesetting.
   fontId*: FontId
   glyphId*: FontGlyphId
@@ -225,6 +237,8 @@ proc convertArrangement*(
     hAlign: FontHorizontal,
     vAlign: FontVertical,
     gfonts: seq[GlyphFont],
+    minContent = false,
+    wrap = false,
 ): GlyphArrangement =
   var
     lines = newSeqOfCap[Slice[int]](arrangement.lines.len())
@@ -240,7 +254,7 @@ proc convertArrangement*(
   result = GlyphArrangement(
     contentHash: block:
       var h = Hash(0)
-      h = h !& getContentHash(box.wh, uiSpans, hAlign, vAlign)
+      h = h !& getContentHash(box.wh, uiSpans, hAlign, vAlign, minContent, wrap)
       h = h !& hash(figUiScale())
       !$h,
     lines: lines,

--- a/src/figdraw/common/fonttypes.nim
+++ b/src/figdraw/common/fonttypes.nim
@@ -40,6 +40,8 @@ type
     size*: float32 ## Font size in pixels.
     lineHeight*: float32
     descentAdj*: float32
+    underline*: bool
+    strikethrough*: bool
       ## The line height in pixels or autoLineHeight for the font's default line height.
 
   FontFeature* = object
@@ -798,12 +800,16 @@ proc getContentHash*(
     uiSpans: openArray[(FontStyle, string)],
     hAlign = FontHorizontal.Left,
     vAlign = FontVertical.Top,
+    minContent = false,
+    wrap = false,
 ): Hash =
   var h = Hash(0)
   h = h !& hash(size)
   h = h !& hash(uiSpans)
   h = h !& hash(hAlign)
   h = h !& hash(vAlign)
+  h = h !& hash(minContent)
+  h = h !& hash(wrap)
   result = !$h
 
 proc getContentHash*(
@@ -811,8 +817,10 @@ proc getContentHash*(
     uiSpans: openArray[(FigFont, string)],
     hAlign = FontHorizontal.Left,
     vAlign = FontVertical.Top,
+    minContent = false,
+    wrap = false,
 ): Hash =
   var styled = newSeqOfCap[(FontStyle, string)](uiSpans.len)
   for (font, text) in uiSpans:
     styled.add((fs(font), text))
-  result = getContentHash(size, styled, hAlign, vAlign)
+  result = getContentHash(size, styled, hAlign, vAlign, minContent, wrap)

--- a/src/figdraw/common/textbackends/harfbuzzy.nim
+++ b/src/figdraw/common/textbackends/harfbuzzy.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, hashes, math, sequtils, strutils, unicode]
+import std/[algorithm, hashes, math, sequtils, strutils, tables, unicode]
 
 import pkg/harfbuzzy as hb
 import pkg/vmath
@@ -16,28 +16,98 @@ const hbGlyphFlagUnsafeToBreak = 0x00000001'u32
 type
   DecodedSource = object
     runes: seq[Rune]
-    byteStarts: seq[int]
-    byteEnds: seq[int]
+    displayByteStarts: seq[int]
+    displayByteEnds: seq[int]
+    sourceByteStarts: seq[int]
+    sourceByteEnds: seq[int]
+    sourceRuneStarts: seq[int]
+    sourceRuneEnds: seq[int]
 
   ShapedSpan = object
     style: FontStyle
     text: string
     byteOffset: int
 
-  Paragraph = seq[ShapedSpan]
+  Paragraph = object
+    spans: seq[ShapedSpan]
+    byteStart: int
+    lineStyle: FontStyle
+    hasLineStyle: bool
+
+  ShapedGroup = object
+    style: FontStyle
+    spans: seq[ShapedSpan]
 
   HarfbuzzFontInfo = object
     typeface: hb.Typeface
     fontId: FontId
     glyphFont: GlyphFont
 
-proc decodeSource(text: string): DecodedSource =
+var harfbuzzTypefaceCache {.threadvar.}: Table[FontId, hb.Typeface]
+
+proc decodeText(
+    text: string
+): tuple[runes: seq[Rune], byteStarts: seq[int], byteEnds: seq[int]] =
   var byteOffset = 0
   for rune in text.runes:
     result.runes.add rune
     result.byteStarts.add byteOffset
     byteOffset += ($rune).len
     result.byteEnds.add byteOffset
+
+proc decodeSource(
+    sourceSpans, displaySpans: openArray[(FontStyle, string)]
+): DecodedSource =
+  var
+    sourceByteOffset = 0
+    sourceRuneOffset = 0
+    displayByteOffset = 0
+
+  for spanIndex in 0 ..< sourceSpans.len:
+    let
+      sourceText = sourceSpans[spanIndex][1]
+      displayText = displaySpans[spanIndex][1]
+      source = decodeText(sourceText)
+      display = decodeText(displayText)
+
+    result.runes.add source.runes
+    for displayIndex in 0 ..< display.runes.len:
+      let
+        mappedStart =
+          if source.runes.len == 0:
+            0
+          else:
+            min(
+              displayIndex * source.runes.len div max(display.runes.len, 1),
+              source.runes.len - 1,
+            )
+        mappedEnd =
+          if source.runes.len == 0:
+            0
+          else:
+            max(
+              mappedStart + 1,
+              min(
+                ((displayIndex + 1) * source.runes.len + display.runes.len - 1) div
+                  max(display.runes.len, 1),
+                source.runes.len,
+              ),
+            )
+
+      result.displayByteStarts.add displayByteOffset + display.byteStarts[displayIndex]
+      result.displayByteEnds.add displayByteOffset + display.byteEnds[displayIndex]
+      result.sourceRuneStarts.add sourceRuneOffset + mappedStart
+      result.sourceRuneEnds.add sourceRuneOffset + mappedEnd
+      if source.runes.len > 0:
+        result.sourceByteStarts.add sourceByteOffset + source.byteStarts[mappedStart]
+        result.sourceByteEnds.add sourceByteOffset + source.byteEnds[mappedEnd - 1]
+      else:
+        result.sourceByteStarts.add sourceByteOffset
+        result.sourceByteEnds.add sourceByteOffset
+
+    sourceByteOffset += sourceText.len
+    sourceRuneOffset += source.runes.len
+    displayByteOffset += displayText.len
 
 proc applyFontCase(text: string, fontCase: FontCase): string =
   case fontCase
@@ -51,10 +121,14 @@ proc applyFontCase(text: string, fontCase: FontCase): string =
     text.title()
 
 proc splitParagraphs(spans: openArray[(FontStyle, string)]): seq[Paragraph] =
-  result.add(@[])
+  result.add Paragraph(byteStart: 0)
 
   var byteOffset = 0
   for (style, text) in spans:
+    if not result[^1].hasLineStyle:
+      result[^1].lineStyle = style
+      result[^1].hasLineStyle = true
+
     var
       partStart = 0
       byteIndex = 0
@@ -62,7 +136,7 @@ proc splitParagraphs(spans: openArray[(FontStyle, string)]): seq[Paragraph] =
       let ch = text[byteIndex]
       if ch == '\n' or ch == '\r':
         if byteIndex > partStart:
-          result[^1].add(
+          result[^1].spans.add(
             ShapedSpan(
               style: style,
               text: text[partStart ..< byteIndex],
@@ -75,12 +149,14 @@ proc splitParagraphs(spans: openArray[(FontStyle, string)]): seq[Paragraph] =
           breakLen = 2
         byteIndex += breakLen
         partStart = byteIndex
-        result.add(@[])
+        result.add Paragraph(
+          byteStart: byteOffset + byteIndex, lineStyle: style, hasLineStyle: true
+        )
       else:
         inc byteIndex
 
     if partStart < text.len:
-      result[^1].add(
+      result[^1].spans.add(
         ShapedSpan(
           style: style,
           text: text[partStart ..< text.len],
@@ -90,26 +166,61 @@ proc splitParagraphs(spans: openArray[(FontStyle, string)]): seq[Paragraph] =
 
     byteOffset += text.len
 
+proc shapingGroups(paragraph: Paragraph): seq[ShapedGroup] =
+  for span in paragraph.spans:
+    if result.len > 0 and result[^1].style.font == span.style.font:
+      result[^1].spans.add span
+    else:
+      result.add ShapedGroup(style: span.style, spans: @[span])
+
+proc text(group: ShapedGroup): string =
+  for span in group.spans:
+    result.add span.text
+
+proc byteOffset(group: ShapedGroup): int =
+  if group.spans.len > 0:
+    result = group.spans[0].byteOffset
+
+proc fillForByte(group: ShapedGroup, byteOffset: int): Fill =
+  for span in group.spans:
+    if byteOffset >= span.byteOffset and byteOffset < span.byteOffset + span.text.len:
+      return span.style.color
+  result = group.style.color
+
 proc runeRangeForBytes(
     decoded: DecodedSource, byteStart, byteEnd: int
 ): GlyphSourceRange =
-  result.byteStart = byteStart
-  result.byteEnd = byteEnd
+  result.byteStart = high(int)
+  result.byteEnd = 0
   result.runeStart = decoded.runes.len
-  result.runeEnd = decoded.runes.len
+  result.runeEnd = 0
 
-  for i in 0 ..< decoded.runes.len:
-    if decoded.byteEnds[i] > byteStart:
-      result.runeStart = i
-      break
+  for i in 0 ..< decoded.displayByteStarts.len:
+    if decoded.displayByteEnds[i] > byteStart and decoded.displayByteStarts[i] < byteEnd:
+      result.byteStart = min(result.byteStart, decoded.sourceByteStarts[i])
+      result.byteEnd = max(result.byteEnd, decoded.sourceByteEnds[i])
+      result.runeStart = min(result.runeStart, decoded.sourceRuneStarts[i])
+      result.runeEnd = max(result.runeEnd, decoded.sourceRuneEnds[i])
 
-  for i in result.runeStart ..< decoded.runes.len:
-    if decoded.byteStarts[i] >= byteEnd:
-      result.runeEnd = i
-      break
-  if result.runeEnd == decoded.runes.len and byteEnd >= byteStart:
-    result.runeEnd = decoded.runes.len
-  if result.runeStart > result.runeEnd:
+  if result.byteStart == high(int):
+    result.byteStart = 0
+    result.runeStart = 0
+
+proc sourceInsertionForDisplayByte(
+    decoded: DecodedSource, byteOffset: int
+): GlyphSourceRange =
+  for i in 0 ..< decoded.displayByteStarts.len:
+    if decoded.displayByteStarts[i] >= byteOffset:
+      result.byteStart = decoded.sourceByteStarts[i]
+      result.byteEnd = result.byteStart
+      result.runeStart = decoded.sourceRuneStarts[i]
+      result.runeEnd = result.runeStart
+      return
+
+  if decoded.sourceByteEnds.len > 0:
+    result.byteStart = decoded.sourceByteEnds[^1]
+    result.byteEnd = result.byteStart
+    result.runeStart = decoded.sourceRuneEnds[^1]
     result.runeEnd = result.runeStart
 
 proc firstRune(decoded: DecodedSource, source: GlyphSourceRange): Rune =
@@ -171,12 +282,16 @@ proc toHarfbuzzVariations(variations: openArray[FontVariation]): seq[hb.Variatio
   for variation in variations:
     result.add hb.initVariation(hb.toTag(variation.tag), variation.value)
 
-proc initHarfbuzzTypeface(font: FigFont): hb.Typeface =
+proc initHarfbuzzTypeface(font: FigFont, fontId: FontId): hb.Typeface =
+  if fontId in harfbuzzTypefaceCache:
+    return harfbuzzTypefaceCache[fontId]
+
   let source = getTypefaceSource(font.typefaceId)
   let blob = hb.initBlob(source.data)
-  let face = hb.initFace(blob)
+  let face = hb.initFace(blob, source.faceIndex)
   result = hb.initTypeface(face)
   result.font.setVariations(font.variations.toHarfbuzzVariations())
+  harfbuzzTypefaceCache[fontId] = result
 
 proc fallbackFont(font: FigFont, typefaceId: TypefaceId): FigFont =
   result = font
@@ -193,7 +308,7 @@ proc initHarfbuzzFontInfos(font: FigFont): seq[HarfbuzzFontInfo] =
       figFont = font.fallbackFont(typefaceId)
       fontInfo = glyphFontFor(figFont)
     result.add HarfbuzzFontInfo(
-      typeface: initHarfbuzzTypeface(figFont),
+      typeface: initHarfbuzzTypeface(figFont, fontInfo.id),
       fontId: fontInfo.id,
       glyphFont: fontInfo.glyph,
     )
@@ -205,8 +320,21 @@ proc shapeParagraph(
   for info in fontInfos:
     typefaces.add info.typeface
 
+  var features = font.features
+  if font.noKerningAdjustments:
+    var hasKerningFeature = false
+    for feature in features:
+      if feature.tag.toLowerAscii() == "kern":
+        hasKerningFeature = true
+        break
+    if not hasKerningFeature:
+      features.add fontFeature("kern", 0)
+
   let context = hb.initShapeContext(
-    typefaces, hb.ParagraphOptions(features: font.features.toHarfbuzzFeatures())
+    typefaces,
+    hb.ParagraphOptions(
+      features: features.toHarfbuzzFeatures(), flags: {hb.beginningOfText, hb.endOfText}
+    ),
   )
   context.shapeParagraph(text)
 
@@ -335,31 +463,44 @@ proc buildWrappedLines(
     lineStart = glyphRange.a
     lineWidth = 0.0'f32
     lastBreak = -1
+    lastSafeBreak = -1
     glyphIndex = glyphRange.a
 
   while glyphIndex <= glyphRange.b:
     let glyph = arrangement.arrangedGlyphs[glyphIndex]
     let width = glyph.glyphWrapWidth()
-
+    var startNextLine = false
     if glyphIndex > lineStart and lineWidth + width > boxWidth:
-      if lastBreak >= lineStart and lastBreak < glyphIndex:
-        result.add lineStart .. lastBreak
-        lineStart = lastBreak + 1
-      else:
-        result.add lineStart .. glyphIndex - 1
-        lineStart = glyphIndex
-      lineWidth = 0
-      lastBreak = -1
-      glyphIndex = lineStart
-      continue
+      let breakIndex =
+        if lastBreak >= lineStart and lastBreak < glyphIndex:
+          lastBreak
+        elif lastSafeBreak >= lineStart and lastSafeBreak < glyphIndex:
+          lastSafeBreak
+        else:
+          -1
+      if breakIndex >= lineStart:
+        result.add lineStart .. breakIndex
+        lineStart = breakIndex + 1
+        lineWidth = 0
+        lastBreak = -1
+        lastSafeBreak = -1
+        glyphIndex = lineStart
+        startNextLine = true
 
-    lineWidth += width
-    let
-      breakAfter = glyphIndex >= safeBreakAfter.len or safeBreakAfter[glyphIndex]
-      preferredBreakAfter = arrangement.preferredLineBreakAfter(glyphIndex)
-    if preferredBreakAfter and breakAfter:
-      lastBreak = glyphIndex
-    inc glyphIndex
+    if not startNextLine:
+      lineWidth += width
+      let
+        breakAfter = glyphIndex >= safeBreakAfter.len or safeBreakAfter[glyphIndex]
+        preferredBreakAfter = arrangement.preferredLineBreakAfter(glyphIndex)
+        clusterBoundary =
+          glyphIndex == glyphRange.b or
+          arrangement.arrangedGlyphs[glyphIndex].source !=
+          arrangement.arrangedGlyphs[glyphIndex + 1].source
+      if breakAfter and clusterBoundary:
+        lastSafeBreak = glyphIndex
+      if preferredBreakAfter and breakAfter:
+        lastBreak = glyphIndex
+      inc glyphIndex
 
   if lineStart <= glyphRange.b:
     result.add lineStart .. glyphRange.b
@@ -428,18 +569,53 @@ proc reflowLines(arrangement: var GlyphArrangement) =
       lineX += oldGlyph.glyphWrapWidth()
     lineTop += lineHeight
 
-proc appendShapedSpan(
+proc addGlyphSpan(
+    arrangement: var GlyphArrangement, glyphFont: GlyphFont, color: Fill
+) =
+  let glyphIndex = arrangement.arrangedGlyphs.len
+  if arrangement.spans.len > 0 and arrangement.spans[^1].b == glyphIndex - 1 and
+      arrangement.fonts[^1] == glyphFont and arrangement.spanColors[^1] == color:
+    arrangement.spans[^1].b = glyphIndex
+  else:
+    arrangement.spans.add glyphIndex .. glyphIndex
+    arrangement.fonts.add glyphFont
+    arrangement.spanColors.add color
+
+proc appendEmptyLineGlyph(
     arrangement: var GlyphArrangement,
     decoded: DecodedSource,
-    style: FontStyle,
-    text: string,
-    byteOffset: int,
+    displayByteOffset: int,
+    glyphFont: GlyphFont,
+    color: Fill,
+    safeBreakAfter: var seq[bool],
+) =
+  let source = decoded.sourceInsertionForDisplayByte(displayByteOffset)
+  arrangement.addGlyphSpan(glyphFont, color)
+  arrangement.arrangedGlyphs.add ArrangedGlyph(
+    fontId: glyphFont.fontId,
+    source: source,
+    rune: Rune(0),
+    isWhitespace: true,
+    pos: vec2(0, glyphFont.descentAdj),
+    rect: rect(0, 0, 0, glyphFont.lineHeight),
+  )
+  arrangement.runes.add Rune(0)
+  arrangement.positions.add vec2(0, glyphFont.descentAdj)
+  arrangement.selectionRects.add rect(0, 0, 0, glyphFont.lineHeight)
+  safeBreakAfter.add true
+
+proc appendShapedGroup(
+    arrangement: var GlyphArrangement,
+    decoded: DecodedSource,
+    group: ShapedGroup,
     pen: var Vec2,
     safeBreakAfter: var seq[bool],
 ) =
   let
-    fontInfos = initHarfbuzzFontInfos(style.font)
-    paragraph = fontInfos.shapeParagraph(style.font, text)
+    groupText = group.text()
+    groupByteOffset = group.byteOffset()
+    fontInfos = initHarfbuzzFontInfos(group.style.font)
+    paragraph = fontInfos.shapeParagraph(group.style.font, groupText)
 
   for run in paragraph.visualRuns:
     if run.glyphRun.glyphs.len == 0:
@@ -452,19 +628,17 @@ proc appendShapedSpan(
         else:
           0
       fontInfo = fontInfos[fontIndex]
-      scale = fontInfo.typeface.pxScale(style.font)
-      spanStart = arrangement.arrangedGlyphs.len
-
-    arrangement.fonts.add fontInfo.glyphFont
-    arrangement.spanColors.add style.color
+      scale = fontInfo.typeface.pxScale(group.style.font)
 
     for runGlyphIndex, glyph in run.glyphRun.glyphs:
       let
         cluster = int(glyph.cluster)
         nextCluster = run.nextClusterBoundary(cluster)
-        source =
-          decoded.runeRangeForBytes(byteOffset + cluster, byteOffset + nextCluster)
+        source = decoded.runeRangeForBytes(
+          groupByteOffset + cluster, groupByteOffset + nextCluster
+        )
         rune = decoded.firstRune(source)
+        color = group.fillForByte(groupByteOffset + cluster)
         advance = vec2(glyph.xAdvance.float32 * scale, -glyph.yAdvance.float32 * scale)
         offset = vec2(glyph.xOffset.float32 * scale, -glyph.yOffset.float32 * scale)
         pos = pen + offset
@@ -476,6 +650,7 @@ proc appendShapedSpan(
           glyph.codepoint, fontInfo.glyphFont, scale
         )
 
+      arrangement.addGlyphSpan(fontInfo.glyphFont, color)
       arrangement.arrangedGlyphs.add ArrangedGlyph(
         fontId: fontInfo.fontId,
         glyphId: FontGlyphId(glyph.codepoint.uint32),
@@ -499,9 +674,6 @@ proc appendShapedSpan(
 
       pen += advance
 
-    let spanStop = arrangement.arrangedGlyphs.len - 1
-    arrangement.spans.add spanStart .. spanStop
-
 proc typeset*(
     box: Rect,
     uiSpans: openArray[(FontStyle, string)],
@@ -518,14 +690,13 @@ proc typeset*(
   for (style, text) in uiSpans:
     shapedSpans.add((style, text.applyFontCase(style.font.fontCase)))
 
-  let sourceText = shapedSpans.mapIt(it[1]).join("")
-  let decoded = decodeSource(sourceText)
+  let decoded = decodeSource(uiSpans, shapedSpans)
   let fontSizes = shapedSpans.mapIt(it[0].font.size.float)
 
   result = GlyphArrangement(
     contentHash: block:
       var h = Hash(0)
-      h = h !& getContentHash(box.wh, uiSpans, hAlign, vAlign)
+      h = h !& getContentHash(box.wh, uiSpans, hAlign, vAlign, minContent, wrap)
       h = h !& hash(figUiScale())
       !$h,
     sourceRunes: decoded.runes,
@@ -537,21 +708,27 @@ proc typeset*(
   for paragraph in paragraphs:
     let glyphStart = result.arrangedGlyphs.len
     pen.x = 0
-    for span in paragraph:
-      if span.text.len > 0:
-        let baseline = glyphFontFor(span.style.font).glyph.descentAdj
+    for group in paragraph.shapingGroups():
+      if group.spans.len > 0:
+        let groupGlyphFont = glyphFontFor(group.style.font).glyph
+        let baseline = groupGlyphFont.descentAdj
         if result.arrangedGlyphs.len == 0:
           pen.y = baseline
-        result.appendShapedSpan(
-          decoded, span.style, span.text, span.byteOffset, pen, safeBreakAfter
-        )
+        result.appendShapedGroup(decoded, group, pen, safeBreakAfter)
+
+    if result.arrangedGlyphs.len == glyphStart and paragraphs.len > 1 and
+        paragraph.hasLineStyle:
+      let emptyLineFont = glyphFontFor(paragraph.lineStyle.font).glyph
+      result.appendEmptyLineGlyph(
+        decoded, paragraph.byteStart, emptyLineFont, paragraph.lineStyle.color,
+        safeBreakAfter,
+      )
 
     let glyphStop = result.arrangedGlyphs.len - 1
     result.addParagraphLines(glyphStart .. glyphStop, box.w, safeBreakAfter, wrap)
 
-  if result.arrangedGlyphs.len > 0:
-    if wrap or paragraphs.len > 1:
-      result.reflowLines()
+  if wrap or paragraphs.len > 1 or result.arrangedGlyphs.len == 0:
+    result.reflowLines()
 
   var alignmentBox = box
   if minContent:

--- a/src/figdraw/common/textbackends/pixie.nim
+++ b/src/figdraw/common/textbackends/pixie.nim
@@ -40,7 +40,12 @@ proc typeset*(
     let lineGap = (lineHeight / pf.scale) - pf.typeface.ascent + pf.typeface.descent
     let baselineOffset = round((pf.typeface.ascent + lineGap / 2) * pf.scale)
     gfonts.add GlyphFont(
-      fontId: fontId, lineHeight: lineHeight, descentAdj: baselineOffset
+      fontId: fontId,
+      size: style.font.size,
+      lineHeight: lineHeight,
+      descentAdj: baselineOffset,
+      underline: style.font.underline,
+      strikethrough: style.font.strikethrough,
     )
 
   var ha: HorizontalAlignment
@@ -63,7 +68,9 @@ proc typeset*(
 
   let arrangement =
     pixie.typeset(spans, bounds = wh, hAlign = ha, vAlign = va, wrap = wrap)
-  result = convertArrangement(arrangement, box, uiSpans, hAlign, vAlign, gfonts)
+  result = convertArrangement(
+    arrangement, box, uiSpans, hAlign, vAlign, gfonts, minContent, wrap
+  )
 
   let content = result.calcMinMaxContent()
   result.minSize = content.minSize
@@ -76,22 +83,25 @@ proc typeset*(
     let arr = pixie.typeset(
       spans, bounds = wh, hAlign = LeftAlign, vAlign = TopAlign, wrap = wrap
     )
-    let minResult = convertArrangement(arr, box, uiSpans, hAlign, vAlign, gfonts)
+    let minResult =
+      convertArrangement(arr, box, uiSpans, hAlign, vAlign, gfonts, minContent, wrap)
 
-    let minContent = minResult.calcMinMaxContent()
+    let minContentSize = minResult.calcMinMaxContent()
     trace "minContent:",
       boxWh = box.wh,
       wh = wh,
-      minSize = minContent.minSize,
-      maxSize = minContent.maxSize,
-      bounding = minContent.bounding,
+      minSize = minContentSize.minSize,
+      maxSize = minContentSize.maxSize,
+      bounding = minContentSize.bounding,
       boundH = result.bounding.h
 
-    if minContent.bounding.h > result.bounding.h:
-      let wh = vec2(wh.x, minContent.bounding.h)
+    if minContentSize.bounding.h > result.bounding.h:
+      let wh = vec2(wh.x, minContentSize.bounding.h)
       let minAdjusted =
         pixie.typeset(spans, bounds = wh, hAlign = ha, vAlign = va, wrap = wrap)
-      result = convertArrangement(minAdjusted, box, uiSpans, hAlign, vAlign, gfonts)
+      result = convertArrangement(
+        minAdjusted, box, uiSpans, hAlign, vAlign, gfonts, minContent, wrap
+      )
       let contentAdjusted = result.calcMinMaxContent()
       result.minSize = contentAdjusted.minSize
       result.maxSize = contentAdjusted.maxSize

--- a/src/figdraw/common/textrasters/glyphid_raster.nim
+++ b/src/figdraw/common/textrasters/glyphid_raster.nim
@@ -1,4 +1,4 @@
-import std/math
+import std/[math, tables]
 
 import pkg/chroma
 import pkg/harfbuzzy/raw as hbraw
@@ -60,10 +60,23 @@ type
   DrawPathState = object
     path: Path
 
-  HbFontHandles = object
+  HbFontHandlePayload = object
     blob: hbraw.HbBlob
     face: hbraw.HbFace
     font: hbraw.HbFont
+
+  HbFontHandles = ref HbFontHandlePayload
+
+proc `=destroy`(handles: HbFontHandlePayload) =
+  if handles.font != nil:
+    hbraw.hb_font_destroy(handles.font)
+  if handles.face != nil:
+    hbraw.hb_face_destroy(handles.face)
+  if handles.blob != nil:
+    hbraw.hb_blob_destroy(handles.blob)
+
+var hbFontCache {.threadvar.}: Table[FontId, HbFontHandles]
+var harfbuzzVersionChecked {.threadvar.}: bool
 
 proc hb_draw_funcs_create(): HbDrawFuncs {.
   cdecl, importc: "hb_draw_funcs_create", dynlib: hbraw.hbLib
@@ -112,9 +125,9 @@ proc hb_draw_funcs_set_close_path_func(
   destroy: hbraw.HbDestroyFunc,
 ) {.cdecl, importc: "hb_draw_funcs_set_close_path_func", dynlib: hbraw.hbLib.}
 
-proc hb_font_draw_glyph_or_fail(
+proc hb_font_draw_glyph(
   font: hbraw.HbFont, glyph: hbraw.HbCodepoint, funcs: HbDrawFuncs, drawData: pointer
-): hbraw.HbBool {.cdecl, importc: "hb_font_draw_glyph_or_fail", dynlib: hbraw.hbLib.}
+) {.cdecl, importc: "hb_font_draw_glyph", dynlib: hbraw.hbLib.}
 
 proc hbTag(tag: string): hbraw.HbTag =
   if tag.len == 0 or tag.len > 4:
@@ -207,18 +220,14 @@ proc createDrawFuncs(): HbDrawFuncs =
   hb_draw_funcs_set_close_path_func(result, drawClosePath, nil, nil)
   hb_draw_funcs_make_immutable(result)
 
-proc destroy(handles: var HbFontHandles) =
-  if handles.font != nil:
-    hbraw.hb_font_destroy(handles.font)
-    handles.font = nil
-  if handles.face != nil:
-    hbraw.hb_face_destroy(handles.face)
-    handles.face = nil
-  if handles.blob != nil:
-    hbraw.hb_blob_destroy(handles.blob)
-    handles.blob = nil
-
 proc initHbFont(fontId: FontId): HbFontHandles =
+  if not harfbuzzVersionChecked:
+    if hbraw.hb_version_atleast(7, 0, 0) == 0:
+      raise newException(
+        ValueError, "the Harfbuzzy raster backend requires HarfBuzz 7.0 or newer"
+      )
+    harfbuzzVersionChecked = true
+
   let
     font = getFigFont(fontId)
     source = getTypefaceSource(font.typefaceId)
@@ -226,6 +235,7 @@ proc initHbFont(fontId: FontId): HbFontHandles =
   if source.data.len == 0:
     raise newException(ValueError, "typeface source data is empty")
 
+  new(result)
   result.blob = hbraw.hb_blob_create(
     source.data.cstring,
     cuint(source.data.len),
@@ -236,14 +246,12 @@ proc initHbFont(fontId: FontId): HbFontHandles =
   if result.blob == nil:
     raise newException(ValueError, "could not create HarfBuzz blob")
 
-  result.face = hbraw.hb_face_create(result.blob, 0)
+  result.face = hbraw.hb_face_create(result.blob, cuint(source.faceIndex))
   if result.face == nil:
-    result.destroy()
     raise newException(ValueError, "could not create HarfBuzz face")
 
   result.font = hbraw.hb_font_create(result.face)
   if result.font == nil:
-    result.destroy()
     raise newException(ValueError, "could not create HarfBuzz font")
 
   hbraw.hb_ot_font_set_funcs(result.font)
@@ -252,17 +260,29 @@ proc initHbFont(fontId: FontId): HbFontHandles =
     hbraw.hb_font_set_scale(result.font, cint(upem), cint(upem))
   result.font.setVariations(font.variations)
 
+proc cachedHbFont(fontId: FontId): HbFontHandles =
+  if fontId notin hbFontCache:
+    hbFontCache[fontId] = initHbFont(fontId)
+  hbFontCache[fontId]
+
+proc clearGlyphIdFontCache*(fontId: FontId) =
+  hbFontCache.del(fontId)
+
+proc clearGlyphIdTypefaceCache*(typefaceId: TypefaceId) =
+  var fontIds: seq[FontId]
+  for fontId in hbFontCache.keys:
+    if getFigFont(fontId).typefaceId == typefaceId:
+      fontIds.add fontId
+  for fontId in fontIds:
+    hbFontCache.del(fontId)
+
 proc drawGlyphPath(font: hbraw.HbFont, glyphId: FontGlyphId): Path =
   let funcs = createDrawFuncs()
   defer:
     hb_draw_funcs_destroy(funcs)
 
   var state = DrawPathState(path: newPath())
-  let ok = hb_font_draw_glyph_or_fail(
-    font, hbraw.HbCodepoint(uint32(glyphId)), funcs, addr state
-  )
-  if ok == 0:
-    return nil
+  hb_font_draw_glyph(font, hbraw.HbCodepoint(uint32(glyphId)), funcs, addr state)
   state.path
 
 proc imageBoundsFor(path: Path, fallbackSize: Vec2): Rect =
@@ -286,9 +306,7 @@ proc renderGlyphIdGlyph*(
     upload = true,
 ): Image {.discardable.} =
   ## Renders one glyph by shaped font glyph id through HarfBuzz draw callbacks.
-  var handles = initHbFont(fontId)
-  defer:
-    handles.destroy()
+  let handles = cachedHbFont(fontId)
 
   let
     figFont = getFigFont(fontId)
@@ -316,8 +334,7 @@ proc renderGlyphIdGlyph*(
   path.transform(transform)
 
   let
-    fallbackSize =
-      vec2(max(glyphRect.w.scaled(), 1.0'f32), max(glyphRect.h.scaled(), 1.0'f32))
+    fallbackSize = vec2(1.0'f32, 1.0'f32)
     bounds = imageBoundsFor(path, fallbackSize)
     imageWidth = max(ceil(bounds.x + bounds.w).int, 1)
     imageHeight = max(ceil(bounds.y + bounds.h).int, 1)

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -1,15 +1,14 @@
-import std/isolation
 import std/os
 import std/strutils
 import std/locks
 import std/math
+import std/tables
 
 import pkg/vmath
 import pkg/pixie
 import pkg/pixie/fonts
 import pkg/chronicles
 
-import ./rchannels
 import ./imgutils
 import ./fonttypes
 import ./shared
@@ -24,6 +23,7 @@ type TypefaceSource* = object
   name*: string
   data*: string
   kind*: TypeFaceKinds
+  faceIndex*: int
 
 type FontRef* = object
   ## Thread-affine managed font handle.
@@ -41,12 +41,14 @@ var
   staticTypefaceTable*:
     Table[string, tuple[name: string, data: string, kind: TypeFaceKinds]]
   fontLock*: Lock
+  fontUiScaleTable: Table[FontId, float32]
 
 fontLock.initLock()
 
-proc `=destroy`*(fontRef: FontRef) =
+proc `=destroy`*(fontRef: var FontRef) =
   if fontRef.managed:
     releaseFontRefId(fontRef.fontId)
+  `=destroy`(fontRef.font)
 
 proc `=wasMoved`*(fontRef: var FontRef) =
   wasMoved(fontRef.font)
@@ -61,10 +63,11 @@ proc `=dup`*(src: FontRef): FontRef =
   result.managed = src.managed
 
 proc `=copy`*(dest: var FontRef, src: FontRef) =
+  let font = src.font
   if src.managed:
     retainFontRefId(src.fontId)
   `=destroy`(dest)
-  dest.font = src.font
+  dest.font = font
   dest.fontId = src.fontId
   dest.managed = src.managed
 
@@ -86,8 +89,9 @@ proc lookupTypefaceNames(name: string): seq[string] =
 proc registerStaticTypefaceData(name, data: string, kind: TypeFaceKinds) =
   ## Registers a static typeface blob that can be found by loadTypeface.
   let entry = (name: name, data: data, kind: kind)
-  for key in lookupTypefaceNames(name):
-    staticTypefaceTable[key] = entry
+  withLock(fontLock):
+    for key in lookupTypefaceNames(name):
+      staticTypefaceTable[key] = entry
 
 template registerStaticTypeface*(
     name: static[string], path: static[string], kind: static[TypeFaceKinds] = TTF
@@ -130,9 +134,86 @@ proc readTypefaceImpl(
 
 proc typefaceKindFromPath(path: string): TypeFaceKinds =
   case splitFile(path).ext.toLowerAscii()
-  of ".otf": OTF
+  of ".otf", ".otc": OTF
   of ".svg": SVG
   else: TTF
+
+proc isTypefaceCollection(path: string): bool =
+  splitFile(path).ext.toLowerAscii() in [".ttc", ".otc"]
+
+proc readTypefacePath(
+    path, requestedName: string
+): tuple[typeface: Typeface, source: TypefaceSource] {.raises: [PixieError].} =
+  if path.isTypefaceCollection():
+    let typefaces = readTypefaces(path)
+    if typefaces.len == 0:
+      raise newException(PixieError, "typeface collection is empty")
+
+    let requested = requestedName.normalizeTypefaceLookupName()
+    var faceIndex = 0
+    for index, typeface in typefaces:
+      let faceName = typeface.name().normalizeTypefaceLookupName()
+      if requested.len > 0 and faceName.len > 0 and (
+        faceName == requested or faceName.contains(requested) or
+        requested.contains(faceName)
+      ):
+        faceIndex = index
+        break
+
+    result.typeface = typefaces[faceIndex]
+    result.typeface.filePath = path & "#" & $faceIndex
+    try:
+      result.source = TypefaceSource(
+        name: path,
+        data: readFile(path),
+        kind: typefaceKindFromPath(path),
+        faceIndex: faceIndex,
+      )
+    except IOError as e:
+      raise newException(PixieError, e.msg, e)
+  else:
+    try:
+      let data = readFile(path)
+      let kind = typefaceKindFromPath(path)
+      result.typeface = readTypefaceImpl(path, data, kind)
+      result.source = TypefaceSource(name: path, data: data, kind: kind)
+    except IOError as e:
+      raise newException(PixieError, e.msg, e)
+
+proc sameTypefaceSource(a, b: TypefaceSource): bool {.inline.} =
+  a.kind == b.kind and a.faceIndex == b.faceIndex and a.data == b.data
+
+proc typefaceIdForLocked(source: TypefaceSource): TypefaceId =
+  let sourceHash = hash((source.kind, source.faceIndex, source.data))
+  for salt in 0 .. 100:
+    let candidateHash =
+      if salt == 0:
+        sourceHash
+      else:
+        hash((sourceHash, salt))
+    if candidateHash != Hash(0):
+      let candidate = TypefaceId(candidateHash)
+      if candidate notin typefaceSourceTable or
+          typefaceSourceTable[candidate].sameTypefaceSource(source):
+        return candidate
+
+  raise newException(ValueError, "could not allocate a collision-free typeface id")
+
+proc registerTypeface(typeface: Typeface, source: TypefaceSource): TypefaceId =
+  withLock(fontLock):
+    result = typefaceIdForLocked(source)
+    if result notin typefaceTable:
+      typefaceTable[result] = typeface
+      typefaceSourceTable[result] = source
+
+proc staticTypefaceEntry(
+    name: string, entry: var tuple[name: string, data: string, kind: TypeFaceKinds]
+): bool =
+  withLock(fontLock):
+    for key in lookupTypefaceNames(name):
+      if key in staticTypefaceTable:
+        entry = staticTypefaceTable[key]
+        return true
 
 proc loadTypeface*(name: string, fallbackNames: openArray[string] = []): TypefaceId =
   ## loads a font from a file and adds it to the font index
@@ -167,34 +248,27 @@ proc loadTypeface*(name: string, fallbackNames: openArray[string] = []): Typefac
     let typefacePath = resolveTypefacePath(candidate)
     if typefacePath.len > 0:
       try:
-        typeface = readTypeface(typefacePath)
-        source = TypefaceSource(
-          name: typefacePath,
-          data: readFile(typefacePath),
-          kind: typefaceKindFromPath(typefacePath),
-        )
+        (typeface, source) = readTypefacePath(typefacePath, candidate)
         loaded = true
         break
       except PixieError:
         warn "failed to read resolved typeface path",
           requested = name, candidate = candidate, path = typefacePath
 
-    for key in lookupTypefaceNames(candidate):
-      if key in staticTypefaceTable:
-        let staticEntry = staticTypefaceTable[key]
-        try:
-          info "resolved typeface from static registry",
-            requested = name, candidate = candidate, staticName = staticEntry.name
-          typeface =
-            readTypefaceImpl(staticEntry.name, staticEntry.data, staticEntry.kind)
-          source = TypefaceSource(
-            name: staticEntry.name, data: staticEntry.data, kind: staticEntry.kind
-          )
-          loaded = true
-          break
-        except PixieError:
-          warn "failed to read static registered typeface",
-            requested = name, candidate = candidate, staticName = staticEntry.name
+    var staticEntry: tuple[name: string, data: string, kind: TypeFaceKinds]
+    if candidate.staticTypefaceEntry(staticEntry):
+      try:
+        info "resolved typeface from static registry",
+          requested = name, candidate = candidate, staticName = staticEntry.name
+        typeface =
+          readTypefaceImpl(staticEntry.name, staticEntry.data, staticEntry.kind)
+        source = TypefaceSource(
+          name: staticEntry.name, data: staticEntry.data, kind: staticEntry.kind
+        )
+        loaded = true
+      except PixieError:
+        warn "failed to read static registered typeface",
+          requested = name, candidate = candidate, staticName = staticEntry.name
     if loaded:
       break
 
@@ -204,32 +278,22 @@ proc loadTypeface*(name: string, fallbackNames: openArray[string] = []): Typefac
       "Unable to resolve typeface '" & name & "' with fallback names: " & $fallbackNames,
     )
 
-  let id = typeface.getId()
-
-  doAssert Hash(id) != 0
-  if id in typefaceTable:
-    doAssert typefaceTable[id] == typeface
-  typefaceTable[id] = typeface
-  typefaceSourceTable[id] = source
-  result = id
+  result = registerTypeface(typeface, source)
 
 proc loadTypeface*(name, data: string, kind: TypeFaceKinds): TypefaceId =
   ## loads a font from buffer and adds it to the font index
 
-  let
-    typeface = readTypefaceImpl(name, data, kind)
-    id = typeface.getId()
-
-  typefaceTable[id] = typeface
-  typefaceSourceTable[id] = TypefaceSource(name: name, data: data, kind: kind)
-  result = id
+  let typeface = readTypefaceImpl(name, data, kind)
+  result =
+    registerTypeface(typeface, TypefaceSource(name: name, data: data, kind: kind))
 
 proc getTypefaceSource*(id: TypefaceId): TypefaceSource =
-  if id notin typefaceSourceTable:
-    raise newException(
-      ValueError, "typeface source data is not available for id " & $Hash(id)
-    )
-  typefaceSourceTable[id]
+  withLock(fontLock):
+    if id notin typefaceSourceTable:
+      raise newException(
+        ValueError, "typeface source data is not available for id " & $Hash(id)
+      )
+    result = typefaceSourceTable[id]
 
 proc getFigFont*(fontId: FontId): FigFont =
   withLock(fontLock):
@@ -237,31 +301,63 @@ proc getFigFont*(fontId: FontId): FigFont =
       raise newException(ValueError, "font is not available for id " & $Hash(fontId))
     result = fontTable[fontId]
 
-proc pixieFont(font: FigFont): (FontId, Font) =
-  let
-    id = FontId(hash((font.getId(), figUiScale())))
+proc pixieFont(font: FigFont): Font =
+  var typeface: Typeface
+  withLock(fontLock):
+    if font.typefaceId notin typefaceTable:
+      raise newException(ValueError, "typeface is not available")
     typeface = typefaceTable[font.typefaceId]
 
-  var pxfont = newFont(typeface)
-  pxfont.size = font.size
-  pxfont.typeface = typeface
-  pxfont.textCase = parseEnum[TextCase]($font.fontCase)
-  pxfont.lineHeight = font.lineHeight
-  pxfont.underline = font.underline
-  pxfont.strikethrough = font.strikethrough
-  pxfont.noKerningAdjustments = font.noKerningAdjustments
+  result = newFont(typeface)
+  result.size = font.size
+  result.typeface = typeface
+  result.textCase = parseEnum[TextCase]($font.fontCase)
+  result.lineHeight = font.lineHeight
+  result.underline = font.underline
+  result.strikethrough = font.strikethrough
+  result.noKerningAdjustments = font.noKerningAdjustments
 
   if font.lineHeight == 0.0'f32:
-    pxfont.lineHeight = pxfont.defaultLineHeight()
-  result = (id, pxfont)
+    result.lineHeight = result.defaultLineHeight()
+
+proc rasterFont(font: FigFont): FigFont =
+  FigFont(
+    typefaceId: font.typefaceId,
+    size: font.size,
+    fontCase: font.fontCase,
+    variations: font.variations,
+  )
+
+proc registerFont(font: FigFont): FontId =
+  let
+    raster = font.rasterFont()
+    uiScale = figUiScale()
+    fontHash = hash((raster.getId(), uiScale))
+
+  withLock(fontLock):
+    for salt in 0 .. 100:
+      let candidateHash =
+        if salt == 0:
+          fontHash
+        else:
+          hash((fontHash, salt))
+      if candidateHash != Hash(0):
+        let candidate = FontId(candidateHash)
+        if candidate notin fontTable:
+          fontTable[candidate] = raster
+          fontUiScaleTable[candidate] = uiScale
+          return candidate
+        if fontTable[candidate] == raster and
+            fontUiScaleTable.getOrDefault(candidate, uiScale) == uiScale:
+          return candidate
+
+  raise newException(ValueError, "could not allocate a collision-free font id")
 
 proc convertFont*(font: FigFont): (FontId, Font) =
   ## does the typesetting using pixie, then converts to Figuro's internal
   ## types
 
-  result = font.pixieFont()
-  if not fontTable.hasKey(result[0]):
-    fontTable[result[0]] = font
+  result = (font.registerFont(), font.pixieFont())
 
 proc convertFont*(style: FontStyle): (FontId, Font) =
   style.font.convertFont()
@@ -291,7 +387,14 @@ proc glyphFontFor*(uiFont: FigFont): tuple[id: FontId, font: Font, glyph: GlyphF
   result = (
     id: fontId,
     font: pf,
-    glyph: GlyphFont(fontId: fontId, lineHeight: lineHeight, descentAdj: baselineOffset),
+    glyph: GlyphFont(
+      fontId: fontId,
+      size: uiFont.size,
+      lineHeight: lineHeight,
+      descentAdj: baselineOffset,
+      underline: uiFont.underline,
+      strikethrough: uiFont.strikethrough,
+    ),
   )
 
 proc getLineHeightImpl*(font: FigFont): float32 =
@@ -312,7 +415,7 @@ proc getPixieFont*(fontId: FontId): Font =
   var uifont: FigFont
   withLock(fontLock):
     uifont = fontTable[fontId]
-  result = uifont.pixieFont()[1]
+  result = uifont.pixieFont()
   result.size = result.size.getScaledFont()
   #result.size = result.size
   result.lineHeight = result.lineHeight.scaled()

--- a/src/figdraw/figrender.nim
+++ b/src/figdraw/figrender.nim
@@ -318,6 +318,68 @@ proc glyphLocalPos*(glyphPos: Vec2, glyphDescent: float32): Vec2 {.inline.} =
   ## Converts a local glyph baseline position into local glyph top-left coordinates.
   vec2(glyphPos.x.scaled(), scaled(glyphPos.y - glyphDescent))
 
+proc drawTextDecoration(
+    ctx: BackendContext, decoration: Rect, color: Fill
+) {.forbids: [AppMainThreadEff].} =
+  if decoration.w <= 0 or decoration.h <= 0:
+    return
+  ctx.drawRoundedRectSdf(
+    rect = decoration.scaled(),
+    fill = color.toBackendFill(),
+    radii = [0.0'f32, 0.0'f32, 0.0'f32, 0.0'f32],
+    mode = figbackend.SdfMode.sdfModeClipAA,
+    factor = 4.0'f32,
+    spread = 0.0'f32,
+    shapeSize = vec2(0.0'f32, 0.0'f32),
+  )
+
+proc renderTextDecorations(
+    ctx: BackendContext, arrangement: GlyphArrangement
+) {.forbids: [AppMainThreadEff].} =
+  for spanIndex, span in arrangement.spans:
+    if spanIndex >= arrangement.fonts.len:
+      break
+    let font = arrangement.fonts[spanIndex]
+    if font.underline or font.strikethrough:
+      let color =
+        if spanIndex < arrangement.spanColors.len:
+          arrangement.spanColors[spanIndex]
+        else:
+          fill(rgba(0, 0, 0, 255))
+      let thickness = max(round(font.size / 16.0'f32), 1.0'f32)
+      for line in arrangement.lines:
+        let
+          start = max(span.a, line.a)
+          stop = min(span.b, line.b)
+        if start <= stop:
+          var
+            minX = float32.high
+            maxX = -float32.high
+            minY = float32.high
+            maxY = -float32.high
+          for glyphIndex in start .. stop:
+            let glyphRect = arrangement.glyphRect(glyphIndex)
+            minX = min(minX, glyphRect.x)
+            maxX = max(maxX, glyphRect.x + glyphRect.w)
+            minY = min(minY, glyphRect.y)
+            maxY = max(maxY, glyphRect.y + glyphRect.h)
+
+          if minX < maxX and minY < maxY:
+            if font.underline:
+              ctx.drawTextDecoration(
+                rect(minX, maxY - thickness * 1.5'f32, maxX - minX, thickness), color
+              )
+            if font.strikethrough:
+              ctx.drawTextDecoration(
+                rect(
+                  minX,
+                  minY + (maxY - minY) * 0.5'f32 - thickness * 0.5'f32,
+                  maxX - minX,
+                  thickness,
+                ),
+                color,
+              )
+
 proc renderText(ctx: BackendContext, node: Fig) {.forbids: [AppMainThreadEff].} =
   ## Render characters (glyphs)
   let
@@ -354,6 +416,8 @@ proc renderText(ctx: BackendContext, node: Fig) {.forbids: [AppMainThreadEff].} 
             spread = 0.0'f32,
             shapeSize = vec2(0.0'f32, 0.0'f32),
           )
+
+    ctx.renderTextDecorations(node.textLayout)
 
     for glyph in node.textLayout.glyphs():
       if glyph.isWhitespace:
@@ -1711,9 +1775,11 @@ proc renderRoot*(
       ctx.clearImageAtlas()
     of ImkClearFontGlyphs:
       trace "font glyphs cleared", fontId = $Hash(img.fontId)
+      clearGlyphRasterFontCache(img.fontId)
       ctx.clearFontGlyphs(img.fontId)
     of ImkClearTypefaceGlyphs:
       trace "typeface glyphs cleared", typefaceId = $Hash(img.typefaceId)
+      clearGlyphRasterTypefaceCache(img.typefaceId)
       ctx.clearTypefaceGlyphs(img.typefaceId)
     of ImkRetainImage:
       trace "image retained", id = $img.id.Hash
@@ -1730,6 +1796,7 @@ proc renderRoot*(
       trace "font released", fontId = $Hash(img.fontId)
       if ctx.releaseFontOwner(img.fontId, img.ownerToken):
         forgetReleasedFontGlyphs(img.fontId)
+        clearGlyphRasterFontCache(img.fontId)
         ctx.clearFontGlyphs(img.fontId)
 
   for zlvl, list in nodes.layers.pairs():

--- a/tests/tfigrender_env_override.nim
+++ b/tests/tfigrender_env_override.nim
@@ -1,5 +1,6 @@
 import std/[os, unittest]
 
+import figdraw/commons
 import figdraw/figrender
 
 proc withCleanEnv(body: proc()) =
@@ -43,23 +44,30 @@ proc withCleanEnv(body: proc()) =
   body()
 
 suite "figrender env overrides":
-  test "force opengl wins over backend selection":
-    withCleanEnv proc() =
-      putEnv("FIGDRAW_BACKEND", "vulkan")
-      putEnv("FIGDRAW_FORCE_OPENGL", "1")
-      check runtimeForceOpenGlRequested() == true
+  when UseOpenGlFallback and (UseMetalBackend or UseVulkanBackend):
+    test "force opengl wins over backend selection":
+      withCleanEnv proc() =
+        putEnv("FIGDRAW_BACKEND", "vulkan")
+        putEnv("FIGDRAW_FORCE_OPENGL", "1")
+        check runtimeForceOpenGlRequested() == true
 
-  test "backend=opengl enables override":
-    withCleanEnv proc() =
-      putEnv("FIGDRAW_BACKEND", "opengl")
-      delEnv("FIGDRAW_FORCE_OPENGL")
-      check runtimeForceOpenGlRequested() == true
+    test "backend=opengl enables override":
+      withCleanEnv proc() =
+        putEnv("FIGDRAW_BACKEND", "opengl")
+        delEnv("FIGDRAW_FORCE_OPENGL")
+        check runtimeForceOpenGlRequested() == true
 
-  test "backend=vulkan without force does not enable opengl override":
-    withCleanEnv proc() =
-      putEnv("FIGDRAW_BACKEND", "vulkan")
-      delEnv("FIGDRAW_FORCE_OPENGL")
-      check runtimeForceOpenGlRequested() == false
+    test "backend=vulkan without force does not enable opengl override":
+      withCleanEnv proc() =
+        putEnv("FIGDRAW_BACKEND", "vulkan")
+        delEnv("FIGDRAW_FORCE_OPENGL")
+        check runtimeForceOpenGlRequested() == false
+  else:
+    test "backend selection cannot enable an unavailable fallback":
+      withCleanEnv proc() =
+        putEnv("FIGDRAW_BACKEND", "opengl")
+        putEnv("FIGDRAW_FORCE_OPENGL", "1")
+        check runtimeForceOpenGlRequested() == false
 
   test "text flags default to disabled":
     withCleanEnv proc() =

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -56,12 +56,27 @@ proc firstLoadableSystemFontPath(candidates: openArray[string]): string =
   ""
 
 when figdrawTextBackend == "harfbuzzy" or figdrawTextBackend == "hybrid":
-  proc firstLoadableNamedSystemFontPath(candidates: openArray[string]): string =
+  proc firstLoadableNamedSystemFontPath(
+      candidates: openArray[string], requiredText: string
+  ): string =
+    proc supportsRequiredRunes(typeface: Typeface): bool =
+      for rune in requiredText.runes:
+        if not typeface.hasGlyph(rune):
+          return false
+      true
+
     let preferred = findSystemFontFile(candidates)
     if preferred.len > 0:
       try:
-        discard readTypeface(preferred)
-        return preferred
+        if readTypeface(preferred).supportsRequiredRunes():
+          return preferred
+      except PixieError:
+        discard
+
+    for path in systemFontFiles():
+      try:
+        if readTypeface(path).supportsRequiredRunes():
+          return path
       except PixieError:
         discard
     ""
@@ -1062,11 +1077,13 @@ suite "fontutils":
         check caret.sourceRune == 8
 
     test "harfbuzzy shapes Arabic when a system Arabic font is available":
+      const arabicText = "سلام"
       let fontPath = firstLoadableNamedSystemFontPath(
         [
           "Noto Naskh Arabic", "Noto Sans Arabic", "Geeza Pro", "Arial Unicode",
           "Arial", "DejaVu Sans",
-        ]
+        ],
+        arabicText,
       )
       if fontPath.len == 0:
         check true
@@ -1074,7 +1091,7 @@ suite "fontutils":
         let typefaceId = loadTypeface(fontPath)
         let uiFont = FigFont(typefaceId: typefaceId, size: 32.0'f32)
         let box = rect(0, 0, 320, 90)
-        let spans = [(fs(uiFont), "سلام")]
+        let spans = [(fs(uiFont), arabicText)]
 
         let arrangement = typeset(
           box, spans, hAlign = Left, vAlign = Top, minContent = false, wrap = false

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,4 +1,4 @@
-import std/[hashes, os, unittest, tables, locks, unicode]
+import std/[hashes, os, tables, unicode, unittest]
 
 import pkg/pixie
 import pkg/pixie/fonts
@@ -118,16 +118,64 @@ suite "fontutils":
     check id1 in typefaceSourceTable
     check typefaceSourceTable[id1].data == fontData
 
+  test "typeface ids distinguish different bytes with the same name":
+    let
+      ubuntuData = readFile(figDataDir() / "Ubuntu.ttf")
+      hackData = readFile(figDataDir() / "HackNerdFont-Regular.ttf")
+      ubuntuId = loadTypeface("same-name.ttf", ubuntuData, TTF)
+      hackId = loadTypeface("same-name.ttf", hackData, TTF)
+
+    check ubuntuId != hackId
+    check getTypefaceSource(ubuntuId).data == ubuntuData
+    check getTypefaceSource(hackId).data == hackData
+
+  test "typeface ids reuse identical bytes loaded through aliases":
+    let
+      fontData = readFile(figDataDir() / "Ubuntu.ttf")
+      firstId = loadTypeface("first-name.ttf", fontData, TTF)
+      secondId = loadTypeface("second-name.ttf", fontData, TTF)
+
+    check firstId == secondId
+
   test "convertFont caches pixie font":
     let fontData = readFile(figDataDir() / "Ubuntu.ttf")
     let typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
     let uiFont = FigFont(typefaceId: typefaceId, size: 20.0'f32)
 
-    let (fontId1, pf1) = uiFont.convertFont()
-    let (fontId2, pf2) = uiFont.convertFont()
+    let fontId1 = uiFont.convertFont()[0]
+    let fontId2 = uiFont.convertFont()[0]
 
     check fontId1 == fontId2
     check fontId1 in fontTable
+
+  test "raster font ids ignore shaping-only settings":
+    let
+      fontData = readFile(figDataDir() / "Ubuntu.ttf")
+      typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+      baseFont = FigFont(typefaceId: typefaceId, size: 20.0'f32)
+      shapingFont = FigFont(
+        typefaceId: typefaceId,
+        size: 20.0'f32,
+        fallbackTypefaceIds: @[typefaceId],
+        features: @[fontFeature("liga", 0)],
+        noKerningAdjustments: true,
+        underline: true,
+      )
+
+    check baseFont.convertFont()[0] == shapingFont.convertFont()[0]
+
+  test "layout content hashes include wrapping policy":
+    let
+      fontData = readFile(figDataDir() / "Ubuntu.ttf")
+      typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+      uiFont = FigFont(typefaceId: typefaceId, size: 20.0'f32)
+      spans = [(fs(uiFont), "alpha beta")]
+      size = vec2(100, 40)
+
+    check getContentHash(size, spans, Left, Top, false, false) !=
+      getContentHash(size, spans, Left, Top, false, true)
+    check getContentHash(size, spans, Left, Top, false, true) !=
+      getContentHash(size, spans, Left, Top, true, true)
 
   test "lineHeight affects computed lineHeight":
     let fontData = readFile(figDataDir() / "Ubuntu.ttf")
@@ -139,6 +187,23 @@ suite "fontutils":
 
     check abs(pf.lineHeight - expected) < 0.01'f32
     check abs(getLineHeightImpl(uiFont).scaled() - expected) < 0.01'f32
+
+  test "text decorations are carried into glyph font spans":
+    let
+      fontData = readFile(figDataDir() / "Ubuntu.ttf")
+      typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+      uiFont = FigFont(
+        typefaceId: typefaceId, size: 24.0'f32, underline: true, strikethrough: true
+      )
+      arrangement = typeset(
+        rect(0, 0, 200, 60), [(fs(uiFont), "Decorated")], Left, Top, false, false
+      )
+
+    check arrangement.fonts.len > 0
+    for font in arrangement.fonts:
+      check font.size == uiFont.size
+      check font.underline
+      check font.strikethrough
 
   test "getTypesetImpl returns consistent hashes and generated glyph images":
     let fontData = readFile(figDataDir() / "Ubuntu.ttf")
@@ -452,6 +517,42 @@ suite "fontutils":
       check arrangement.glyphIndexAt(hitPoint) == ligatureGlyph
       check arrangement.sourceRuneRangeAt(hitPoint) == 1 .. 3
 
+    test "paint-only span boundaries preserve shaping continuity":
+      let
+        fontData = readFile(figDataDir() / "Ubuntu.ttf")
+        typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+        uiFont = FigFont(typefaceId: typefaceId, size: 32.0'f32)
+        box = rect(0, 0, 300, 80)
+        whole = typeset(box, [(fs(uiFont), "office")], Left, Top, false, false)
+        split = typeset(
+          box,
+          [
+            (fs(uiFont, rgba(220, 40, 40, 255).color), "of"),
+            (fs(uiFont, rgba(40, 90, 220, 255).color), "fice"),
+          ],
+          Left,
+          Top,
+          false,
+          false,
+        )
+
+      check split.arrangedGlyphs.len == whole.arrangedGlyphs.len
+      check split.glyphRangeFor(1 .. 3).len == 1
+      check split.spans.len == 2
+      check split.spanColors.len == 2
+
+    test "font case preserves original source text and byte ranges":
+      let
+        fontData = readFile(figDataDir() / "Ubuntu.ttf")
+        typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+        source = "a" & $Rune(0x017f) & "b"
+        uiFont = FigFont(typefaceId: typefaceId, size: 28.0'f32, fontCase: UpperCase)
+        arrangement =
+          typeset(rect(0, 0, 240, 60), [(fs(uiFont), source)], Left, Top, false, false)
+
+      check arrangement.sourceRunes == source.toRunes()
+      check arrangement.glyphRangeForRawBytes(1 .. 2).len > 0
+
     test "OpenType features can disable discretionary ligature shaping":
       let fontData = readFile(figDataDir() / "Ubuntu.ttf")
       let typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
@@ -663,6 +764,40 @@ suite "fontutils":
         for glyphIndex in line:
           lineY[i] = min(lineY[i], arrangement.arrangedGlyphs[glyphIndex].rect.y)
       check lineY[0] < lineY[1]
+
+    test "harfbuzzy preserves empty hard-break lines":
+      let
+        fontData = readFile(figDataDir() / "Ubuntu.ttf")
+        typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+        uiFont = FigFont(typefaceId: typefaceId, size: 24.0'f32)
+        arrangement = typeset(
+          rect(0, 0, 260, 180), [(fs(uiFont), "a\n\nb")], Left, Top, false, false
+        )
+
+      check arrangement.lines.len == 3
+      check arrangement.lines[1].len == 1
+      let
+        firstLine = arrangement.arrangedGlyphs[arrangement.lines[0].a].rect
+        emptyLine = arrangement.arrangedGlyphs[arrangement.lines[1].a].rect
+        lastLine = arrangement.arrangedGlyphs[arrangement.lines[2].a].rect
+      check emptyLine.w == 0
+      check emptyLine.h > 0
+      check firstLine.y < emptyLine.y
+      check emptyLine.y < lastLine.y
+
+    test "noKerningAdjustments disables Harfbuzz kerning":
+      let
+        fontData = readFile(figDataDir() / "Ubuntu.ttf")
+        typefaceId = loadTypeface("Ubuntu.ttf", fontData, TTF)
+        defaultFont = FigFont(typefaceId: typefaceId, size: 32.0'f32)
+        noKerningFont =
+          FigFont(typefaceId: typefaceId, size: 32.0'f32, noKerningAdjustments: true)
+        box = rect(0, 0, 240, 80)
+        defaultLayout = typeset(box, [(fs(defaultFont), "AV")], Left, Top, false, false)
+        noKerningLayout =
+          typeset(box, [(fs(noKerningFont), "AV")], Left, Top, false, false)
+
+      check noKerningLayout.bounding.w > defaultLayout.bounding.w
 
     test "harfbuzzy wrapped Hebrew lines stay in logical order":
       let fontPath =

--- a/tests/trender_3d_overlay.nim
+++ b/tests/trender_3d_overlay.nim
@@ -321,8 +321,8 @@ suite "opengl 3d overlay render":
     if fileExists(outPath):
       removeFile(outPath)
     block renderOnce:
-      when UseMetalBackend:
-        # The overlay test relies on an OpenGL context to draw the background.
+      when UseMetalBackend or defined(windows):
+        # The raw OpenGL overlay path is unsupported on Metal and Windows llvmpipe.
         skip()
         break renderOnce
       var img: Image

--- a/tests/trender_rgb_boxes.nim
+++ b/tests/trender_rgb_boxes.nim
@@ -109,6 +109,8 @@ suite "opengl rgb boxes render":
           title = "figdraw test: rgb boxes",
         )
       except WindyError:
+        if getEnv("FIGDRAW_REQUIRE_GRAPHICS") == "1":
+          raise
         skip()
         break renderOnce
 

--- a/tests/trender_rgb_boxes_sdf_siwin.nim
+++ b/tests/trender_rgb_boxes_sdf_siwin.nim
@@ -106,6 +106,8 @@ suite "siwin rgb boxes render (sdf)":
           title = "figdraw test: rgb boxes (sdf, siwin)",
         )
       except ValueError:
+        if getEnv("FIGDRAW_REQUIRE_GRAPHICS") == "1":
+          raise
         skip()
         break renderOnce
 


### PR DESCRIPTION
## Summary

- make typeface and raster font identities collision-safe, preserve collection face indexes, and fix `FontRef` ownership
- improve HarfBuzz shaping continuity, source mapping, safe wrapping, empty lines, kerning control, handle caching, and text decorations
- split Linux CI into X11/Wayland and OpenGL/Vulkan jobs, for four Linux runs
- make test discovery path-separator independent and fail when no tests are found
- run Windows graphical tests against pinned Mesa llvmpipe instead of silently skipping unavailable WGL contexts
- install and test native HarfBuzz/FriBidi on Windows CI
- document HarfBuzz 7 requirements and current color-font limitations

## Test plan

- `nph` on all touched Nim files
- `nim r tests/tfontutils.nim`
- `nim r -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim`
- `nim r -d:figdrawTextBackend=hybrid tests/tfontutils.nim`
- strict OpenGL Windy and Siwin screenshot tests with `FIGDRAW_REQUIRE_GRAPHICS=1`
- `nim bindings`
- `nim test`
- `nim test_compile`
- Linux-target `nim check`
- workflow YAML parse and `git diff --check`
- GitHub Actions run 29106018819: all six jobs passed