### PR TITLE
Update native dynlib APIs

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -177,40 +177,26 @@ jobs:
         ls -la /usr/share/vulkan/icd.d || true
         vulkaninfo --summary || true
 
-    - name: Install GrabNim
-      if: runner.os != 'Windows'
-      run: |
-        curl -fsSL https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh
-        echo "$HOME/.local/share/grabnim/current/bin" >> $GITHUB_PATH
-        echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-    - name: Install Nim
-      if: runner.os != 'Windows'
-      run: |
-        grabnim ${{ matrix.nimversion }}
-        nim -v
-
-    - name: Install Nim (Windows)
-      if: runner.os == 'Windows'
-      uses: jiro4989/setup-nim-action@v2
-      with:
-        nim-version: ${{ matrix.nimversion }}
-
     - name: Install Atlas
-      run: curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | bash -
-
-    - name: Versions
       run: |
-        echo "Nim:: "
-        nim -v
-        echo "Nimble:: "
+        curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | bash -
+        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+
+    - name: Atlas version
+      run: |
         atlas -v
 
     - name: Cache packages
       uses: actions/cache@v3
       with:
         path: deps/
-        key: ${{ runner.os }}-${{ matrix.display }}-${{ matrix.renderer }}-${{ hashFiles('figdraw.nimble') }}
+        key: ${{ runner.os }}-${{ matrix.display }}-${{ matrix.renderer }}-nim${{ matrix.nimversion }}-${{ hashFiles('figdraw.nimble') }}
+
+    - name: Setup Nim environment
+      run: atlas --binary --github-path env ${{ matrix.nimversion }}
+
+    - name: Nim version
+      run: nim -v
 
     - name: Install Deps
       run: atlas install -t:8 --features:windy,sdl2,siwin,harfbuzz
@@ -321,61 +307,4 @@ jobs:
           ${{ runner.temp }}/weston.log
         if-no-files-found: ignore
 
-  native-dynlib:
-    name: ubuntu-24.04-native-dynlib-devel
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Install native build dependencies
-      timeout-minutes: 15
-      run: |
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-          pkg-config \
-          libx11-xcb-dev \
-          libxcb1-dev \
-          libxcursor-dev \
-          libxkbcommon-dev \
-          libxrender-dev \
-          libwayland-dev \
-          libwayland-egl-backend-dev \
-          libgl1-mesa-dev \
-          libgles2-mesa-dev \
-          libegl1-mesa-dev
-
-    - name: Install Nim devel snapshot
-      env:
-        NIM_DEVEL_TAG: 2026-07-21-devel-adda34bcb84fec12e92be74181256a9413e741b0
-        NIM_DEVEL_ARCHIVE: nim-2.3.1-linux_x64.tar.xz
-        NIM_DEVEL_SHA256: f987585a2772ef9a3d16dcbd92b47db2bfbd509dabd019d2075987fa9270073d
-      run: |
-        NIM_DEVEL_DIR="${RUNNER_TEMP}/nim-devel"
-        NIM_DEVEL_PATH="${RUNNER_TEMP}/${NIM_DEVEL_ARCHIVE}"
-        curl -fsSL \
-          "https://github.com/nim-lang/nightlies/releases/download/${NIM_DEVEL_TAG}/${NIM_DEVEL_ARCHIVE}" \
-          -o "${NIM_DEVEL_PATH}"
-        echo "${NIM_DEVEL_SHA256}  ${NIM_DEVEL_PATH}" | sha256sum --check
-        mkdir -p "${NIM_DEVEL_DIR}"
-        tar -xJf "${NIM_DEVEL_PATH}" --strip-components=1 -C "${NIM_DEVEL_DIR}"
-        echo "${NIM_DEVEL_DIR}/bin" >> "$GITHUB_PATH"
-        "${NIM_DEVEL_DIR}/bin/nim" -v
-
-    - name: Install Atlas
-      run: curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | bash -
-
-    - name: Cache native packages
-      uses: actions/cache@v3
-      with:
-        path: deps/
-        key: ${{ runner.os }}-native-dynlib-devel-${{ hashFiles('figdraw.nimble') }}
-
-    - name: Install native dependencies
-      run: atlas install -t:8 --features:siwin,sharedlib
-
-    - name: Build native dynlib
-      run: |
-        nim -v
-        nim native_dynlib
-        test -f bin/figdraw_native_abi.nim
-        test -f bin/libfigdraw_native.so
+  # Native dynlib CI is temporarily disabled until Atlas can pin a historical devel build.

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -177,6 +177,13 @@ jobs:
         ls -la /usr/share/vulkan/icd.d || true
         vulkaninfo --summary || true
 
+    # Atlas's Windows release currently needs the OpenSSL runtime bundled by Nim.
+    - name: Install Nim bootstrap (Windows)
+      if: runner.os == 'Windows'
+      uses: jiro4989/setup-nim-action@v2
+      with:
+        nim-version: ${{ matrix.nimversion }}
+
     - name: Install Atlas
       run: |
         curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | bash -
@@ -196,7 +203,9 @@ jobs:
       run: atlas --binary --github-path env ${{ matrix.nimversion }}
 
     - name: Nim version
-      run: nim -v
+      run: |
+        command -v nim
+        nim -v
 
     - name: Install Deps
       run: atlas install -t:8 --features:windy,sdl2,siwin,harfbuzz

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -344,18 +344,22 @@ jobs:
           libgles2-mesa-dev \
           libegl1-mesa-dev
 
