### PR TITLE
Run Vulkan tests on Windows

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup software OpenGL (Mesa)
-      if: runner.os == 'Windows' && matrix.renderer == 'opengl'
+      if: runner.os == 'Windows'
       uses: ssciwr/setup-mesa-dist-win@v3.0.0
       with:
         version: '26.0.3'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -293,6 +293,7 @@ jobs:
       env:
         NIMFLAGS: ${{ matrix.nimflags }}
         FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
+        FIGDRAW_TEST_EXCLUDE: ${{ matrix.test_exclude }}
         FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
         FIGDRAW_REQUIRE_GRAPHICS: ${{ matrix.require_graphics }}
         GALLIUM_DRIVER: 'llvmpipe'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -53,6 +53,7 @@ jobs:
             renderer: opengl
             nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '1'
+            require_graphics: '1'
             vulkan_icd: ''
           - os: windows-2022
             nimversion: '2.2.10'
@@ -60,6 +61,7 @@ jobs:
             renderer: vulkan
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
+            require_graphics: '0'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1
@@ -289,7 +291,7 @@ jobs:
         NIMFLAGS: ${{ matrix.nimflags }}
         FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
         FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
-        FIGDRAW_REQUIRE_GRAPHICS: '1'
+        FIGDRAW_REQUIRE_GRAPHICS: ${{ matrix.require_graphics }}
         GALLIUM_DRIVER: 'llvmpipe'
         LIBGL_ALWAYS_SOFTWARE: '1'
         VK_ICD_FILENAMES: ${{ matrix.vulkan_icd }}
@@ -297,6 +299,18 @@ jobs:
       run: |
         nim test
         nim r $NIMFLAGS -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
+
+    - name: Run Windows Vulkan graphics tests
+      if: runner.os == 'Windows' && matrix.renderer == 'vulkan'
+      env:
+        NIMFLAGS: ${{ matrix.nimflags }}
+        FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
+        FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
+        FIGDRAW_REQUIRE_GRAPHICS: '1'
+        VK_ICD_FILENAMES: ${{ matrix.vulkan_icd }}
+        VK_DRIVER_FILES: ${{ matrix.vulkan_icd }}
+      run: |
+        nim r $NIMFLAGS tests/trender_image_msdf_invert.nim
 
     - name: Upload Test Output (on failure)
       if: failure()

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -60,7 +60,7 @@ jobs:
             renderer: vulkan
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
-            vulkan_icd: 'C:/msys64/mingw64/share/vulkan/icd.d/lvp_icd.x86_64.json'
+            vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1
 
@@ -80,17 +80,21 @@ jobs:
           mingw-w64-x86_64-fribidi
         echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
 
-    - name: Install Windows software Vulkan (Mesa Lavapipe)
+    - name: Install Windows software Vulkan (SwiftShader)
+      if: runner.os == 'Windows' && matrix.renderer == 'vulkan'
+      uses: jakoch/install-vulkan-sdk-action@37effcfa045411f8bfbbda26df2fd1b3bf3436fa
+      with:
+        install_runtime_only: true
+        install_swiftshader: true
+        swiftshader_destination: 'C:\swiftshader'
+        cache: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Verify Windows software Vulkan
       if: runner.os == 'Windows' && matrix.renderer == 'vulkan'
       run: |
-        C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed \
-          mingw-w64-x86_64-mesa
         test -f "${{ matrix.vulkan_icd }}"
-        test -f C:/msys64/mingw64/bin/vulkan_lvp.dll
-        MSYS2_ARG_CONV_EXCL='*' C:/Windows/System32/reg.exe ADD \
-          'HKLM\SOFTWARE\Khronos\Vulkan\Drivers' \
-          /v 'C:\msys64\mingw64\share\vulkan\icd.d\lvp_icd.x86_64.json' \
-          /t REG_DWORD /d 0 /f
+        test -f C:/swiftshader/vk_swiftshader.dll
         MSYS2_ARG_CONV_EXCL='*' C:/Windows/System32/reg.exe QUERY \
           'HKLM\SOFTWARE\Khronos\Vulkan\Drivers'
 

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -54,6 +54,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '1'
             require_graphics: '1'
+            test_exclude: ''
             vulkan_icd: ''
           - os: windows-2022
             nimversion: '2.2.10'
@@ -62,6 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1
@@ -229,6 +231,7 @@ jobs:
       env:
         XDG_SESSION_TYPE: "x11"
         FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
+        FIGDRAW_TEST_EXCLUDE: ${{ matrix.test_exclude }}
         FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
         NIMFLAGS: ${{ matrix.nimflags }}
         GALLIUM_DRIVER: "llvmpipe"

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -95,8 +95,10 @@ jobs:
       run: |
         test -f "${{ matrix.vulkan_icd }}"
         test -f C:/swiftshader/vk_swiftshader.dll
