### PR TITLE
Support dedicated render presentation targets

### DIFF
--- a/src/figdraw/figrender.nim
+++ b/src/figdraw/figrender.nim
@@ -1843,7 +1843,9 @@ proc renderFrame*[BackendState](
     frameSize: Vec2,
     clearMain: bool = true,
     clearColor: Color = color(1.0, 1.0, 1.0, 1.0),
+    allowOpenGlFallback = true,
 ) =
+  ## Set allowOpenGlFallback to false after detaching a window-bound context.
   let frameSize = frameSize.scaled()
   if frameSize.x <= 0 or frameSize.y <= 0:
     return
@@ -1853,7 +1855,7 @@ proc renderFrame*[BackendState](
         frameSize, clearMain = clearMain, clearMainColor = clearColor
       )
     except CatchableError as exc:
-      if renderer.ctx.kind() == rbOpenGL:
+      if renderer.ctx.kind() == rbOpenGL or not allowOpenGlFallback:
         raise
       renderer.useOpenGlFallback(exc.msg)
       renderer.ctx.beginFrame(

--- a/src/figdraw/windowing/siwinshim.nim
+++ b/src/figdraw/windowing/siwinshim.nim
@@ -342,6 +342,7 @@ type
     ## Opaque per-window backend state used by siwin + FigDraw integration.
     window*: Window
     dedicatedRender*: bool
+    presentationReady: bool
     resizeClearColor: Color
     resizeClearColorSet: bool
     when UseMetalBackend and defined(macosx):
@@ -355,6 +356,8 @@ type
     ## this value exists solely so the window host can keep its geometry current.
     when UseMetalBackend and defined(macosx):
       metalLayer*: MetalLayerHandle
+    when UseVulkanBackend and defined(macosx):
+      vulkanMetalLayer*: MetalLayerHandle
 
 when defined(macosx):
   proc setOpaque(window: NSWindow, opaque: BOOL) {.objc: "setOpaque:".}
@@ -402,6 +405,8 @@ proc presentationTarget*(
 ): SiwinPresentationTarget =
   when UseMetalBackend and defined(macosx):
     result.metalLayer = renderer.backendState.metalLayer
+  when UseVulkanBackend and defined(macosx):
+    result.vulkanMetalLayer = renderer.backendState.vulkanMetalLayer
 
 proc updatePresentationTarget*(target: SiwinPresentationTarget, window: Window) =
   ## Update the native layer from the thread which owns the window. Rendering
@@ -409,18 +414,61 @@ proc updatePresentationTarget*(target: SiwinPresentationTarget, window: Window) 
   when UseMetalBackend and defined(macosx):
     if not target.metalLayer.layer.isNil and not window.isNil:
       target.metalLayer.updateMetalLayer(window)
+  when UseVulkanBackend and defined(macosx):
+    if not target.vulkanMetalLayer.layer.isNil and not window.isNil:
+      target.vulkanMetalLayer.updateMetalLayer(window)
+
+func backendSupportsDedicatedRenderThread*(kind: RendererBackendKind): bool =
+  ## Whether this build can present this backend from a dedicated thread.
+  case kind
+  of rbMetal:
+    when UseMetalBackend and defined(macosx): true else: false
+  of rbVulkan:
+    when UseVulkanBackend: true else: false
+  of rbOpenGL:
+    false
+
+proc supportsDedicatedRenderThread*(renderer: FigRenderer[SiwinRenderBackend]): bool =
+  ## Whether the configured presentation backend can be detached from its
+  ## native window. OpenGL remains bound to the window and platform thread.
+  if renderer.isNil or renderer.ctx.isNil or not renderer.backendState.presentationReady:
+    return false
+  if not backendSupportsDedicatedRenderThread(renderer.backendKind()):
+    return false
+  case renderer.backendKind()
+  of rbMetal:
+    when UseMetalBackend and defined(macosx):
+      return not renderer.backendState.metalLayer.layer.isNil
+    else:
+      discard
+  of rbVulkan:
+    when UseVulkanBackend:
+      when defined(macosx):
+        return not renderer.backendState.vulkanMetalLayer.layer.isNil
+      else:
+        return true
+    else:
+      discard
+  of rbOpenGL:
+    discard
 
 proc useDedicatedRenderThread*(renderer: FigRenderer[SiwinRenderBackend]) =
   ## Marks this renderer as owned by a dedicated render thread after the window
   ## thread has attached and configured its presentation target. Do not retain
   ## the native window across the ownership boundary: its lifetime remains on
   ## the platform thread.
+  if not renderer.supportsDedicatedRenderThread():
+    raise newException(
+      ValueError, "the active siwin backend cannot render on a dedicated thread"
+    )
   renderer.backendState.dedicatedRender = true
   renderer.backendState.window = nil
 
 proc setupBackend*(renderer: FigRenderer, window: Window) =
   ## One-time backend hookup between a siwin window and FigDraw renderer.
   renderer.backendState.window = window
+  renderer.backendState.dedicatedRender = false
+  renderer.backendState.presentationReady = false
   renderer.backendState.resizeClearColorSet = false
   renderer.configureTransparentPresentation(window)
   when UseOpenGlFallback and (UseMetalBackend or UseVulkanBackend):
@@ -442,6 +490,7 @@ proc setupBackend*(renderer: FigRenderer, window: Window) =
         renderer.backendState.metalLayer =
           attachMetalLayer(window, renderer.ctx.metalDevice())
         renderer.ctx.setPresentLayer(renderer.backendState.metalLayer.layer)
+        renderer.backendState.presentationReady = true
       except CatchableError as exc:
         when UseOpenGlFallback:
           renderer.useOpenGlFallback(exc.msg)
@@ -495,6 +544,7 @@ proc setupBackend*(renderer: FigRenderer, window: Window) =
             ValueError,
             "Vulkan present target unavailable for this siwin window (Wayland/X11 mismatch)",
           )