-    - name: Install GrabNim
+    - name: Install Nim devel snapshot
+      env:
+        NIM_DEVEL_TAG: 2026-07-21-devel-adda34bcb84fec12e92be74181256a9413e741b0
+        NIM_DEVEL_ARCHIVE: nim-2.3.1-linux_x64.tar.xz
+        NIM_DEVEL_SHA256: f987585a2772ef9a3d16dcbd92b47db2bfbd509dabd019d2075987fa9270073d
       run: |
-        curl -fsSL https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh
-        echo "$HOME/.local/share/grabnim/current/bin" >> "$GITHUB_PATH"
-        echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-
-    - name: Install Nim devel
-      run: |
-        grabnim devel
-        eval "$(grabnim use devel)"
-        nim -v
-        echo "$(grabnim path devel)/bin" >> "$GITHUB_PATH"
+        NIM_DEVEL_DIR="${RUNNER_TEMP}/nim-devel"
+        NIM_DEVEL_PATH="${RUNNER_TEMP}/${NIM_DEVEL_ARCHIVE}"
+        curl -fsSL \
+          "https://github.com/nim-lang/nightlies/releases/download/${NIM_DEVEL_TAG}/${NIM_DEVEL_ARCHIVE}" \
+          -o "${NIM_DEVEL_PATH}"
+        echo "${NIM_DEVEL_SHA256}  ${NIM_DEVEL_PATH}" | sha256sum --check
+        mkdir -p "${NIM_DEVEL_DIR}"
+        tar -xJf "${NIM_DEVEL_PATH}" --strip-components=1 -C "${NIM_DEVEL_DIR}"
+        echo "${NIM_DEVEL_DIR}/bin" >> "$GITHUB_PATH"
+        "${NIM_DEVEL_DIR}/bin/nim" -v
 
     - name: Install Atlas
       run: curl -fsSL https://raw.githubusercontent.com/nim-lang/atlas/HEAD/install.sh | bash -

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -197,10 +197,15 @@ jobs:
       uses: actions/cache@v3
       with:
         path: deps/
-        key: ${{ runner.os }}-${{ matrix.display }}-${{ matrix.renderer }}-nim${{ matrix.nimversion }}-${{ hashFiles('figdraw.nimble') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.display }}-${{ matrix.renderer }}-nim${{ matrix.nimversion }}-${{ hashFiles('figdraw.nimble') }}
 
     - name: Setup Nim environment
+      if: runner.os != 'macOS'
       run: atlas --binary --github-path env ${{ matrix.nimversion }}
+
+    - name: Setup native Nim environment (macOS)
+      if: runner.os == 'macOS'
+      run: atlas --source --github-path env ${{ matrix.nimversion }}
 
     - name: Nim version
       run: |

--- a/config.nims
+++ b/config.nims
@@ -184,7 +184,7 @@ when defined(feature.figdraw.sharedlib):
     backend = nativeBackend,
   )
   nativeBuild.nimArgs =
-    @["--mm:orc", "-d:useMalloc", "-d:release", "--path:src", "--path:deps/siwin/src"]
+    @["--mm:arc", "-d:useMalloc", "-d:release", "--path:src", "--path:deps/siwin/src"]
   nativeBuild.libraryNameStrdefine = true
   when defined(macosx):
     nativeBuild.linkerArgs =

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -1,4 +1,4 @@
-version = "0.35.1"
+version = "0.35.2"
 author = "Jaremy Creechley"
 description = "UI Engine for Nim"
 license = "MIT"

--- a/src/figdraw/bindings/native_bindings.nim
+++ b/src/figdraw/bindings/native_bindings.nim
@@ -16,16 +16,27 @@ import figdraw/utils/drawutils
 import figdraw/windowing/siwinshim
 
 type
+  NativeCloseCallback = proc(context: pointer) {.cdecl.}
   NativeResizeCallback =
     proc(context: pointer, width, height: int32, initial: bool) {.cdecl.}
   NativeRenderCallback = proc(context: pointer) {.cdecl.}
+  NativeWindowMoveCallback = proc(context: pointer, x, y: int32) {.cdecl.}
+  NativeMouseMoveCallback = proc(context: pointer, x, y: float32, kind: uint8) {.cdecl.}
+  NativeMouseButtonCallback =
+    proc(context: pointer, button: MouseButton, pressed, generated: bool) {.cdecl.}
+  NativeScrollCallback =
+    proc(context: pointer, delta, deltaX: float, device: uint8) {.cdecl.}
   NativeKeyCallback = proc(
     context: pointer, key: Key, pressed, repeated, generated: bool, modifierMask: uint8
   ) {.cdecl.}
   NativeTextInputCallback =
     proc(context, text: pointer, textLen: int, repeated: bool) {.cdecl.}
+  NativeStateBoolChangedCallback =
+    proc(context: pointer, value: bool, kind: uint8, isExternal: bool) {.cdecl.}
+  NativePopupCallback = proc(context: pointer, reason: uint8) {.cdecl.}
 
   PopupConstraintAdjustments* = set[PopupConstraintAdjustment]
+  WindowVisualCapabilities* = set[WindowVisualCapability]
   FigFlagSet* = set[FigFlags]
   Vec2s* = seq[Vec2]
   Figs* = seq[Fig]