+        test -f C:/swiftshader/vulkan-1.dll
         MSYS2_ARG_CONV_EXCL='*' C:/Windows/System32/reg.exe QUERY \
           'HKLM\SOFTWARE\Khronos\Vulkan\Drivers'
+        echo "C:/swiftshader" >> "$GITHUB_PATH"
 
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -53,11 +53,19 @@ jobs:
             renderer: opengl
             nimflags: '-d:figdraw.opengl=on -d:figdraw.vulkan=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '1'
+            vulkan_icd: ''
+          - os: windows-2022
+            nimversion: '2.2.10'
+            display: none
+            renderer: vulkan
+            nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
+            force_opengl: '0'
+            vulkan_icd: 'C:/msys64/mingw64/share/vulkan/icd.d/lvp_icd.x86_64.json'
     steps:
     - uses: actions/checkout@v1
 
     - name: Setup software OpenGL (Mesa)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.renderer == 'opengl'
       uses: ssciwr/setup-mesa-dist-win@v3.0.0
       with:
         version: '26.0.3'
@@ -71,6 +79,14 @@ jobs:
           mingw-w64-x86_64-harfbuzz \
           mingw-w64-x86_64-fribidi
         echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
+
+    - name: Install Windows software Vulkan (Mesa Lavapipe)
+      if: runner.os == 'Windows' && matrix.renderer == 'vulkan'
+      run: |
+        C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed \
+          mingw-w64-x86_64-mesa
+        test -f "${{ matrix.vulkan_icd }}"
+        test -f C:/msys64/mingw64/bin/vulkan_lvp.dll
 
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'
@@ -259,20 +275,16 @@ jobs:
       if: runner.os == 'Windows'
       env:
         NIMFLAGS: ${{ matrix.nimflags }}
+        FIGDRAW_TEST_RENDERER: ${{ matrix.renderer }}
         FIGDRAW_FORCE_OPENGL: ${{ matrix.force_opengl }}
         FIGDRAW_REQUIRE_GRAPHICS: '1'
         GALLIUM_DRIVER: 'llvmpipe'
         LIBGL_ALWAYS_SOFTWARE: '1'
+        VK_ICD_FILENAMES: ${{ matrix.vulkan_icd }}
+        VK_DRIVER_FILES: ${{ matrix.vulkan_icd }}
       run: |
         nim test
         nim r $NIMFLAGS -d:figdrawTextBackend=harfbuzzy tests/tfontutils.nim
-
-    - name: Build Tests (Vulkan Compile Check)
-      if: runner.os == 'Windows'
-      env:
-        NIMFLAGS: "-d:figdraw.opengl=off -d:figdraw.vulkan=on"
-      run: |
-        nim test_compile
 
     - name: Upload Test Output (on failure)
       if: failure()

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -87,6 +87,12 @@ jobs:
           mingw-w64-x86_64-mesa
         test -f "${{ matrix.vulkan_icd }}"
         test -f C:/msys64/mingw64/bin/vulkan_lvp.dll
+        MSYS2_ARG_CONV_EXCL='*' C:/Windows/System32/reg.exe ADD \
+          'HKLM\SOFTWARE\Khronos\Vulkan\Drivers' \
+          /v 'C:\msys64\mingw64\share\vulkan\icd.d\lvp_icd.x86_64.json' \
+          /t REG_DWORD /d 0 /f
+        MSYS2_ARG_CONV_EXCL='*' C:/Windows/System32/reg.exe QUERY \
+          'HKLM\SOFTWARE\Khronos\Vulkan\Drivers'
 
     - name: Setup software OpenGL/Vulkan (Mesa) + Xvfb (X11)
       if: runner.os == 'Linux' && matrix.display == 'x11'

--- a/config.nims
+++ b/config.nims
@@ -110,6 +110,11 @@ proc platforms(): seq[string] =
 task test, "run unit test":
   let enableSdl2 =
     getEnv("FIGDRAW_TEST_SDL2").strip().toLowerAscii() in ["1", "true", "yes", "on"]
+  var excludedTests: seq[string]
+  for testName in getEnv("FIGDRAW_TEST_EXCLUDE").split(','):
+    let cleaned = testName.strip()
+    if cleaned.len > 0:
+      excludedTests.add(cleaned)
 
   var testRuns = 0
   for platformArg in platforms():
@@ -117,7 +122,7 @@ task test, "run unit test":
       echo "Running platform args: ", platformArg
     for file in listFiles("tests"):
       let name = file.extractFilename()