+        renderer.backendState.presentationReady = true
       except CatchableError as exc:
         when UseOpenGlFallback:
           renderer.useOpenGlFallback(exc.msg)
@@ -542,5 +592,10 @@ proc renderFrame*(
     else:
       renderer.syncResizeBackgroundColor(clearColor)
   figrender.renderFrame(
-    renderer, nodes, frameSize, clearMain = clearMain, clearColor = clearColor
+    renderer,
+    nodes,
+    frameSize,
+    clearMain = clearMain,
+    clearColor = clearColor,
+    allowOpenGlFallback = not renderer.backendState.dedicatedRender,
   )

--- a/src/figdraw/windowing/siwinshim.nim
+++ b/src/figdraw/windowing/siwinshim.nim
@@ -337,15 +337,24 @@ when (UseMetalBackend or UseVulkanBackend) and defined(macosx):
     ## Controls CAMetalLayer opacity without exposing Objective-C details.
     siwinmetal.setOpaque(handle, opaque)
 
-type SiwinRenderBackend* = object
-  ## Opaque per-window backend state used by siwin + FigDraw integration.
-  window*: Window
-  resizeClearColor: Color
-  resizeClearColorSet: bool
-  when UseMetalBackend and defined(macosx):
-    metalLayer*: MetalLayerHandle
-  when UseVulkanBackend and defined(macosx):
-    vulkanMetalLayer*: MetalLayerHandle
+type
+  SiwinRenderBackend* = object
+    ## Opaque per-window backend state used by siwin + FigDraw integration.
+    window*: Window
+    dedicatedRender*: bool
+    resizeClearColor: Color
+    resizeClearColorSet: bool
+    when UseMetalBackend and defined(macosx):
+      metalLayer*: MetalLayerHandle
+    when UseVulkanBackend and defined(macosx):
+      vulkanMetalLayer*: MetalLayerHandle
+
+  SiwinPresentationTarget* = object
+    ## Main-thread-owned presentation state for a renderer that encodes frames
+    ## on another thread. The renderer retains its own copy of the Metal layer;
+    ## this value exists solely so the window host can keep its geometry current.
+    when UseMetalBackend and defined(macosx):
+      metalLayer*: MetalLayerHandle
 
 when defined(macosx):
   proc setOpaque(window: NSWindow, opaque: BOOL) {.objc: "setOpaque:".}
@@ -387,6 +396,27 @@ proc configureTransparentPresentation*(
     when UseVulkanBackend:
       if not renderer.backendState.vulkanMetalLayer.layer.isNil:
         renderer.backendState.vulkanMetalLayer.setOpaque(false)
+
+proc presentationTarget*(
+    renderer: FigRenderer[SiwinRenderBackend]
+): SiwinPresentationTarget =
+  when UseMetalBackend and defined(macosx):
+    result.metalLayer = renderer.backendState.metalLayer
+
+proc updatePresentationTarget*(target: SiwinPresentationTarget, window: Window) =
+  ## Update the native layer from the thread which owns the window. Rendering
+  ## may subsequently acquire its drawable and encode commands elsewhere.
+  when UseMetalBackend and defined(macosx):
+    if not target.metalLayer.layer.isNil and not window.isNil:
+      target.metalLayer.updateMetalLayer(window)
+
+proc useDedicatedRenderThread*(renderer: FigRenderer[SiwinRenderBackend]) =
+  ## Marks this renderer as owned by a dedicated render thread after the window
+  ## thread has attached and configured its presentation target. Do not retain
+  ## the native window across the ownership boundary: its lifetime remains on
+  ## the platform thread.
+  renderer.backendState.dedicatedRender = true
+  renderer.backendState.window = nil
 
 proc setupBackend*(renderer: FigRenderer, window: Window) =
   ## One-time backend hookup between a siwin window and FigDraw renderer.
@@ -481,11 +511,11 @@ proc beginFrame*(renderer: FigRenderer[SiwinRenderBackend]) =
         renderer.backendState.window.makeCurrent()
       discard renderer.applyRuntimeBackendOverride()
   when UseMetalBackend and defined(macosx):
-    if renderer.backendKind() == rbMetal:
+    if not renderer.backendState.dedicatedRender and renderer.backendKind() == rbMetal:
       let window = renderer.backendState.window
       renderer.backendState.metalLayer.updateMetalLayer(window)
   when UseVulkanBackend and defined(macosx):
-    if renderer.backendKind() == rbVulkan:
+    if not renderer.backendState.dedicatedRender and renderer.backendKind() == rbVulkan:
       let window = renderer.backendState.window
       renderer.backendState.vulkanMetalLayer.updateMetalLayer(window)
   when NeedSiwinOpenGLContext:
@@ -506,7 +536,11 @@ proc renderFrame*(
 ) =
   ## Renders a frame and uses its clear color for uncovered resize areas.
   if clearMain:
-    renderer.syncResizeBackgroundColor(clearColor)
+    if renderer.backendState.dedicatedRender:
+      renderer.backendState.resizeClearColor = clearColor
+      renderer.backendState.resizeClearColorSet = true
+    else:
+      renderer.syncResizeBackgroundColor(clearColor)
   figrender.renderFrame(
     renderer, nodes, frameSize, clearMain = clearMain, clearColor = clearColor
   )

--- a/tests/tsiwin_dedicated_render.nim
+++ b/tests/tsiwin_dedicated_render.nim
@@ -1,0 +1,55 @@
+import std/unittest
+
+import figdraw
+import figdraw/figrender
+import figdraw/windowing/siwinshim
+
+type FailingContext = ref object of BackendContext
+  kindValue: RendererBackendKind
+
+method kind(ctx: FailingContext): RendererBackendKind =
+  ctx.kindValue
+
+method beginFrame(
+    ctx: FailingContext, frameSize: Vec2, clearMain: bool, clearMainColor: Color
+) =
+  discard ctx
+  discard frameSize
+  discard clearMain
+  discard clearMainColor
+  raise newException(ValueError, "preferred backend failed")
+
+suite "siwin dedicated rendering":
+  test "reports platform backend support":
+    check not backendSupportsDedicatedRenderThread(rbOpenGL)
+    when UseMetalBackend and defined(macosx):
+      check backendSupportsDedicatedRenderThread(rbMetal)
+    else:
+      check not backendSupportsDedicatedRenderThread(rbMetal)
+    when UseVulkanBackend:
+      check backendSupportsDedicatedRenderThread(rbVulkan)
+    else:
+      check not backendSupportsDedicatedRenderThread(rbVulkan)
+
+  test "requires a configured presentation target":
+    let renderer = newFigRenderer(
+      FailingContext(kindValue: PreferredBackendKind), SiwinRenderBackend()
+    )
+    check not renderer.supportsDedicatedRenderThread()
+    expect ValueError:
+      renderer.useDedicatedRenderThread()
+    check not renderer.backendState.dedicatedRender
+
+  test "dedicated rendering does not fall back to window-bound OpenGL":
+    when UseOpenGlFallback and (UseMetalBackend or UseVulkanBackend):
+      let
+        context = FailingContext(kindValue: PreferredBackendKind)
+        renderer = newFigRenderer(context, SiwinRenderBackend())
+      var renders = newRenders()
+      expect ValueError:
+        figrender.renderFrame(
+          renderer, renders, vec2(64, 64), allowOpenGlFallback = false
+        )
+      check renderer.ctx == context
+    else:
+      skip()

--- a/tests/tsiwin_resize_presentation.nim
+++ b/tests/tsiwin_resize_presentation.nim
@@ -62,8 +62,16 @@ suite "siwin resize presentation":
           size = ivec2(320, 220), title = "figdraw resize presentation test"
         )
       try:
+        check not backendSupportsDedicatedRenderThread(rbOpenGL)
+        check not renderer.supportsDedicatedRenderThread()
         renderer.setupBackend(window)
+        check renderer.supportsDedicatedRenderThread()
+        let target = renderer.presentationTarget()
+        target.updatePresentationTarget(window)
         renderer.checkLayerPolicy(window)
+        renderer.useDedicatedRenderThread()
+        check renderer.backendState.dedicatedRender
+        check renderer.backendState.window.isNil
       finally:
         if window.opened:
           window.close()


### PR DESCRIPTION
## Summary
- add a presentation target that can be captured on the platform thread and consumed by a dedicated renderer
- avoid renderer reads of the native window when using that target
- expose dedicated-render-thread setup without transferring native-window ownership

## Verification
- exercised through Merenda tests and the example-bundle compilation