@@ -57,6 +68,9 @@ type
   NativePoint* = object
     x*, y*: float32
 
+  NativeWindowVisualRegion* = object
+    x*, y*, width*, height*: int32
+
   NativePopupPlacement* = object
     anchorX*, anchorY*: int32
     anchorWidth*, anchorHeight*: int32
@@ -78,10 +92,10 @@ type
     autoScale: bool
     title: string
 
-proc systemFontDirs*(): seq[string] =
+proc systemFontDirs*(): Strings =
   systemfonts.systemFontDirs()
 
-proc systemFontFiles*(): seq[string] =
+proc systemFontFiles*(): Strings =
   systemfonts.systemFontFiles()
 
 proc textBackend*(): string =
@@ -228,6 +242,13 @@ proc typeset*(
 ): GlyphArrangement =
   fontutils.typeset(box, spans, hAlign, vAlign, minContent, wrap)
 
+proc placeStyledGlyphs*(
+    style: FontStyle,
+    glyphs: openArray[(Rune, Vec2)],
+    origin: GlyphOrigin = GlyphTopLeft,
+): GlyphArrangement =
+  fontutils.placeGlyphs(style, glyphs, origin)
+
 proc newFigSiwinApp*(
     width, height: int32,
     title: string,
@@ -309,9 +330,17 @@ func nativeModifierMask(modifiers: set[ModifierKey]): uint8 =
 
 proc siwinSetEventCallbacks*(
     appHandle: NativeSiwinApp,
-    context, resizeCallback, renderCallback, keyCallback, textInputCallback: pointer,
+    context, closeCallback, resizeCallback, renderCallback, windowMoveCallback,
+      mouseMoveCallback, mouseButtonCallback, scrollCallback, keyCallback,
+      textInputCallback, stateBoolChangedCallback, popupCallback: pointer,
 ) =
   let app = siwinApp(appHandle)
+  if closeCallback == nil:
+    app.window.eventsHandler.onClose = nil
+  else:
+    app.window.eventsHandler.onClose = proc(e: CloseEvent) =
+      discard e
+      cast[NativeCloseCallback](closeCallback)(context)
   if resizeCallback == nil:
     app.window.eventsHandler.onResize = nil
   else:
@@ -321,7 +350,34 @@ proc siwinSetEventCallbacks*(
     app.window.eventsHandler.onRender = nil
   else:
     app.window.eventsHandler.onRender = proc(e: RenderEvent) =
+      discard e
       cast[NativeRenderCallback](renderCallback)(context)
+  if windowMoveCallback == nil:
+    app.window.eventsHandler.onWindowMove = nil
+  else:
+    app.window.eventsHandler.onWindowMove = proc(e: WindowMoveEvent) =
+      cast[NativeWindowMoveCallback](windowMoveCallback)(context, e.pos.x, e.pos.y)
+  if mouseMoveCallback == nil:
+    app.window.eventsHandler.onMouseMove = nil
+  else:
+    app.window.eventsHandler.onMouseMove = proc(e: MouseMoveEvent) =
+      cast[NativeMouseMoveCallback](mouseMoveCallback)(
+        context, e.pos.x, e.pos.y, e.kind.ord.uint8
+      )
+  if mouseButtonCallback == nil:
+    app.window.eventsHandler.onMouseButton = nil
+  else:
+    app.window.eventsHandler.onMouseButton = proc(e: MouseButtonEvent) =
+      cast[NativeMouseButtonCallback](mouseButtonCallback)(
+        context, e.button, e.pressed, e.generated
+      )
+  if scrollCallback == nil:
+    app.window.eventsHandler.onScroll = nil
+  else:
+    app.window.eventsHandler.onScroll = proc(e: ScrollEvent) =
+      cast[NativeScrollCallback](scrollCallback)(
+        context, e.delta, e.deltaX, e.device.ord.uint8
+      )
   if keyCallback == nil:
     app.window.eventsHandler.onKey = nil
   else:
@@ -346,6 +402,18 @@ proc siwinSetEventCallbacks*(
       cast[NativeTextInputCallback](textInputCallback)(
         context, text, e.text.len, e.repeated
       )
+  if stateBoolChangedCallback == nil:
+    app.window.eventsHandler.onStateBoolChanged = nil
+  else:
+    app.window.eventsHandler.onStateBoolChanged = proc(e: StateBoolChangedEvent) =
+      cast[NativeStateBoolChangedCallback](stateBoolChangedCallback)(
+        context, e.value, e.kind.ord.uint8, e.isExternal
+      )
+  if popupCallback == nil:
+    app.window.eventsHandler.onPopupDone = nil
+  else:
+    app.window.eventsHandler.onPopupDone = proc(e: PopupEvent) =
+      cast[NativePopupCallback](popupCallback)(context, e.reason.ord.uint8)
 
 proc step*(appHandle: NativeSiwinApp) =
   siwinApp(appHandle).window.step()
@@ -436,6 +504,9 @@ proc siwinIsTransparent*(appHandle: NativeSiwinApp): bool =
 
 proc siwinSetFrameless*(appHandle: NativeSiwinApp, frameless: bool) =
   siwinApp(appHandle).window.frameless = frameless
+
+proc siwinNativeWindowKey*(appHandle: NativeSiwinApp): pointer =
+  cast[pointer](siwinApp(appHandle).window)
 
 proc siwinMinSize*(appHandle: NativeSiwinApp): NativeWindowSize =
   let size = siwinApp(appHandle).window.minSize
@@ -539,10 +610,10 @@ proc siwinClipboardText*(appHandle: NativeSiwinApp): string =
 proc siwinSetClipboardText*(appHandle: NativeSiwinApp, value: string) =
   siwinApp(appHandle).window.clipboard.text = value
 
-proc siwinClipboardFiles*(appHandle: NativeSiwinApp): seq[string] =
+proc siwinClipboardFiles*(appHandle: NativeSiwinApp): Strings =
   siwinApp(appHandle).window.clipboard.files
 
-proc siwinSetClipboardFiles*(appHandle: NativeSiwinApp, value: seq[string]) =
+proc siwinSetClipboardFiles*(appHandle: NativeSiwinApp, value: Strings) =
   siwinApp(appHandle).window.clipboard.files = value
 
 proc siwinClipboardData*(appHandle: NativeSiwinApp, mimeType: string): string =
@@ -550,6 +621,9 @@ proc siwinClipboardData*(appHandle: NativeSiwinApp, mimeType: string): string =
 
 proc siwinSetClipboardData*(appHandle: NativeSiwinApp, mimeType, value: string) =
   siwinApp(appHandle).window.clipboard[mimeType] = value
+
+proc siwinClipboardMimeTypes*(appHandle: NativeSiwinApp): Strings =
+  siwinApp(appHandle).window.clipboard.availableMimeTypes
 
 proc siwinUiScale*(appHandle: NativeSiwinApp): float32 =
   siwinApp(appHandle).window.uiScale()
@@ -572,6 +646,28 @@ proc siwinRepositionPopup*(appHandle: NativeSiwinApp, placement: NativePopupPlac
 proc siwinRefreshUiScale*(appHandle: NativeSiwinApp) =
   let app = siwinApp(appHandle)
   app.window.refreshUiScale(app.autoScale)
+
+proc siwinVisualCapabilities*(appHandle: NativeSiwinApp): WindowVisualCapabilities =
+  siwinApp(appHandle).window.visualCapabilities()
+
+proc siwinTrySetBackdrop*(
+    appHandle: NativeSiwinApp,
+    kind: WindowBackdropKind,
+    material: WindowBackdropMaterial,
+    regions: openArray[NativeWindowVisualRegion],
+): bool =
+  var nativeRegions = newSeqOfCap[WindowVisualRegion](regions.len)
+  for region in regions:
+    nativeRegions.add WindowVisualRegion(
+      pos: ivec2(region.x, region.y), size: ivec2(region.width, region.height)
+    )
+  let config =
+    case kind
+    of wbkNone, wbkBlur:
+      WindowBackdropConfig(kind: kind, regions: nativeRegions)
+    of wbkMaterial:
+      WindowBackdropConfig(kind: kind, material: material, regions: nativeRegions)
+  siwinApp(appHandle).window.trySetBackdrop(config)
 
 proc siwinBackendName*(appHandle: NativeSiwinApp): string =
   siwinApp(appHandle).renderer.siwinBackendName()

--- a/src/figdraw/bindings/native_dynlib.json
+++ b/src/figdraw/bindings/native_dynlib.json
@@ -8,7 +8,10 @@
     {"source": "../common/filltypes.nim", "name": "fill"},
     {"source": "../common/filltypes.nim", "name": "linear"},
     {"source": "../common/shared.nim", "name": "setFigDataDir"},
-    {"source": "../common/typefaces.nim", "name": "loadTypeface"}
+    {"source": "../common/typefaces.nim", "name": "loadTypeface"},
+    {"source": "../utils/drawutils.nim", "name": "figDashedRoundedRectBorder"},
+    {"source": "../utils/drawutils.nim", "name": "figDottedRoundedRectBorder"},
+    {"source": "../utils/drawutils.nim", "name": "figRoundedRectBorder"}
   ],
   "requireMatches": true
 }

--- a/src/figdraw/dynlib.nim
+++ b/src/figdraw/dynlib.nim
@@ -29,7 +29,32 @@ const figdrawTextBackend* {.strdefine.} =
 type
   ImageRef* = ImageId
 
+  DirectionCorners* = enum
+    dcTopLeft
+    dcTopRight
+    dcBottomLeft
+    dcBottomRight
+
+  CornerRadii2D*[T] = object
+    x*, y*: array[DirectionCorners, T]
+
   SiwinRenderBackend* = object
+
+  SiwinPresentationTarget* = object
+
+  WindowVisualRegion* = object
+    pos*: vmath.IVec2
+    size*: vmath.IVec2
+
+  WindowBackdropConfig* = object
+    regions*: seq[WindowVisualRegion]
+    case kind*: WindowBackdropKind
+    of wbkMaterial:
+      material*: WindowBackdropMaterial
+    of wbkNone, wbkBlur:
+      discard
+
+  WindowVisualEffectError* = object of CatchableError
 
   Mouse* = object
     pos*: vmath.Vec2
@@ -47,13 +72,7 @@ type
     handle: NativeSiwinApp
     eventsHandler*: WindowEventsHandler
     clipboard*: Clipboard
-    wasOpened: bool
-    pollReady: bool
-    lastMouse: Mouse
-    lastKeyboard: Keyboard
-    lastPos: vmath.IVec2
-    lastFocused, lastFullscreen, lastMaximized, lastFrameless: bool
-    lastPopupOpen: bool
+    backdropConfig: WindowBackdropConfig
     autoScale: bool
     width, height: int32
     titleText: string
@@ -164,6 +183,10 @@ type
     onStateBoolChanged*: proc(e: StateBoolChangedEvent)
     onPopupDone*: proc(e: PopupEvent)
 
+converter nilToImageRef*(value: typeof(nil)): ImageRef =
+  discard value
+  default(ImageRef)
+
 proc dispatchNativeResize(
     context: pointer, width, height: int32, initial: bool
 ) {.cdecl.} =
@@ -173,10 +196,51 @@ proc dispatchNativeResize(
       ResizeEvent(window: window, size: vmath.ivec2(width, height), initial: initial)
     )
 
+proc dispatchNativeClose(context: pointer) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onClose != nil:
+    window.eventsHandler.onClose(CloseEvent(window: window))
+
 proc dispatchNativeRender(context: pointer) {.cdecl.} =
   let window = cast[Window](context)
   if window.eventsHandler.onRender != nil:
     window.eventsHandler.onRender(RenderEvent(window: window))
+
+proc dispatchNativeWindowMove(context: pointer, x, y: int32) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onWindowMove != nil:
+    window.eventsHandler.onWindowMove(
+      WindowMoveEvent(window: window, pos: vmath.ivec2(x, y))
+    )
+
+proc dispatchNativeMouseMove(context: pointer, x, y: float32, kind: uint8) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onMouseMove != nil:
+    window.eventsHandler.onMouseMove(
+      MouseMoveEvent(window: window, pos: vmath.vec2(x, y), kind: MouseMoveKind(kind))
+    )
+
+proc dispatchNativeMouseButton(
+    context: pointer, button: MouseButton, pressed, generated: bool
+) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onMouseButton != nil:
+    window.eventsHandler.onMouseButton(
+      MouseButtonEvent(
+        window: window, button: button, pressed: pressed, generated: generated
+      )
+    )
+
+proc dispatchNativeScroll(
+    context: pointer, delta, deltaX: float, device: uint8
+) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onScroll != nil:
+    window.eventsHandler.onScroll(
+      ScrollEvent(
+        window: window, delta: delta, deltaX: deltaX, device: ScrollDeviceKind(device)
+      )
+    )
 
 proc dispatchNativeKey(
     context: pointer, key: Key, pressed, repeated, generated: bool, modifierMask: uint8
@@ -210,14 +274,42 @@ proc dispatchNativeTextInput(
       TextInputEvent(window: window, text: value, repeated: repeated)
     )
 
+proc dispatchNativeStateBoolChanged(
+    context: pointer, value: bool, kind: uint8, isExternal: bool
+) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onStateBoolChanged != nil:
+    window.eventsHandler.onStateBoolChanged(
+      StateBoolChangedEvent(
+        window: window,
+        value: value,
+        kind: StateBoolChangedEventKind(kind),
+        isExternal: isExternal,
+      )
+    )
+
+proc dispatchNativePopup(context: pointer, reason: uint8) {.cdecl.} =
+  let window = cast[Window](context)
+  if window.eventsHandler.onPopupDone != nil:
+    window.eventsHandler.onPopupDone(
+      PopupEvent(window: window, reason: PopupDismissReason(reason))
+    )
+
 proc installEventCallbacks(window: Window) =
   siwinSetEventCallbacks(
     window.handle,
     cast[pointer](window),
+    cast[pointer](dispatchNativeClose),
     cast[pointer](dispatchNativeResize),
     cast[pointer](dispatchNativeRender),
+    cast[pointer](dispatchNativeWindowMove),
+    cast[pointer](dispatchNativeMouseMove),
+    cast[pointer](dispatchNativeMouseButton),
+    cast[pointer](dispatchNativeScroll),
     cast[pointer](dispatchNativeKey),
     cast[pointer](dispatchNativeTextInput),
+    cast[pointer](dispatchNativeStateBoolChanged),
+    cast[pointer](dispatchNativePopup),
   )
 
 converter toNativeRect*(value: bumpy.Rect): figdraw_native_abi.Rect {.inline.} =
@@ -287,6 +379,16 @@ proc drawableBezier*(
   for control in controls:
     result.controls.add control.toNativeVec2()
 
+proc drawableEllipse*(center, radii: vmath.Vec2): DrawableOp {.inline.} =
+  DrawableOp(
+    kind: dkEllipse,
+    ellipseCenter: center.toNativeVec2(),
+    ellipseRadii: radii.toNativeVec2(),
+  )
+
+proc drawableEllipse*(x, y, radiusX, radiusY: float32): DrawableOp {.inline.} =
+  drawableEllipse(vmath.vec2(x, y), vmath.vec2(radiusX, radiusY))
+
 proc cornerToU16(v: SomeNumber): uint16 {.inline.} =
   when v is SomeFloat:
     if v <= 0:
@@ -303,11 +405,36 @@ proc cornerToU16(v: SomeNumber): uint16 {.inline.} =
 
 converter toCornerRadii*[T: SomeNumber](a: array[4, T]): CornerRadii =
   for i in 0 ..< 4:
-    result[DirectionCorners(i)] = cornerToU16(a[i])
+    result[i] = cornerToU16(a[i])
 
 converter toCornerRadii*[T: SomeNumber](a: array[DirectionCorners, T]): CornerRadii =
   for c in DirectionCorners:
-    result[c] = cornerToU16(a[c])
+    result[c.ord] = cornerToU16(a[c])
+
+func initCornerRadii2D*[T](radii: array[DirectionCorners, T]): CornerRadii2D[T] =
+  CornerRadii2D[T](x: radii, y: radii)
+
+converter toCornerRadii2D*[T](radii: array[DirectionCorners, T]): CornerRadii2D[T] =
+  initCornerRadii2D(radii)
+
+func initCornerRadii2D*[T](x, y: array[DirectionCorners, T]): CornerRadii2D[T] =
+  CornerRadii2D[T](x: x, y: y)
+
+func isCircular*[T](radii: CornerRadii2D[T]): bool =
+  for corner in DirectionCorners:
+    if radii.x[corner] != radii.y[corner]:
+      return false
+  true
+
+proc initWindowBackdrop*(
+    regions: openArray[WindowVisualRegion] = []
+): WindowBackdropConfig =
+  WindowBackdropConfig(kind: wbkBlur, regions: @regions)
+
+proc initWindowBackdrop*(
+    material: WindowBackdropMaterial, regions: openArray[WindowVisualRegion] = []
+): WindowBackdropConfig =
+  WindowBackdropConfig(kind: wbkMaterial, material: material, regions: @regions)
 
 const
   clearColor* = chroma.color(0, 0, 0, 0)
@@ -375,7 +502,7 @@ proc placeGlyphs*(
     newSeqOfCap[(figdraw_native_abi.Rune, figdraw_native_abi.Vec2)](glyphs.len)
   for (rune, pos) in glyphs:
     nativeGlyphs.add((rune.toNativeRune(), pos.toNativeVec2()))
-  figdraw_native_abi.placeGlyphs(style, nativeGlyphs, origin)
+  figdraw_native_abi.placeStyledGlyphs(style, nativeGlyphs, origin)
 
 template registerStaticTypeface*(
     name: static[string], path: static[string], kind: static[TypeFaceKinds] = TTF
@@ -594,7 +721,10 @@ proc setClipboardData*(clipboard: Clipboard, mimeType, value: string) =
     clipboard.mimeTypes.add mimeType
 
 proc availableMimeTypes*(clipboard: Clipboard): seq[string] =
-  clipboard.mimeTypes
+  result = siwinClipboardMimeTypes(clipboard.window.handle)
+  for mimeType in clipboard.mimeTypes:
+    if mimeType notin result:
+      result.add mimeType
 
 proc setupBackend*(renderer: FigRenderer[SiwinRenderBackend], window: Window) =
   if window.handle.isNil:
@@ -680,6 +810,9 @@ proc pos*(window: Window): vmath.IVec2 =
 proc `pos=`*(window: Window, value: vmath.IVec2) =
   siwinSetWindowPos(window.handle, value.x, value.y)
 
+proc nativeWindowKey*(window: Window): pointer =
+  siwinNativeWindowKey(window.handle)
+
 proc logicalSize*(window: Window): vmath.Vec2 =
   let
     size = window.backingSize()
@@ -689,6 +822,9 @@ proc logicalSize*(window: Window): vmath.Vec2 =
 proc `title=`*(window: Window, value: string) =
   window.titleText = value
   siwinSetTitle(window.handle, value)
+
+proc title*(window: Window): string =
+  siwinTitle(window.handle)
 
 proc visible*(window: Window): bool =
   siwinIsVisible(window.handle)
@@ -732,6 +868,104 @@ proc `frameless=`*(window: Window, value: bool) =
 proc transparent*(window: Window): bool =
   siwinIsTransparent(window.handle)
 
+proc visualCapabilities*(window: Window): set[WindowVisualCapability] =
+  siwinVisualCapabilities(window.handle)
+
+proc supports*(window: Window, capability: WindowVisualCapability): bool =
+  capability in window.visualCapabilities()
+
+proc backdrop*(window: Window): WindowBackdropConfig =
+  window.backdropConfig
+
+proc trySetBackdrop*(window: Window, config: WindowBackdropConfig): bool =
+  var regions = newSeqOfCap[NativeWindowVisualRegion](config.regions.len)
+  for region in config.regions:
+    regions.add NativeWindowVisualRegion(
+      x: region.pos.x, y: region.pos.y, width: region.size.x, height: region.size.y
+    )
+  let material =
+    case config.kind
+    of wbkMaterial: config.material
+    of wbkNone, wbkBlur: wbmDefault
+  result = siwinTrySetBackdrop(window.handle, config.kind, material, regions)
+  if result:
+    window.backdropConfig = config
+
+proc clearBackdrop*(window: Window) =
+  discard window.trySetBackdrop(WindowBackdropConfig(kind: wbkNone))
+
+proc setBackdrop*(window: Window, config: WindowBackdropConfig) =
+  if not window.trySetBackdrop(config):
+    raise WindowVisualEffectError.newException(
+      "window backdrop effect is not supported by this backend or configuration"
+    )
+
+proc minSize*(window: Window): vmath.IVec2 =
+  let size = siwinMinSize(window.handle)
+  vmath.ivec2(size.w, size.h)
+
+proc `minSize=`*(window: Window, value: vmath.IVec2) =
+  siwinSetMinSize(window.handle, value.x, value.y)
+
+proc maxSize*(window: Window): vmath.IVec2 =
+  let size = siwinMaxSize(window.handle)
+  vmath.ivec2(size.w, size.h)
+
+proc `maxSize=`*(window: Window, value: vmath.IVec2) =
+  siwinSetMaxSize(window.handle, value.x, value.y)
+
+proc customTitlebar*(window: Window): bool =
+  siwinUsesCustomTitlebar(window.handle)
+
+proc supportsCustomTitlebar*(window: Window): bool =
+  siwinSupportsCustomTitlebar(window.handle)
+
+proc `customTitlebar=`*(window: Window, value: bool) =
+  siwinSetCustomTitlebar(window.handle, value)
+
+proc setTitleRegion*(window: Window, pos, size: vmath.Vec2) =
+  siwinSetTitleRegion(window.handle, pos.x, pos.y, size.x, size.y)
+
+proc setInputRegion*(window: Window, pos, size: vmath.Vec2) =
+  siwinSetInputRegion(window.handle, pos.x, pos.y, size.x, size.y)
+
+proc setBorderWidth*(window: Window, innerWidth, outerWidth, diagonalSize: float32) =
+  siwinSetBorderWidth(window.handle, innerWidth, outerWidth, diagonalSize)
+
+proc startInteractiveMove*(window: Window, pos: vmath.Vec2) =
+  siwinStartInteractiveMove(window.handle, pos.x, pos.y)
+
+proc startInteractiveResize*(window: Window, edge: Edge, pos: vmath.Vec2) =
+  siwinStartInteractiveResize(window.handle, edge, pos.x, pos.y)
+
+proc showWindowMenu*(window: Window, pos: vmath.Vec2) =
+  siwinShowWindowMenu(window.handle, pos.x, pos.y)
+
+proc `cursor=`*(window: Window, value: BuiltinCursor) =
+  siwinSetBuiltinCursor(window.handle, value)
+
+proc `vsync=`*(window: Window, value: bool) =
+  window.vsync = value
+  siwinSetVsync(window.handle, value)
+
+proc separateTouch*(window: Window): bool =
+  siwinUsesSeparateTouch(window.handle)
+
+proc `separateTouch=`*(window: Window, value: bool) =
+  siwinSetSeparateTouch(window.handle, value)
+
+proc canBecomeKeyWindow*(window: Window): bool =
+  siwinCanBecomeKeyWindow(window.handle)
+
+proc `canBecomeKeyWindow=`*(window: Window, value: bool) =
+  siwinSetCanBecomeKeyWindow(window.handle, value)
+
+proc canBecomeMainWindow*(window: Window): bool =
+  siwinCanBecomeMainWindow(window.handle)
+
+proc `canBecomeMainWindow=`*(window: Window, value: bool) =
+  siwinSetCanBecomeMainWindow(window.handle, value)
+
 proc `icon=`*(window: Window, image: Image) {.inline.} =
   figdraw_native_abi.siwinSetIcon(window.handle, image)
 
@@ -751,16 +985,6 @@ proc close*(window: Window) =
 proc firstStep*(window: Window, makeVisible = true) =
   window.installEventCallbacks()
   firstStep(window.handle, makeVisible)
-  window.wasOpened = window.opened
-  window.lastMouse = window.mouse()
-  window.lastKeyboard = window.keyboard()
-  window.lastPos = window.pos()
-  window.lastFocused = window.focused()
-  window.lastFullscreen = window.fullscreen()
-  window.lastMaximized = window.maximized()
-  window.lastFrameless = window.frameless()
-  window.lastPopupOpen = siwinPopupOpen(window.handle)
-  window.pollReady = true
 
 proc redraw*(window: Window) =
   redraw(window.handle)
@@ -772,81 +996,14 @@ proc step*(window: Window) =
   window.installEventCallbacks()
   step(window.handle)
 
-  let
-    currentMouse = window.mouse()
-    currentKeyboard = window.keyboard()
-    currentPos = window.pos()
-    currentFocused = window.focused()
-    currentFullscreen = window.fullscreen()
-    currentMaximized = window.maximized()
-    currentFrameless = window.frameless()
-    currentPopupOpen = siwinPopupOpen(window.handle)
+proc presentationTarget*(
+    renderer: FigRenderer[SiwinRenderBackend]
+): SiwinPresentationTarget =
+  discard renderer
 
-  if window.pollReady:
-    if currentMouse.pos != window.lastMouse.pos and
-        window.eventsHandler.onMouseMove != nil:
-      window.eventsHandler.onMouseMove(
-        MouseMoveEvent(
-          window: window,
-          pos: currentMouse.pos,
-          kind: if currentMouse.pressed == {}: move else: moveWhileDragging,
-        )
-      )
-
-    if window.eventsHandler.onMouseButton != nil:
-      for button in MouseButton:
-        let
-          wasPressed = button in window.lastMouse.pressed
-          isPressed = button in currentMouse.pressed
-        if wasPressed != isPressed:
-          window.eventsHandler.onMouseButton(
-            MouseButtonEvent(window: window, button: button, pressed: isPressed)
-          )
-
-    if currentPos != window.lastPos and window.eventsHandler.onWindowMove != nil:
-      window.eventsHandler.onWindowMove(
-        WindowMoveEvent(window: window, pos: currentPos)
-      )
-
-    template dispatchState(kindValue, currentValue, previousValue: untyped) =
-      if currentValue != previousValue and window.eventsHandler.onStateBoolChanged != nil:
-        window.eventsHandler.onStateBoolChanged(
-          StateBoolChangedEvent(
-            window: window, value: currentValue, kind: kindValue, isExternal: true
-          )
-        )
-
-    dispatchState(StateBoolChangedEventKind.focus, currentFocused, window.lastFocused)
-    dispatchState(
-      StateBoolChangedEventKind.fullscreen, currentFullscreen, window.lastFullscreen
-    )
-    dispatchState(
-      StateBoolChangedEventKind.maximized, currentMaximized, window.lastMaximized
-    )
-    dispatchState(
-      StateBoolChangedEventKind.frameless, currentFrameless, window.lastFrameless
-    )
-
-    if window.lastPopupOpen and not currentPopupOpen and
-        window.eventsHandler.onPopupDone != nil:
-      window.eventsHandler.onPopupDone(
-        PopupEvent(window: window, reason: pdrCompositorDismissed)
-      )
-
-  window.lastMouse = currentMouse
-  window.lastKeyboard = currentKeyboard
-  window.lastPos = currentPos
-  window.lastFocused = currentFocused
-  window.lastFullscreen = currentFullscreen
-  window.lastMaximized = currentMaximized
-  window.lastFrameless = currentFrameless
-  window.lastPopupOpen = currentPopupOpen
-  window.pollReady = true
-
-  let isOpened = window.opened
-  if window.wasOpened and not isOpened and window.eventsHandler.onClose != nil:
-    window.eventsHandler.onClose(CloseEvent(window: window))
-  window.wasOpened = isOpened
+proc updatePresentationTarget*(target: SiwinPresentationTarget, window: Window) =
+  discard target
+  discard window
 
 proc beginFrame*(renderer: FigRenderer[SiwinRenderBackend]) =
   discard renderer

--- a/tests/tdynlib_api.nim
+++ b/tests/tdynlib_api.nim
@@ -1,0 +1,66 @@
+import std/unittest
+
+when defined(useNativeDynlib):
+  import figdraw/dynlib
+
+suite "native dynlib API":
+  when defined(useNativeDynlib):
+    test "supports elliptical corners and drawable ellipses":
+      let
+        horizontal = [4'u16, 6'u16, 8'u16, 10'u16]
+        vertical = [2'u16, 3'u16, 4'u16, 5'u16]
+        radii = initCornerRadii2D(horizontal, vertical)
+        ellipse = drawableEllipse(vec2(12.0'f32, 18.0'f32), vec2(24.0'f32, 10.0'f32))
+
+      check not radii.isCircular()
+      check initCornerRadii2D(horizontal).isCircular()
+      check ellipse.kind == dkEllipse
+      check ellipse.ellipseCenter.toVec2() == vec2(12.0'f32, 18.0'f32)
+      check ellipse.ellipseRadii.toVec2() == vec2(24.0'f32, 10.0'f32)
+
+      var node = Fig(kind: nkRectangle)
+      node.corners = horizontal
+      node.cornerRadiiY = vertical
+      node.flags.incl NfEllipticalCorners
+      check NfEllipticalCorners in node.flags
+
+    test "provides source-compatible image and backdrop values":
+      var imageRef: ImageRef
+      imageRef = nil
+      check imageRef == default(ImageRef)
+
+      let
+        region = WindowVisualRegion(pos: ivec2(8, 12), size: ivec2(160, 90))
+        blur = initWindowBackdrop([region])
+        material = initWindowBackdrop(wbmSidebar, [region])
+      check blur.kind == wbkBlur
+      check blur.regions == @[region]
+      check material.kind == wbkMaterial
+      check material.material == wbmSidebar
+
+    test "exposes the NimKit Siwin window surface":
+      doAssert compiles(
+        block:
+          var window: Window
+          discard window.nativeWindowKey()
+          discard window.title()
+          window.minSize = ivec2(100, 80)
+          window.maxSize = ivec2(1920, 1080)
+          window.customTitlebar = true
+          window.setTitleRegion(vec2(0, 0), vec2(200, 40))
+          window.setInputRegion(vec2(0, 0), vec2(200, 120))
+          window.setBorderWidth(6, 8, 12)
+          window.startInteractiveMove(vec2(20, 20))
+          window.startInteractiveResize(topLeft, vec2(20, 20))
+          window.showWindowMenu(vec2(20, 20))
+          window.cursor = arrow
+          window.vsync = true
+          window.separateTouch = true
+          window.canBecomeKeyWindow = true
+          window.canBecomeMainWindow = true
+          discard window.visualCapabilities()
+          discard window.trySetBackdrop(WindowBackdropConfig(kind: wbkNone))
+      )
+  else:
+    test "requires useNativeDynlib":
+      skip()


### PR DESCRIPTION
## Summary

- update the native dynlib ABI for elliptical corners, drawable ellipses, and rounded border helpers
- expose the Siwin event and window APIs required by Merenda NimKit
- keep callback and visual-region data ABI-safe across the shared-library boundary
- build the native library with ARC and bump the package version to 0.35.2
- add focused dynlib API coverage

## Testing

- `nim test`
- native dynlib regeneration
- `tests/tdynlib_api.nim` with `useNativeDynlib`
- `tests/tsiwin_redraw.nim` with `useNativeDynlib`
- focused compilation of Merenda NimKit backend and image modules

The SDL2 example remains skipped unless `FIGDRAW_TEST_SDL2=1`, matching the existing test-task behavior.