-      if name.startsWith("t") and name.endsWith(".nim"):
+      if name.startsWith("t") and name.endsWith(".nim") and name notin excludedTests:
         inc testRuns
         nimExec("r", file, platform = platformArg)
 

--- a/src/figdraw/vulkan/vulkan_utils.nim
+++ b/src/figdraw/vulkan/vulkan_utils.nim
@@ -175,11 +175,12 @@ proc chooseSwapCompositeAlpha*(
 proc chooseSwapExtent*(
     capabilities: VkSurfaceCapabilitiesKHR, width, height: int32
 ): VkExtent2D =
-  if capabilities.currentExtent.width != 0xFFFFFFFF'u32:
+  if capabilities.currentExtent.width != 0xFFFFFFFF'u32 and
+      capabilities.currentExtent.width > 0 and capabilities.currentExtent.height > 0:
     return capabilities.currentExtent
 
-  result.width = width.uint32
-  result.height = height.uint32
+  result.width = max(1'i32, width).uint32
+  result.height = max(1'i32, height).uint32
   result.width = max(
     capabilities.minImageExtent.width,
     min(capabilities.maxImageExtent.width, result.width),

--- a/tests/opengl_test_utils.nim
+++ b/tests/opengl_test_utils.nim
@@ -50,6 +50,20 @@ proc renderAndScreenshotOnce*(
       size = ivec2(windowW.int32, windowH.int32), fullscreen = false, title = title
     )
     try:
+      when defined(windows):
+        window.visible = true
+        window.size = ivec2(windowW.int32, windowH.int32)
+        var windowReady = false
+        for _ in 0 ..< 50:
+          pollEvents()
+          let clientSize = window.backingSize()
+          if clientSize.x > 0 and clientSize.y > 0:
+            windowReady = true
+            break
+          sleep(10)
+        if not windowReady:
+          raise newException(WindyError, "Win32 window has no drawable client area")
+
       let renderer = glrenderer.newFigRenderer(
         atlasSize = atlasSize, backendState = WindyRenderBackend()
       )

--- a/tests/opengl_test_utils.nim
+++ b/tests/opengl_test_utils.nim
@@ -70,8 +70,8 @@ proc renderAndScreenshotOnce*(
       result.writeFile(outputPath)
     except VulkanError as exc:
       raise newException(WindyError, "Vulkan device not available: " & exc.msg)
-    except ValueError:
-      raise newException(WindyError, "Vulkan device not available")
+    except ValueError as exc:
+      raise newException(WindyError, "Vulkan device not available: " & exc.msg)
     finally:
       window.close()
   else:

--- a/tests/tvulkan_text_runtime.nim
+++ b/tests/tvulkan_text_runtime.nim
@@ -3,7 +3,9 @@ import std/unittest
 import figdraw/commons
 
 when UseVulkanBackend:
+  import pkg/vulkan
   import figdraw/vulkan/vulkan_context
+  import figdraw/vulkan/vulkan_utils
 
   suite "vulkan text runtime toggles":
     test "vulkan context stores text runtime flags":
@@ -21,6 +23,18 @@ when UseVulkanBackend:
       check ctx.textLcdFilteringEnabled() == true
       check ctx.textSubpixelPositioningEnabled() == true
       check ctx.textSubpixelGlyphVariantsEnabled() == true
+
+    test "zero surface extent uses requested window size":
+      let capabilities = VkSurfaceCapabilitiesKHR(
+        currentExtent: newVkExtent2D(width = 0, height = 0),
+        minImageExtent: newVkExtent2D(width = 1, height = 1),
+        maxImageExtent: newVkExtent2D(width = 4096, height = 4096),
+      )
+
+      let extent = chooseSwapExtent(capabilities, 800, 600)
+
+      check extent.width == 800
+      check extent.height == 600
 else:
   suite "vulkan text runtime toggles":
     test "vulkan backend not enabled":


### PR DESCRIPTION
## Summary
- split Windows CI into OpenGL and Vulkan runtime jobs
- run the Vulkan job against SwiftShader, with its ICD and loader explicitly available to the test process
- compile the Vulkan job without the OpenGL renderer or fallback
- filter software-renderer-sensitive graphics tests only from the Windows Vulkan general suite, then run a hard-required Siwin image/MSDF pixel test as its Vulkan gate
- leave full graphical coverage in the Windows OpenGL and Linux renderer rows
- handle zero Vulkan surface extents and test the fallback extent selection

## Test plan
- `nim c -d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off tests/trender_rgb_boxes.nim`
- `nim c -d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off tests/tvulkan_text_runtime.nim`
- `nim r tests/tvulkan_text_runtime.nim`
- `FIGDRAW_TEST_EXCLUDE=… nim test` (verified filtered discovery; local example build later needs generated bindings)
- GitHub Actions Windows OpenGL and Vulkan jobs