### PR TITLE
Harden render fragment handles

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -205,7 +205,10 @@ jobs:
 
     - name: Setup native Nim environment (macOS)
       if: runner.os == 'macOS'
-      run: atlas --source --github-path env ${{ matrix.nimversion }}
+      # Atlas 0.15.2 resolves version tags from the wrong working directory in
+      # source mode. An explicit Git ref bypasses that path while retaining a
+      # native arm64 Nim build.
+      run: atlas --source --git-ref=v${{ matrix.nimversion }} --github-path env ${{ matrix.nimversion }}
 
     - name: Nim version
       run: |

--- a/README.md
+++ b/README.md
@@ -522,6 +522,9 @@ Fragments can be moved or reordered without rebuilding their contents. `moveFrag
 fragment beneath a node, while `moveFragmentToRoot` places it in a layer root sequence. Positions
 refer to the final logical slot sequence and count both physical nodes and fragment slots. These
 operations preserve fragment IDs, generations, cursors, and nested attachments.
+For a complete sibling-list reconciliation, use `reorderChildFragments` or
+`reorderRootFragments` instead of issuing one move per sibling. The bulk operations run in one
+linear pass and keep physical node positions fixed while fragment slots exchange order.
 
 Fragment handles and cursors are bound to their owning tree and generation. Operations reject
 foreign, stale, and detached values with `RenderFragmentError`; `handleStatus` can classify a handle

--- a/README.md
+++ b/README.md
@@ -483,9 +483,9 @@ discard renders.addChildren(0.ZLevel, root, menuItems)
 
 ### Fragment-backed render trees
 
-`RenderFragments` adds independently replaceable subtrees without changing the layout or behavior
-of `Renders` and `RenderList`. It provides the same layer/root/child helpers, plus `RenderCursor`
-overloads for inserting nested fragments. Fragment insertion does not copy nodes into the base
+`RenderFragments` adds independently replaceable subtrees without changing the rendering behavior
+of `Renders` and `RenderList`. A fragment is a persistent logical child or layer-root slot whose
+contents can have zero, one, or many roots. Fragment insertion does not copy nodes into the base
 `Renders`, so existing base indexes stay stable:
 
 ```nim
@@ -494,26 +494,37 @@ let root = fragments.addRoot(0.ZLevel, Fig(kind: nkRectangle))
 
 var menu = RenderList()
 discard menu.addRoot(Fig(kind: nkRectangle))
-let menuRoots = fragments.insertChildren(0.ZLevel, root, menu, 0)
+let menuFragment = fragments.attachChildFragment(0.ZLevel, root, 0, menu)
+let menuRoots = fragments.fragmentRoots(menuFragment)
 
 var submenu = RenderList()
 discard submenu.addRoot(Fig(kind: nkRectangle))
-discard fragments.insertChildren(menuRoots[0], submenu, 0)
+discard fragments.attachChildFragment(menuRoots[0], 0, submenu)
 ```
 
-Keep a returned cursor to replace that fragment later. `updateFragment` preserves the fragment's
-position and identity, and returns cursors for the replacement roots:
+Keep the returned handle to replace that fragment later. `replaceFragment` preserves the fragment's
+position and returns its next generation. The handle remains available when the replacement is
+empty, so the same slot can become nonempty again:
 
 ```nim
 var updatedMenu = RenderList()
 discard updatedMenu.addRoot(Fig(kind: nkRectangle))
-let updatedRoots = fragments.updateFragment(menuRoots[0], updatedMenu)
+let updatedMenuFragment = fragments.replaceFragment(menuFragment, updatedMenu)
+let updatedRoots = fragments.fragmentRoots(updatedMenuFragment)
 ```
 
-Use the `RenderFragments` helpers for mutation after wrapping or inserting fragments so its logical
-traversal metadata stays synchronized. `renderRoot` and `renderFrame` accept the `RenderInput` union
-(`Renders | RenderFragments`), so existing whole-tree rendering remains source compatible while a
-fragment-backed tree can be sent through the same renderer entry points.
+Fragment handles and cursors are bound to their owning tree and generation. Operations reject
+foreign, stale, and detached values with `RenderFragmentError`; `handleStatus` can classify a handle
+without mutating the tree. Use `updateNode` for controlled visual changes to an existing node.
+
+`attachRootFragment` adds the same persistent slot behavior to a layer root sequence. `materialize`
+creates an independent monolithic `Renders` copy in logical traversal order for compatibility,
+diagnostics, or transfer to another thread.
+
+`renderRoot` and `renderFrame` accept the `RenderInput` union (`Renders | RenderFragments`), so
+existing whole-tree rendering remains source compatible while a fragment-backed tree can be sent
+through the same renderer entry points. The older `insertChildren` and `updateFragment` cursor APIs
+remain as compatibility wrappers, but new code should retain a `RenderFragmentHandle`.
 
 The animated examples replace the card fragment every frame while leaving the base render tree
 intact:

--- a/README.md
+++ b/README.md
@@ -513,6 +513,16 @@ let updatedMenuFragment = fragments.replaceFragment(menuFragment, updatedMenu)
 let updatedRoots = fragments.fragmentRoots(updatedMenuFragment)
 ```
 
+`replaceFragment` is the safe leaf operation: it rejects a fragment that still owns nested
+fragment attachments. Replace the narrower child fragment when preserving its identity matters.
+Use the explicitly destructive `replaceFragmentSubtree` only when every nested attachment should
+be detached and its handles invalidated.
+
+Fragments can be moved or reordered without rebuilding their contents. `moveFragment` places a
+fragment beneath a node, while `moveFragmentToRoot` places it in a layer root sequence. Positions
+refer to the final logical slot sequence and count both physical nodes and fragment slots. These
+operations preserve fragment IDs, generations, cursors, and nested attachments.
+
 Fragment handles and cursors are bound to their owning tree and generation. Operations reject
 foreign, stale, and detached values with `RenderFragmentError`; `handleStatus` can classify a handle
 without mutating the tree. Use `updateNode` for controlled visual changes to an existing node.

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ let updatedRoots = fragments.fragmentRoots(updatedMenuFragment)
 Fragment handles and cursors are bound to their owning tree and generation. Operations reject
 foreign, stale, and detached values with `RenderFragmentError`; `handleStatus` can classify a handle
 without mutating the tree. Use `updateNode` for controlled visual changes to an existing node.
+Layer indexing and `pairs` return detached diagnostic copies rather than mutable tree storage.
 
 `attachRootFragment` adds the same persistent slot behavior to a layer root sequence. `materialize`
 creates an independent monolithic `Renders` copy in logical traversal order for compatibility,

--- a/examples/renderfragments_common.nim
+++ b/examples/renderfragments_common.nim
@@ -4,7 +4,7 @@ import figdraw
 
 type FragmentExample* = object
   renders*: RenderFragments
-  fragmentRoot: RenderCursor
+  fragment: RenderFragmentHandle
   logicalSize: Vec2
   frame: int
 
@@ -67,8 +67,9 @@ proc initFragmentExample*(logicalSize: Vec2): FragmentExample =
       fill: linear(rgba(244, 247, 255, 255), rgba(218, 226, 246, 255), axis = fgaY),
     ),
   )
-  result.fragmentRoot =
-    result.renders.insertChildren(0.ZLevel, background, makeCards(logicalSize, 0), 0)[0]
+  result.fragment = result.renders.attachChildFragment(
+    0.ZLevel, background, 0, makeCards(logicalSize, 0)
+  )
 
 proc resize*(example: var FragmentExample, logicalSize: Vec2) =
   if logicalSize != example.logicalSize:
@@ -78,6 +79,6 @@ proc resize*(example: var FragmentExample, logicalSize: Vec2) =
 
 proc update*(example: var FragmentExample) =
   inc example.frame
-  example.fragmentRoot = example.renders.updateFragment(
-    example.fragmentRoot, makeCards(example.logicalSize, example.frame)
-  )[0]
+  example.fragment = example.renders.replaceFragment(
+    example.fragment, makeCards(example.logicalSize, example.frame)
+  )

--- a/src/figdraw/figrender.nim
+++ b/src/figdraw/figrender.nim
@@ -1948,9 +1948,14 @@ proc renderRoot*[Input: RenderInput](
 ) {.forbids: [AppMainThreadEff].} =
   ## draw roots for each level
   ctx.processImageMessages()
-  for zlvl, _ in nodes.pairs():
-    for root in nodes.roots(zlvl):
-      ctx.render(nodes, root)
+  when Input is RenderFragments:
+    for zlvl in nodes.levels():
+      for root in nodes.roots(zlvl):
+        ctx.render(nodes, root)
+  else:
+    for zlvl, _ in nodes.pairs():
+      for root in nodes.roots(zlvl):
+        ctx.render(nodes, root)
 
   ctx.publishAtlasUsage()
 

--- a/src/figdraw/renderfragments.nim
+++ b/src/figdraw/renderfragments.nim
@@ -3,6 +3,16 @@ import std/tables
 import ./fignodes
 
 type
+  RenderFragmentError* = object of CatchableError
+
+  RenderFragmentStatus* = enum
+    rfsValid
+    rfsForeignTree
+    rfsStaleTree
+    rfsStaleLayer
+    rfsDetached
+    rfsStaleFragment
+
   RenderChildKind = enum
     rckNode
     rckFragment
@@ -13,32 +23,61 @@ type
       node: FigIdx
     of rckFragment:
       fragment: RenderFragment
-      root: FigIdx
 
   RenderEntries = object
     childEntries: Table[int16, seq[RenderChild]]
     rootEntries: seq[RenderChild]
     ready: bool
 
-  RenderFragment* = ref object ## An independently replaceable render subtree.
+  RenderFragment = ref object
+    id: uint64
     list: RenderList
     entries: RenderEntries
+    zlevel: ZLevel
+    generation: uint64
+    nodeGeneration: uint64
+    attached: bool
 
   RenderFragments* = ref object
-    ## A render tree whose base `Renders` remains physically unchanged when
-    ## fragment subtrees are inserted or replaced.
+    ## A render tree containing independently replaceable logical subtrees.
+    ##
+    ## Fragment edges are stored separately from physical `RenderList` nodes, so
+    ## replacement does not change indexes in the surrounding lists.
     base: Renders
-    layerEntries: Table[ZLevel, RenderEntries]
+    layerEntries: OrderedTable[ZLevel, RenderEntries]
+    layerGenerations: Table[ZLevel, uint64]
+    baseNodeGenerations: Table[ZLevel, uint64]
+    treeGeneration: uint64
+    nextFragmentId: uint64
 
-  RenderCursor* = object ## Identifies a Fig in a base layer or an inserted fragment.
+  RenderFragmentHandle* = object
+    ## Opaque identity for one attached, independently replaceable subtree.
+    owner: RenderFragments
+    treeGeneration: uint64
+    layerGeneration: uint64
+    fragmentGeneration: uint64
+    fragment: RenderFragment
+
+  RenderCursor* = object ## Identifies a Fig in a particular version of a render tree.
     zlevel*: ZLevel
     index*: FigIdx
+    owner: RenderFragments
+    treeGeneration: uint64
+    layerGeneration: uint64
+    nodeGeneration: uint64
     fragment: RenderFragment
 
   RenderInput* = Renders | RenderFragments
 
+proc `==`*(a, b: RenderFragmentHandle): bool =
+  a.owner == b.owner and a.treeGeneration == b.treeGeneration and
+    a.layerGeneration == b.layerGeneration and
+    a.fragmentGeneration == b.fragmentGeneration and a.fragment == b.fragment
+
 proc `==`*(a, b: RenderCursor): bool =
-  a.zlevel == b.zlevel and a.index == b.index and a.fragment == b.fragment
+  a.zlevel == b.zlevel and a.index == b.index and a.owner == b.owner and
+    a.treeGeneration == b.treeGeneration and a.layerGeneration == b.layerGeneration and
+    a.nodeGeneration == b.nodeGeneration and a.fragment == b.fragment
 
 func entryKey(idx: FigIdx): int16 =
   idx.int.int16
@@ -46,39 +85,37 @@ func entryKey(idx: FigIdx): int16 =
 proc nodeChild(idx: FigIdx): RenderChild =
   RenderChild(kind: rckNode, node: idx)
 
-proc fragmentChild(fragment: RenderFragment, root: FigIdx): RenderChild =
-  RenderChild(kind: rckFragment, fragment: fragment, root: root)
-
-proc makeCursor(
-    zlevel: ZLevel, index: FigIdx, fragment: RenderFragment = nil
-): RenderCursor =
-  RenderCursor(zlevel: zlevel, index: index, fragment: fragment)
+proc fragmentChild(fragment: RenderFragment): RenderChild =
+  RenderChild(kind: rckFragment, fragment: fragment)
 
 proc validIdx(list: RenderList, idx: FigIdx): bool =
   idx.int >= 0 and idx.int < list.nodes.len
 
 proc checkedFigIdx(idx: int): FigIdx =
-  assert idx >= 0 and idx <= high(int16).int
+  if idx < 0 or idx > high(int16).int:
+    raise newException(RenderFragmentError, "RenderList node index is out of range")
   idx.FigIdx
 
+proc invalidRenderList(message: string) {.noinline, noreturn.} =
+  raise newException(RenderFragmentError, message)
+
 proc validateRootIds(list: RenderList) =
+  var roots = newSeq[bool](list.nodes.len)
   for rootIdx in list.rootIds:
-    assert list.validIdx(rootIdx)
-    assert list.nodes[rootIdx.int].parent.int < 0
+    if not list.validIdx(rootIdx):
+      invalidRenderList("RenderList contains an invalid root index")
+    if list.nodes[rootIdx.int].parent.int >= 0:
+      invalidRenderList("RenderList root has a parent")
+    if roots[rootIdx.int]:
+      invalidRenderList("RenderList contains a duplicate root index")
+    roots[rootIdx.int] = true
 
   for idx, node in list.nodes:
     if node.parent.int < 0:
-      var found = false
-      for rootIdx in list.rootIds:
-        if rootIdx.int == idx:
-          found = true
-          break
-      assert found
-
-proc reset(entries: var RenderEntries) =
-  entries.childEntries.clear()
-  entries.rootEntries.setLen(0)
-  entries.ready = false
+      if not roots[idx]:
+        invalidRenderList("RenderList omits a root node from rootIds")
+    elif not list.validIdx(node.parent):
+      invalidRenderList("RenderList node has an invalid parent index")
 
 proc rebuildEntries(list: RenderList, entries: var RenderEntries) =
   entries.childEntries.clear()
@@ -88,13 +125,18 @@ proc rebuildEntries(list: RenderList, entries: var RenderEntries) =
     if node.parent.int < 0:
       entries.rootEntries.add child
     else:
-      assert node.parent.int < list.nodes.len
       entries.childEntries.mgetOrPut(node.parent.entryKey(), @[]).add child
   entries.ready = true
 
 proc ensureEntries(list: RenderList, entries: var RenderEntries) =
   if not entries.ready:
+    list.validateRootIds()
     list.rebuildEntries(entries)
+
+proc reset(entries: var RenderEntries) =
+  entries.childEntries.clear()
+  entries.rootEntries.setLen(0)
+  entries.ready = false
 
 proc shiftEntryIndexes(entries: var RenderEntries, insertIdx, count: int) =
   if not entries.ready or count == 0:
@@ -119,122 +161,231 @@ proc shiftEntryIndexes(entries: var RenderEntries, insertIdx, count: int) =
     if entry.kind == rckNode and entry.node.int >= insertIdx:
       entry.node = (entry.node.int + count).FigIdx
 
-proc effectiveChildCount(
-    list: RenderList, entries: var RenderEntries, parentIdx: FigIdx
-): int =
-  assert list.validIdx(parentIdx)
-  list.ensureEntries(entries)
-  entries.childEntries.getOrDefault(parentIdx.entryKey()).len
+proc cloneRenderList(list: RenderList): RenderList =
+  result.nodes = newSeqOfCap[Fig](list.nodes.len)
+  for node in list.nodes:
+    result.nodes.add node
+  result.rootIds = newSeqOfCap[FigIdx](list.rootIds.len)
+  for root in list.rootIds:
+    result.rootIds.add root
 
-proc childInsertIndex(list: RenderList, parentIdx: FigIdx, childPos: Natural): int =
-  assert list.validIdx(parentIdx)
-  let childCount = list.nodes[parentIdx.int].childCount.int
-  assert childPos.int <= childCount
-  if childPos.int == childCount:
-    return list.nodes.len
-
-  var pos = 0
-  for childIdx in list.nodes.childIndex(parentIdx):
-    if pos == childPos.int:
-      return childIdx.int
-    inc pos
-  assert false
-
-proc rootInsertIndex(list: RenderList, rootPos: Natural): int =
-  assert rootPos.int <= list.rootIds.len
-  if rootPos.int == list.rootIds.len:
-    list.nodes.len
-  else:
-    list.rootIds[rootPos.int].int
+proc cloneRenders(renders: Renders): Renders =
+  result = newRenders()
+  for lvl, list in renders.pairs():
+    result.setLayer(lvl, list.cloneRenderList())
 
 proc relevelList(list: var RenderList, lvl: ZLevel) =
   for node in list.nodes.mitems:
     node.zlevel = lvl
 
-proc insertFragment(
-    list: RenderList,
-    entries: var RenderEntries,
-    parentIdx: FigIdx,
-    children: sink RenderList,
-    childPos: Natural,
-): RenderFragment =
-  list.ensureEntries(entries)
-  assert list.validIdx(parentIdx)
-  assert childPos.int <= list.effectiveChildCount(entries, parentIdx)
-
-  children.validateRootIds()
-  var fragmentEntries: RenderEntries
-  children.rebuildEntries(fragmentEntries)
-  if fragmentEntries.rootEntries.len == 0:
-    return nil
-
-  result = RenderFragment(list: move children, entries: move fragmentEntries)
-  for offset, root in result.entries.rootEntries:
-    assert root.kind == rckNode
-    entries.childEntries.mgetOrPut(parentIdx.entryKey(), @[]).insert(
-      result.fragmentChild(root.node), childPos.int + offset
-    )
-
-proc appendChildren(
-    list: var RenderList,
-    entries: var RenderEntries,
-    parentIdx: FigIdx,
-    children: sink RenderList,
-): seq[FigIdx] =
-  list.ensureEntries(entries)
-  assert list.validIdx(parentIdx)
-  children.validateRootIds()
-  if children.nodes.len == 0:
-    return @[]
-
-  assert list.nodes.len + children.nodes.len <= high(int16).int
-  let base = list.nodes.len
-  for node in children.nodes:
-    var newNode = node
-    if node.parent.int < 0:
-      newNode.parent = parentIdx
-    else:
-      assert node.parent.int < children.nodes.len
-      newNode.parent = checkedFigIdx(base + node.parent.int)
-    list.nodes.add newNode
-
-  for root in children.rootIds:
-    let appendedIdx = checkedFigIdx(base + root.int)
-    entries.childEntries.mgetOrPut(parentIdx.entryKey(), @[]).add(
-      appendedIdx.nodeChild()
-    )
-    if list.nodes[parentIdx.int].childCount ==
-        high(typeof(list.nodes[parentIdx.int].childCount)):
-      raise newException(ValueError, "RenderList parent childCount overflow")
-    inc list.nodes[parentIdx.int].childCount
-    result.add appendedIdx
-
-  for sourceParentIdx, node in children.nodes:
-    if node.childCount > 0:
-      let destinationParent = checkedFigIdx(base + sourceParentIdx)
-      var destinationEntries: seq[RenderChild]
-      for childIdx in children.nodes.childIndex(sourceParentIdx.FigIdx):
-        destinationEntries.add checkedFigIdx(base + childIdx.int).nodeChild()
-      entries.childEntries[destinationParent.entryKey()] = move destinationEntries
-
-proc layerState(fragments: RenderFragments, lvl: ZLevel): var RenderEntries =
+proc ensureLayer(fragments: RenderFragments, lvl: ZLevel) =
   if lvl notin fragments.base.layers:
     fragments.base.layers[lvl] = RenderList()
-  result = fragments.layerEntries.mgetOrPut(lvl, RenderEntries())
-  fragments.base.layers[lvl].ensureEntries(result)
+  if lvl notin fragments.layerEntries:
+    fragments.layerEntries[lvl] = RenderEntries()
+  if lvl notin fragments.layerGenerations:
+    fragments.layerGenerations[lvl] = 1
+  if lvl notin fragments.baseNodeGenerations:
+    fragments.baseNodeGenerations[lvl] = 1
+  fragments.base.layers[lvl].ensureEntries(fragments.layerEntries[lvl])
+
+proc layerGeneration(fragments: RenderFragments, lvl: ZLevel): uint64 =
+  fragments.layerGenerations.getOrDefault(lvl)
+
+proc baseNodeGeneration(fragments: RenderFragments, lvl: ZLevel): uint64 =
+  fragments.baseNodeGenerations.getOrDefault(lvl)
+
+proc advance(value: var uint64) =
+  inc value
+  if value == 0:
+    value = 1
+
+proc makeRendersCursor(zlevel: ZLevel, index: FigIdx): RenderCursor =
+  RenderCursor(zlevel: zlevel, index: index)
+
+proc makeBaseCursor(
+    fragments: RenderFragments, zlevel: ZLevel, index: FigIdx
+): RenderCursor =
+  RenderCursor(
+    zlevel: zlevel,
+    index: index,
+    owner: fragments,
+    treeGeneration: fragments.treeGeneration,
+    layerGeneration: fragments.layerGeneration(zlevel),
+    nodeGeneration: fragments.baseNodeGeneration(zlevel),
+  )
+
+proc makeFragmentCursor(
+    fragments: RenderFragments, fragment: RenderFragment, index: FigIdx
+): RenderCursor =
+  RenderCursor(
+    zlevel: fragment.zlevel,
+    index: index,
+    owner: fragments,
+    treeGeneration: fragments.treeGeneration,
+    layerGeneration: fragments.layerGeneration(fragment.zlevel),
+    nodeGeneration: fragment.nodeGeneration,
+    fragment: fragment,
+  )
+
+proc makeHandle(
+    fragments: RenderFragments, fragment: RenderFragment
+): RenderFragmentHandle =
+  RenderFragmentHandle(
+    owner: fragments,
+    treeGeneration: fragments.treeGeneration,
+    layerGeneration: fragments.layerGeneration(fragment.zlevel),
+    fragmentGeneration: fragment.generation,
+    fragment: fragment,
+  )
+
+proc handleStatus*(
+    fragments: RenderFragments, handle: RenderFragmentHandle
+): RenderFragmentStatus =
+  if fragments.isNil or handle.owner != fragments:
+    return rfsForeignTree
+  if handle.treeGeneration != fragments.treeGeneration:
+    return rfsStaleTree
+  if handle.fragment.isNil:
+    return rfsDetached
+  if handle.layerGeneration != fragments.layerGeneration(handle.fragment.zlevel):
+    return rfsStaleLayer
+  if not handle.fragment.attached:
+    return rfsDetached
+  if handle.fragmentGeneration != handle.fragment.generation:
+    return rfsStaleFragment
+  rfsValid
+
+proc isValid*(fragments: RenderFragments, handle: RenderFragmentHandle): bool =
+  fragments.handleStatus(handle) == rfsValid
+
+proc statusMessage(status: RenderFragmentStatus): string =
+  case status
+  of rfsValid: "valid fragment handle"
+  of rfsForeignTree: "fragment handle belongs to another render tree"
+  of rfsStaleTree: "fragment handle predates a render tree clear"
+  of rfsStaleLayer: "fragment handle predates a layer replacement"
+  of rfsDetached: "fragment handle is detached"
+  of rfsStaleFragment: "fragment handle refers to an older fragment version"
+
+proc requireHandle(fragments: RenderFragments, handle: RenderFragmentHandle) =
+  let status = fragments.handleStatus(handle)
+  if status != rfsValid:
+    raise newException(RenderFragmentError, status.statusMessage())
+
+proc requireCursor(fragments: RenderFragments, cursor: RenderCursor) =
+  if fragments.isNil or cursor.owner != fragments:
+    raise newException(RenderFragmentError, "render cursor belongs to another tree")
+  if cursor.treeGeneration != fragments.treeGeneration:
+    raise newException(RenderFragmentError, "render cursor predates a tree clear")
+  if cursor.layerGeneration != fragments.layerGeneration(cursor.zlevel):
+    raise
+      newException(RenderFragmentError, "render cursor predates a layer replacement")
+
+  if cursor.fragment.isNil:
+    if cursor.nodeGeneration != fragments.baseNodeGeneration(cursor.zlevel):
+      raise newException(RenderFragmentError, "render cursor has a stale node index")
+    if cursor.zlevel notin fragments.base.layers or
+        not fragments.base.layers[cursor.zlevel].validIdx(cursor.index):
+      raise newException(RenderFragmentError, "render cursor has an invalid node index")
+  else:
+    if not cursor.fragment.attached:
+      raise newException(
+        RenderFragmentError, "render cursor belongs to a detached fragment"
+      )
+    if cursor.fragment.zlevel != cursor.zlevel or
+        cursor.nodeGeneration != cursor.fragment.nodeGeneration:
+      raise
+        newException(RenderFragmentError, "render cursor has a stale fragment version")
+    if not cursor.fragment.list.validIdx(cursor.index):
+      raise newException(RenderFragmentError, "render cursor has an invalid node index")
+
+proc fragmentHandle*(cursor: RenderCursor): RenderFragmentHandle =
+  if cursor.owner.isNil or cursor.fragment.isNil:
+    raise
+      newException(RenderFragmentError, "render cursor does not identify a fragment")
+  cursor.owner.requireCursor(cursor)
+  cursor.owner.makeHandle(cursor.fragment)
+
+proc fragmentId*(handle: RenderFragmentHandle): uint64 =
+  if handle.fragment.isNil:
+    return 0
+  handle.fragment.id
+
+proc expandedCount(fragments: RenderFragments, entries: openArray[RenderChild]): int =
+  for entry in entries:
+    case entry.kind
+    of rckNode:
+      inc result
+    of rckFragment:
+      if entry.fragment.attached:
+        result += entry.fragment.entries.rootEntries.len
+
+proc detachFragment(fragment: RenderFragment)
+
+proc detachFragments(entries: RenderEntries) =
+  for entry in entries.rootEntries:
+    if entry.kind == rckFragment:
+      entry.fragment.detachFragment()
+  for _, children in entries.childEntries:
+    for entry in children:
+      if entry.kind == rckFragment:
+        entry.fragment.detachFragment()
+
+proc detachFragment(fragment: RenderFragment) =
+  if fragment.isNil or not fragment.attached:
+    return
+  fragment.entries.detachFragments()
+  fragment.attached = false
+  fragment.generation.advance()
+  fragment.nodeGeneration.advance()
+
+proc newFragment(
+    fragments: RenderFragments, lvl: ZLevel, contents: sink RenderList
+): RenderFragment =
+  contents.relevelList(lvl)
+  contents.validateRootIds()
+  var entries: RenderEntries
+  contents.rebuildEntries(entries)
+  result = RenderFragment(
+    id: fragments.nextFragmentId,
+    list: move contents,
+    entries: move entries,
+    zlevel: lvl,
+    generation: 1,
+    nodeGeneration: 1,
+    attached: true,
+  )
+  fragments.nextFragmentId.advance()
 
 proc newRenderFragments*(): RenderFragments =
-  RenderFragments(base: newRenders(), layerEntries: initTable[ZLevel, RenderEntries]())
+  RenderFragments(
+    base: newRenders(),
+    layerEntries: initOrderedTable[ZLevel, RenderEntries](),
+    layerGenerations: initTable[ZLevel, uint64](),
+    baseNodeGenerations: initTable[ZLevel, uint64](),
+    treeGeneration: 1,
+    nextFragmentId: 1,
+  )
 
 proc newRenderFragments*(renders: Renders): RenderFragments =
-  ## Wraps an existing render tree. Fragment-aware mutations should subsequently
-  ## use this wrapper so its logical traversal metadata stays synchronized.
-  assert not renders.isNil
-  RenderFragments(base: renders, layerEntries: initTable[ZLevel, RenderEntries]())
+  ## Copies an existing render tree so later external mutations cannot invalidate
+  ## fragment traversal metadata.
+  if renders.isNil:
+    raise newException(RenderFragmentError, "cannot copy a nil Renders tree")
+  result = newRenderFragments()
+  result.base = renders.cloneRenders()
+  for lvl, _ in result.base.pairs():
+    result.ensureLayer(lvl)
 
 proc clear*(fragments: RenderFragments) =
+  for _, entries in fragments.layerEntries:
+    entries.detachFragments()
+  fragments.treeGeneration.advance()
   fragments.base.clear()
   fragments.layerEntries.clear()
+  fragments.layerGenerations.clear()
+  fragments.baseNodeGenerations.clear()
 
 func len*(fragments: RenderFragments, lvl: ZLevel): int =
   fragments.base.len(lvl)
@@ -245,79 +396,141 @@ proc contains*(fragments: RenderFragments, lvl: ZLevel): bool =
 proc effectiveChildCount*(
     fragments: RenderFragments, lvl: ZLevel, parentIdx: FigIdx
 ): int =
-  discard fragments.layerState(lvl)
-  fragments.base.layers[lvl].effectiveChildCount(fragments.layerEntries[lvl], parentIdx)
+  fragments.ensureLayer(lvl)
+  if not fragments.base.layers[lvl].validIdx(parentIdx):
+    raise newException(RenderFragmentError, "parent node index is out of range")
+  let children =
+    fragments.layerEntries[lvl].childEntries.getOrDefault(parentIdx.entryKey())
+  fragments.expandedCount(children)
 
 proc effectiveChildCount*(fragments: RenderFragments, parent: RenderCursor): int =
+  fragments.requireCursor(parent)
   if parent.fragment.isNil:
     return fragments.effectiveChildCount(parent.zlevel, parent.index)
-  parent.fragment.list.effectiveChildCount(parent.fragment.entries, parent.index)
+  parent.fragment.list.ensureEntries(parent.fragment.entries)
+  let children =
+    parent.fragment.entries.childEntries.getOrDefault(parent.index.entryKey())
+  fragments.expandedCount(children)
 
 template pairs*(fragments: RenderFragments): auto =
   fragments.base.layers.pairs()
 
-proc `[]`*(fragments: RenderFragments, lvl: ZLevel): var RenderList =
-  discard fragments.layerState(lvl)
+proc `[]`*(fragments: RenderFragments, lvl: ZLevel): lent RenderList =
+  if fragments.isNil or lvl notin fragments.base.layers:
+    raise newException(KeyError, "render layer does not exist")
   fragments.base.layers[lvl]
 
-proc setLayer*(fragments: RenderFragments, lvl: ZLevel, list: RenderList) =
-  fragments.base.setLayer(lvl, list)
-  fragments.layerEntries.mgetOrPut(lvl, RenderEntries()).reset()
+proc setLayer*(fragments: RenderFragments, lvl: ZLevel, list: sink RenderList) =
+  if lvl in fragments.layerEntries:
+    fragments.layerEntries[lvl].detachFragments()
 
-template `[]`*(renders: Renders, cursor: RenderCursor): untyped =
-  assert cursor.fragment.isNil
+  list.relevelList(lvl)
+  list.validateRootIds()
+  fragments.base.setLayer(lvl, move list)
+  fragments.layerEntries.mgetOrPut(lvl, RenderEntries()).reset()
+  fragments.layerGenerations.mgetOrPut(lvl, 1).advance()
+  fragments.baseNodeGenerations.mgetOrPut(lvl, 1).advance()
+  fragments.ensureLayer(lvl)
+
+proc `[]`*(renders: Renders, cursor: RenderCursor): lent Fig =
+  if not cursor.owner.isNil or not cursor.fragment.isNil:
+    raise newException(RenderFragmentError, "fragment cursor cannot index Renders")
   renders.layers[cursor.zlevel].nodes[cursor.index.int]
 
-template `[]`*(fragments: RenderFragments, cursor: RenderCursor): untyped =
+proc `[]`*(fragments: RenderFragments, cursor: RenderCursor): lent Fig =
+  fragments.requireCursor(cursor)
   if cursor.fragment.isNil:
-    fragments.base.layers[cursor.zlevel].nodes[cursor.index.int]
+    return fragments.base.layers[cursor.zlevel].nodes[cursor.index.int]
+  cursor.fragment.list.nodes[cursor.index.int]
+
+proc nodeCursor*(fragments: RenderFragments, lvl: ZLevel, index: FigIdx): RenderCursor =
+  fragments.ensureLayer(lvl)
+  if not fragments.base.layers[lvl].validIdx(index):
+    raise newException(RenderFragmentError, "node index is out of range")
+  fragments.makeBaseCursor(lvl, index)
+
+proc updateNode*(fragments: RenderFragments, cursor: RenderCursor, node: sink Fig) =
+  ## Updates visual node data while retaining fragment topology fields.
+  fragments.requireCursor(cursor)
+  if cursor.fragment.isNil:
+    let current = fragments.base.layers[cursor.zlevel].nodes[cursor.index.int]
+    node.zlevel = current.zlevel
+    node.parent = current.parent
+    node.childCount = current.childCount
+    fragments.base.layers[cursor.zlevel].nodes[cursor.index.int] = move node
   else:
-    cursor.fragment.list.nodes[cursor.index.int]
+    let current = cursor.fragment.list.nodes[cursor.index.int]
+    node.zlevel = current.zlevel
+    node.parent = current.parent
+    node.childCount = current.childCount
+    cursor.fragment.list.nodes[cursor.index.int] = move node
+
+iterator expandEntry(
+    fragments: RenderFragments,
+    lvl: ZLevel,
+    ownerFragment: RenderFragment,
+    entry: RenderChild,
+): RenderCursor =
+  case entry.kind
+  of rckNode:
+    if ownerFragment.isNil:
+      yield fragments.makeBaseCursor(lvl, entry.node)
+    else:
+      yield fragments.makeFragmentCursor(ownerFragment, entry.node)
+  of rckFragment:
+    if not entry.fragment.attached:
+      raise
+        newException(RenderFragmentError, "render tree contains a detached fragment")
+    for root in entry.fragment.entries.rootEntries:
+      if root.kind != rckNode:
+        raise newException(RenderFragmentError, "fragment root metadata is invalid")
+      yield fragments.makeFragmentCursor(entry.fragment, root.node)
 
 iterator roots*(renders: Renders, lvl: ZLevel): RenderCursor =
   for rootIdx in renders[lvl].rootIds:
-    yield makeCursor(lvl, rootIdx)
+    yield makeRendersCursor(lvl, rootIdx)
 
 iterator children*(renders: Renders, parent: RenderCursor): RenderCursor =
-  assert parent.fragment.isNil
+  if not parent.owner.isNil or not parent.fragment.isNil:
+    raise newException(RenderFragmentError, "fragment cursor cannot traverse Renders")
   for childIdx in renders[parent.zlevel].nodes.childIndex(parent.index):
-    yield makeCursor(parent.zlevel, childIdx)
+    yield makeRendersCursor(parent.zlevel, childIdx)
 
 iterator roots*(fragments: RenderFragments, lvl: ZLevel): RenderCursor =
-  let entries = fragments.layerState(lvl)
-  for entry in entries.rootEntries:
-    case entry.kind
-    of rckNode:
-      yield makeCursor(lvl, entry.node)
-    of rckFragment:
-      yield makeCursor(lvl, entry.root, entry.fragment)
+  fragments.ensureLayer(lvl)
+  for entry in fragments.layerEntries[lvl].rootEntries:
+    for cursor in fragments.expandEntry(lvl, nil, entry):
+      yield cursor
 
 iterator children*(fragments: RenderFragments, parent: RenderCursor): RenderCursor =
+  fragments.requireCursor(parent)
   if parent.fragment.isNil:
-    let entries = fragments.layerState(parent.zlevel)
+    let entries = fragments.layerEntries[parent.zlevel]
     for entry in entries.childEntries.getOrDefault(parent.index.entryKey()):
-      case entry.kind
-      of rckNode:
-        yield makeCursor(parent.zlevel, entry.node)
-      of rckFragment:
-        yield makeCursor(parent.zlevel, entry.root, entry.fragment)
+      for cursor in fragments.expandEntry(parent.zlevel, nil, entry):
+        yield cursor
   else:
     parent.fragment.list.ensureEntries(parent.fragment.entries)
-    for entry in parent.fragment.entries.childEntries.getOrDefault(
-      parent.index.entryKey()
-    ):
-      case entry.kind
-      of rckNode:
-        yield makeCursor(parent.zlevel, entry.node, parent.fragment)
-      of rckFragment:
-        yield makeCursor(parent.zlevel, entry.root, entry.fragment)
+    let entries = parent.fragment.entries
+    for entry in entries.childEntries.getOrDefault(parent.index.entryKey()):
+      for cursor in fragments.expandEntry(parent.zlevel, parent.fragment, entry):
+        yield cursor
+
+proc fragmentRoots*(
+    fragments: RenderFragments, handle: RenderFragmentHandle
+): seq[RenderCursor] =
+  fragments.requireHandle(handle)
+  for entry in handle.fragment.entries.rootEntries:
+    if entry.kind != rckNode:
+      raise newException(RenderFragmentError, "fragment root metadata is invalid")
+    result.add fragments.makeFragmentCursor(handle.fragment, entry.node)
 
 proc addRoot*(
     fragments: RenderFragments, lvl: ZLevel, root: Fig
 ): FigIdx {.discardable.} =
   var node = root
   node.zlevel = lvl
-  discard fragments.layerState(lvl)
+  fragments.ensureLayer(lvl)
   result = fragments.base.layers[lvl].addRoot(node)
   fragments.layerEntries[lvl].rootEntries.add result.nodeChild()
 
@@ -327,14 +540,23 @@ proc addRoot*(fragments: RenderFragments, root: Fig): FigIdx {.discardable.} =
 proc insertRoot*(
     fragments: RenderFragments, lvl: ZLevel, root: Fig, rootPos: Natural
 ): FigIdx {.discardable.} =
-  discard fragments.layerState(lvl)
-  let insertIdx = fragments.base.layers[lvl].rootInsertIndex(rootPos)
+  fragments.ensureLayer(lvl)
+  if rootPos.int > fragments.layerEntries[lvl].rootEntries.len:
+    raise newException(RenderFragmentError, "root position is out of range")
+
+  let physicalRootPos = min(rootPos.int, fragments.base.layers[lvl].rootIds.len)
+  let insertIdx =
+    if physicalRootPos == fragments.base.layers[lvl].rootIds.len:
+      fragments.base.layers[lvl].nodes.len
+    else:
+      fragments.base.layers[lvl].rootIds[physicalRootPos].int
   fragments.layerEntries[lvl].shiftEntryIndexes(insertIdx, 1)
 
   var node = root
   node.zlevel = lvl
-  result = fragments.base.layers[lvl].insertRoot(node, rootPos)
+  result = fragments.base.layers[lvl].insertRoot(node, physicalRootPos.Natural)
   fragments.layerEntries[lvl].rootEntries.insert(result.nodeChild(), rootPos.int)
+  fragments.baseNodeGenerations[lvl].advance()
 
 proc insertRoot*(
     fragments: RenderFragments, root: Fig, rootPos: Natural
@@ -344,28 +566,32 @@ proc insertRoot*(
 proc addChild*(
     fragments: RenderFragments, lvl: ZLevel, parentIdx: FigIdx, child: Fig
 ): FigIdx {.discardable.} =
+  fragments.ensureLayer(lvl)
+  if not fragments.base.layers[lvl].validIdx(parentIdx):
+    raise newException(RenderFragmentError, "parent node index is out of range")
+
   var node = child
   node.zlevel = lvl
-  discard fragments.layerState(lvl)
   result = fragments.base.layers[lvl].addChild(parentIdx, node)
-
-  fragments.layerEntries[lvl].childEntries.mgetOrPut(parentIdx.entryKey(), @[]).add result.nodeChild()
+  fragments.layerEntries[lvl].childEntries.mgetOrPut(parentIdx.entryKey(), @[]).add(
+    result.nodeChild()
+  )
 
 proc addChild*(
     fragments: RenderFragments, parent: RenderCursor, child: Fig
 ): RenderCursor {.discardable.} =
+  fragments.requireCursor(parent)
   var node = child
   node.zlevel = parent.zlevel
   if parent.fragment.isNil:
     let index = fragments.addChild(parent.zlevel, parent.index, node)
-    return makeCursor(parent.zlevel, index)
+    return fragments.makeBaseCursor(parent.zlevel, index)
 
-  parent.fragment.list.ensureEntries(parent.fragment.entries)
   let index = parent.fragment.list.addChild(parent.index, node)
   parent.fragment.entries.childEntries.mgetOrPut(parent.index.entryKey(), @[]).add(
     index.nodeChild()
   )
-  makeCursor(parent.zlevel, index, parent.fragment)
+  fragments.makeFragmentCursor(parent.fragment, index)
 
 proc insertChildInto(
     list: var RenderList,
@@ -375,16 +601,21 @@ proc insertChildInto(
     childPos: Natural,
 ): FigIdx =
   list.ensureEntries(entries)
-  assert childPos.int <= list.effectiveChildCount(entries, parentIdx)
+  let currentEntries = entries.childEntries.getOrDefault(parentIdx.entryKey())
+  if childPos.int > currentEntries.len:
+    raise newException(RenderFragmentError, "child slot position is out of range")
+
   let physicalChildCount = list.nodes[parentIdx.int].childCount.int
-  let insertIdx =
-    if childPos.int <= physicalChildCount:
-      list.childInsertIndex(parentIdx, childPos)
-    else:
-      list.nodes.len
+  let physicalChildPos = min(childPos.int, physicalChildCount)
+  var insertIdx = list.nodes.len
+  if physicalChildPos < physicalChildCount:
+    var pos = 0
+    for childIdx in list.nodes.childIndex(parentIdx):
+      if pos == physicalChildPos:
+        insertIdx = childIdx.int
+      inc pos
   entries.shiftEntryIndexes(insertIdx, 1)
-  result =
-    list.insertChild(parentIdx, child, min(childPos.int, physicalChildCount).Natural)
+  result = list.insertChild(parentIdx, child, physicalChildPos.Natural)
 
   let shiftedParentIdx =
     if parentIdx.int >= insertIdx:
@@ -402,62 +633,74 @@ proc insertChild*(
     child: Fig,
     childPos: Natural,
 ): FigIdx {.discardable.} =
+  fragments.ensureLayer(lvl)
+  if not fragments.base.layers[lvl].validIdx(parentIdx):
+    raise newException(RenderFragmentError, "parent node index is out of range")
   var node = child
   node.zlevel = lvl
-  discard fragments.layerState(lvl)
-  fragments.base.layers[lvl].insertChildInto(
+  result = fragments.base.layers[lvl].insertChildInto(
     fragments.layerEntries[lvl], parentIdx, node, childPos
   )
+  fragments.baseNodeGenerations[lvl].advance()
 
 proc insertChild*(
     fragments: RenderFragments, parent: RenderCursor, child: Fig, childPos: Natural
 ): RenderCursor {.discardable.} =
+  fragments.requireCursor(parent)
   var node = child
   node.zlevel = parent.zlevel
   if parent.fragment.isNil:
     let index = fragments.insertChild(parent.zlevel, parent.index, node, childPos)
-    return makeCursor(parent.zlevel, index)
+    return fragments.makeBaseCursor(parent.zlevel, index)
 
   let index = parent.fragment.list.insertChildInto(
     parent.fragment.entries, parent.index, node, childPos
   )
-  makeCursor(parent.zlevel, index, parent.fragment)
+  parent.fragment.nodeGeneration.advance()
+  fragments.makeFragmentCursor(parent.fragment, index)
 
-proc insertChildren*(
-    fragments: RenderFragments,
-    lvl: ZLevel,
+proc appendChildren(
+    list: var RenderList,
+    entries: var RenderEntries,
     parentIdx: FigIdx,
     children: sink RenderList,
-    childPos: Natural,
-): seq[RenderCursor] {.discardable.} =
-  children.relevelList(lvl)
-  discard fragments.layerState(lvl)
-  let fragment = fragments.base.layers[lvl].insertFragment(
-    fragments.layerEntries[lvl], parentIdx, move children, childPos
-  )
-  if fragment.isNil:
+): seq[FigIdx] =
+  list.ensureEntries(entries)
+  if not list.validIdx(parentIdx):
+    raise newException(RenderFragmentError, "parent node index is out of range")
+  children.validateRootIds()
+  if children.nodes.len == 0:
     return @[]
-  for root in fragment.entries.rootEntries:
-    result.add makeCursor(lvl, root.node, fragment)
+  if list.nodes.len + children.nodes.len > high(int16).int:
+    raise newException(RenderFragmentError, "RenderList node capacity exceeded")
 
-proc insertChildren*(
-    fragments: RenderFragments,
-    parent: RenderCursor,
-    children: sink RenderList,
-    childPos: Natural,
-): seq[RenderCursor] {.discardable.} =
-  children.relevelList(parent.zlevel)
-  if parent.fragment.isNil:
-    return
-      fragments.insertChildren(parent.zlevel, parent.index, move children, childPos)
+  let base = list.nodes.len
+  for node in children.nodes:
+    var newNode = node
+    if node.parent.int < 0:
+      newNode.parent = parentIdx
+    else:
+      newNode.parent = checkedFigIdx(base + node.parent.int)
+    list.nodes.add newNode
 
-  let fragment = parent.fragment.list.insertFragment(
-    parent.fragment.entries, parent.index, move children, childPos
-  )
-  if fragment.isNil:
-    return @[]
-  for root in fragment.entries.rootEntries:
-    result.add makeCursor(parent.zlevel, root.node, fragment)
+  for root in children.rootIds:
+    let appendedIdx = checkedFigIdx(base + root.int)
+    entries.childEntries.mgetOrPut(parentIdx.entryKey(), @[]).add(
+      appendedIdx.nodeChild()
+    )
+    if list.nodes[parentIdx.int].childCount ==
+        high(typeof(list.nodes[parentIdx.int].childCount)):
+      raise newException(RenderFragmentError, "RenderList parent childCount overflow")
+    inc list.nodes[parentIdx.int].childCount
+    result.add appendedIdx
+
+  for sourceParentIdx, node in children.nodes:
+    if node.childCount > 0:
+      let destinationParent = checkedFigIdx(base + sourceParentIdx)
+      var destinationEntries: seq[RenderChild]
+      for childIdx in children.nodes.childIndex(sourceParentIdx.FigIdx):
+        destinationEntries.add checkedFigIdx(base + childIdx.int).nodeChild()
+      entries.childEntries[destinationParent.entryKey()] = move destinationEntries
 
 proc addChildren*(
     fragments: RenderFragments,
@@ -465,8 +708,8 @@ proc addChildren*(
     parentIdx: FigIdx,
     children: sink RenderList,
 ): seq[FigIdx] {.discardable.} =
+  fragments.ensureLayer(lvl)
   children.relevelList(lvl)
-  discard fragments.layerState(lvl)
   fragments.base.layers[lvl].appendChildren(
     fragments.layerEntries[lvl], parentIdx, move children
   )
@@ -474,71 +717,177 @@ proc addChildren*(
 proc addChildren*(
     fragments: RenderFragments, parent: RenderCursor, children: sink RenderList
 ): seq[RenderCursor] {.discardable.} =
+  fragments.requireCursor(parent)
   children.relevelList(parent.zlevel)
   if parent.fragment.isNil:
     for index in fragments.addChildren(parent.zlevel, parent.index, move children):
-      result.add makeCursor(parent.zlevel, index)
+      result.add fragments.makeBaseCursor(parent.zlevel, index)
   else:
     for index in parent.fragment.list.appendChildren(
       parent.fragment.entries, parent.index, move children
     ):
-      result.add makeCursor(parent.zlevel, index, parent.fragment)
+      result.add fragments.makeFragmentCursor(parent.fragment, index)
 
-proc replaceFragmentChildren(
-    children: var seq[RenderChild],
-    target: RenderFragment,
-    replacementRoots: openArray[FigIdx],
-) =
-  var updated = newSeqOfCap[RenderChild](children.len + replacementRoots.len)
-  var replaced = false
-  for entry in children:
+proc attachChildFragment*(
+    fragments: RenderFragments,
+    parent: RenderCursor,
+    childPos: Natural,
+    contents: sink RenderList,
+): RenderFragmentHandle =
+  ## Attaches one persistent fragment slot as a logical child of `parent`.
+  ## `childPos` counts node and fragment slots, not expanded fragment roots.
+  fragments.requireCursor(parent)
+
+  let fragment = fragments.newFragment(parent.zlevel, move contents)
+  if parent.fragment.isNil:
+    let children = fragments.layerEntries[parent.zlevel].childEntries.mgetOrPut(
+      parent.index.entryKey(), @[]
+    )
+    if childPos.int > children.len:
+      fragment.attached = false
+      raise newException(RenderFragmentError, "child fragment position is out of range")
+    fragments.layerEntries[parent.zlevel].childEntries[parent.index.entryKey()].insert(
+      fragment.fragmentChild(), childPos.int
+    )
+  else:
+    let children =
+      parent.fragment.entries.childEntries.mgetOrPut(parent.index.entryKey(), @[])
+    if childPos.int > children.len:
+      fragment.attached = false
+      raise newException(RenderFragmentError, "child fragment position is out of range")
+    parent.fragment.entries.childEntries[parent.index.entryKey()].insert(
+      fragment.fragmentChild(), childPos.int
+    )
+  fragments.makeHandle(fragment)
+
+proc attachChildFragment*(
+    fragments: RenderFragments,
+    lvl: ZLevel,
+    parentIdx: FigIdx,
+    childPos: Natural,
+    contents: sink RenderList,
+): RenderFragmentHandle =
+  fragments.attachChildFragment(
+    fragments.nodeCursor(lvl, parentIdx), childPos, move contents
+  )
+
+proc attachRootFragment*(
+    fragments: RenderFragments, lvl: ZLevel, rootPos: Natural, contents: sink RenderList
+): RenderFragmentHandle =
+  ## Attaches one persistent fragment slot to a layer root sequence.
+  fragments.ensureLayer(lvl)
+  if rootPos.int > fragments.layerEntries[lvl].rootEntries.len:
+    raise newException(RenderFragmentError, "root fragment position is out of range")
+
+  let fragment = fragments.newFragment(lvl, move contents)
+  fragments.layerEntries[lvl].rootEntries.insert(fragment.fragmentChild(), rootPos.int)
+  fragments.makeHandle(fragment)
+
+proc replaceFragment*(
+    fragments: RenderFragments, handle: RenderFragmentHandle, contents: sink RenderList
+): RenderFragmentHandle =
+  ## Replaces fragment contents without changing the persistent attachment slot.
+  fragments.requireHandle(handle)
+  contents.relevelList(handle.fragment.zlevel)
+  contents.validateRootIds()
+  var entries: RenderEntries
+  contents.rebuildEntries(entries)
+
+  handle.fragment.entries.detachFragments()
+  handle.fragment.list = move contents
+  handle.fragment.entries = move entries
+  handle.fragment.generation.advance()
+  handle.fragment.nodeGeneration.advance()
+  fragments.makeHandle(handle.fragment)
+
+proc removeFragmentEdge(entries: var RenderEntries, target: RenderFragment): bool =
+  for idx, entry in entries.rootEntries:
     if entry.kind == rckFragment and entry.fragment == target:
-      if not replaced:
-        for root in replacementRoots:
-          updated.add target.fragmentChild(root)
-        replaced = true
-    else:
-      updated.add entry
-  children = move updated
+      entries.rootEntries.delete(idx)
+      return true
 
-proc replaceFragmentReferences(
-    entries: var RenderEntries,
-    target: RenderFragment,
-    replacementRoots: openArray[FigIdx],
-) =
   for _, children in entries.childEntries.mpairs:
-    children.replaceFragmentChildren(target, replacementRoots)
+    for idx, entry in children:
+      if entry.kind == rckFragment and entry.fragment == target:
+        children.delete(idx)
+        return true
 
-proc updateNestedReferences(
-    entries: var RenderEntries,
-    target: RenderFragment,
-    replacementRoots: openArray[FigIdx],
-) =
-  entries.replaceFragmentReferences(target, replacementRoots)
+  for entry in entries.rootEntries:
+    if entry.kind == rckFragment and entry.fragment.entries.removeFragmentEdge(target):
+      return true
   for _, children in entries.childEntries.mpairs:
     for entry in children:
-      if entry.kind == rckFragment and entry.fragment != target:
-        entry.fragment.entries.updateNestedReferences(target, replacementRoots)
+      if entry.kind == rckFragment and entry.fragment.entries.removeFragmentEdge(target):
+        return true
+
+proc removeFragment*(fragments: RenderFragments, handle: RenderFragmentHandle) =
+  fragments.requireHandle(handle)
+  var removed = false
+  for _, entries in fragments.layerEntries.mpairs:
+    if entries.removeFragmentEdge(handle.fragment):
+      removed = true
+      break
+  if not removed:
+    raise newException(RenderFragmentError, "fragment attachment is missing")
+  handle.fragment.detachFragment()
+
+proc insertChildren*(
+    fragments: RenderFragments,
+    lvl: ZLevel,
+    parentIdx: FigIdx,
+    children: sink RenderList,
+    childPos: Natural,
+): seq[RenderCursor] {.discardable.} =
+  ## Compatibility wrapper. New code should retain `attachChildFragment`'s
+  ## handle so an empty replacement can later become nonempty.
+  if children.nodes.len == 0:
+    return @[]
+  let handle = fragments.attachChildFragment(lvl, parentIdx, childPos, move children)
+  fragments.fragmentRoots(handle)
+
+proc insertChildren*(
+    fragments: RenderFragments,
+    parent: RenderCursor,
+    children: sink RenderList,
+    childPos: Natural,
+): seq[RenderCursor] {.discardable.} =
+  ## Compatibility wrapper. New code should use `attachChildFragment`.
+  if children.nodes.len == 0:
+    return @[]
+  let handle = fragments.attachChildFragment(parent, childPos, move children)
+  fragments.fragmentRoots(handle)
 
 proc updateFragment*(
     fragments: RenderFragments, cursor: RenderCursor, updated: sink RenderList
 ): seq[RenderCursor] {.discardable.} =
-  ## Replaces the fragment identified by `cursor` while preserving its identity
-  ## and position in the surrounding render tree.
-  assert not cursor.fragment.isNil
-  updated.relevelList(cursor.zlevel)
-  updated.validateRootIds()
+  ## Compatibility wrapper. New code should use `replaceFragment` and retain the
+  ## returned handle.
+  let handle = cursor.fragmentHandle()
+  let replacement = fragments.replaceFragment(handle, move updated)
+  fragments.fragmentRoots(replacement)
 
-  var updatedEntries: RenderEntries
-  updated.rebuildEntries(updatedEntries)
-  var replacementRoots: seq[FigIdx]
-  for root in updatedEntries.rootEntries:
-    replacementRoots.add root.node
+proc appendMaterialized(
+    fragments: RenderFragments,
+    list: var RenderList,
+    cursor: RenderCursor,
+    parent: FigIdx,
+): FigIdx =
+  var node = fragments[cursor]
+  node.childCount = 0
+  if parent.int < 0:
+    result = list.addRoot(node)
+  else:
+    result = list.addChild(parent, node)
+  for child in fragments.children(cursor):
+    discard fragments.appendMaterialized(list, child, result)
 
-  for _, entries in fragments.layerEntries.mpairs:
-    entries.updateNestedReferences(cursor.fragment, replacementRoots)
-
-  cursor.fragment.list = move updated
-  cursor.fragment.entries = move updatedEntries
-  for root in replacementRoots:
-    result.add makeCursor(cursor.zlevel, root, cursor.fragment)
+proc materialize*(fragments: RenderFragments): Renders =
+  ## Flattens the logical fragment graph into an independent monolithic tree.
+  if fragments.isNil:
+    raise newException(RenderFragmentError, "cannot materialize a nil fragment tree")
+  result = newRenders()
+  for lvl, _ in fragments.pairs():
+    var list = RenderList()
+    for root in fragments.roots(lvl):
+      discard fragments.appendMaterialized(list, root, (-1).FigIdx)
+    result.setLayer(lvl, move list)

--- a/src/figdraw/renderfragments.nim
+++ b/src/figdraw/renderfragments.nim
@@ -61,6 +61,12 @@
 ##     move C to position 0
 ##     after:  [fragment C] [fragment A] [fragment B]
 ##
+## When reconciling a complete sibling order, use `reorderChildFragments` or
+## `reorderRootFragments`. They reorder every fragment edge in one linear pass;
+## repeatedly moving individual siblings would require repeated sequence shifts.
+## Physical node positions remain fixed while fragment edges exchange their
+## fragment identities.
+##
 ## Fragment graphs are mutable and are not safe to share concurrently. Use a
 ## materialized `Renders` value when an independent snapshot is required.
 
@@ -1114,6 +1120,96 @@ proc moveFragmentToRoot*(
     ),
   )
 
+proc reorderFragmentEdges(
+    fragments: RenderFragments,
+    entries: var seq[RenderChild],
+    zlevel: ZLevel,
+    ordered: openArray[RenderFragmentHandle],
+) =
+  var available = initTable[uint64, RenderFragment]()
+  for entry in entries:
+    if entry.kind == rckFragment:
+      available[entry.fragment.id] = entry.fragment
+
+  if ordered.len != available.len:
+    raise newException(
+      RenderFragmentError, "fragment reorder must contain every sibling fragment"
+    )
+
+  var requested = initTable[uint64, bool]()
+  for handle in ordered:
+    fragments.requireHandle(handle)
+    if handle.fragment.zlevel != zlevel or handle.fragment.id notin available:
+      raise newException(
+        RenderFragmentError, "fragment reorder contains a non-sibling fragment"
+      )
+    if handle.fragment.id in requested:
+      raise newException(
+        RenderFragmentError, "fragment reorder contains a duplicate fragment"
+      )
+    requested[handle.fragment.id] = true
+
+  var
+    nextEntries = newSeqOfCap[RenderChild](entries.len)
+    fragmentIndex = 0
+  for entry in entries:
+    if entry.kind == rckNode:
+      nextEntries.add entry
+    else:
+      nextEntries.add ordered[fragmentIndex].fragment.fragmentChild()
+      inc fragmentIndex
+  entries = move nextEntries
+
+proc reorderChildFragments*(
+    fragments: RenderFragments,
+    parent: RenderCursor,
+    ordered: openArray[RenderFragmentHandle],
+) =
+  ## Reorders all direct child-fragment edges beneath `parent` in one pass.
+  ##
+  ## `ordered` must contain every directly attached child fragment exactly once.
+  ## Physical child nodes keep their positions; fragment edges exchange their
+  ## order around those nodes. Fragment IDs, generations, cursors, and nested
+  ## attachments remain valid. Invalid input raises `RenderFragmentError` before
+  ## mutation. Cost is O(n) in the logical child count.
+  fragments.requireCursor(parent)
+  let key = parent.index.entryKey()
+  if parent.fragment.isNil:
+    if key notin fragments.layerEntries[parent.zlevel].childEntries:
+      if ordered.len == 0:
+        return
+      raise newException(
+        RenderFragmentError, "fragment reorder contains a non-sibling fragment"
+      )
+    fragments.reorderFragmentEdges(
+      fragments.layerEntries[parent.zlevel].childEntries[key], parent.zlevel, ordered
+    )
+  else:
+    parent.fragment.list.ensureEntries(parent.fragment.entries)
+    if key notin parent.fragment.entries.childEntries:
+      if ordered.len == 0:
+        return
+      raise newException(
+        RenderFragmentError, "fragment reorder contains a non-sibling fragment"
+      )
+    fragments.reorderFragmentEdges(
+      parent.fragment.entries.childEntries[key], parent.zlevel, ordered
+    )
+
+proc reorderRootFragments*(
+    fragments: RenderFragments, zlevel: ZLevel, ordered: openArray[RenderFragmentHandle]
+) =
+  ## Reorders all fragment edges in one layer root sequence in one pass.
+  ##
+  ## `ordered` must contain every root fragment in the layer exactly once.
+  ## Physical roots keep their positions; fragment edges exchange their order
+  ## around those roots. Invalid input is rejected before mutation. Cost is O(n)
+  ## in the logical root count.
+  fragments.ensureLayer(zlevel)
+  fragments.reorderFragmentEdges(
+    fragments.layerEntries[zlevel].rootEntries, zlevel, ordered
+  )
+
 proc removeFragmentEdge(entries: var RenderEntries, target: RenderFragment): bool =
   for idx, entry in entries.rootEntries:
     if entry.kind == rckFragment and entry.fragment == target:
@@ -1181,20 +1277,65 @@ proc updateFragment*(
   let replacement = fragments.replaceFragmentSubtree(handle, move updated)
   fragments.fragmentRoots(replacement)
 
-proc appendMaterialized(
+proc appendMaterializedEntry(
+  fragments: RenderFragments,
+  list: var RenderList,
+  zlevel: ZLevel,
+  owner: RenderFragment,
+  entry: RenderChild,
+  parent: FigIdx,
+)
+
+proc appendMaterializedNode(
     fragments: RenderFragments,
     list: var RenderList,
-    cursor: RenderCursor,
+    zlevel: ZLevel,
+    owner: RenderFragment,
+    index: FigIdx,
     parent: FigIdx,
-): FigIdx =
-  var node = fragments[cursor]
-  node.childCount = 0
-  if parent.int < 0:
-    result = list.addRoot(node)
+) =
+  var
+    node: Fig
+    entries: ptr RenderEntries
+  if owner.isNil:
+    node = fragments.base.layers[zlevel].nodes[index.int]
+    entries = addr fragments.layerEntries[zlevel]
   else:
-    result = list.addChild(parent, node)
-  for child in fragments.children(cursor):
-    discard fragments.appendMaterialized(list, child, result)
+    node = owner.list.nodes[index.int]
+    entries = addr owner.entries
+
+  node.childCount = 0
+  var materialized: FigIdx
+  if parent.int < 0:
+    materialized = list.addRoot(node)
+  else:
+    materialized = list.addChild(parent, node)
+
+  let key = index.entryKey()
+  if key in entries[].childEntries:
+    let children = addr entries[].childEntries[key]
+    for child in children[]:
+      fragments.appendMaterializedEntry(list, zlevel, owner, child, materialized)
+
+proc appendMaterializedEntry(
+    fragments: RenderFragments,
+    list: var RenderList,
+    zlevel: ZLevel,
+    owner: RenderFragment,
+    entry: RenderChild,
+    parent: FigIdx,
+) =
+  case entry.kind
+  of rckNode:
+    fragments.appendMaterializedNode(list, zlevel, owner, entry.node, parent)
+  of rckFragment:
+    if not entry.fragment.attached:
+      raise
+        newException(RenderFragmentError, "render tree contains a detached fragment")
+    for root in entry.fragment.entries.rootEntries:
+      if root.kind != rckNode:
+        raise newException(RenderFragmentError, "fragment root metadata is invalid")
+      fragments.appendMaterializedNode(list, zlevel, entry.fragment, root.node, parent)
 
 proc materialize*(fragments: RenderFragments): Renders =
   ## Flattens the logical fragment graph into an independent monolithic tree.
@@ -1203,6 +1344,6 @@ proc materialize*(fragments: RenderFragments): Renders =
   result = newRenders()
   for lvl in fragments.levels():
     var list = RenderList()
-    for root in fragments.roots(lvl):
-      discard fragments.appendMaterialized(list, root, (-1).FigIdx)
+    for root in fragments.layerEntries[lvl].rootEntries:
+      fragments.appendMaterializedEntry(list, lvl, nil, root, (-1).FigIdx)
     result.setLayer(lvl, move list)

--- a/src/figdraw/renderfragments.nim
+++ b/src/figdraw/renderfragments.nim
@@ -412,13 +412,22 @@ proc effectiveChildCount*(fragments: RenderFragments, parent: RenderCursor): int
     parent.fragment.entries.childEntries.getOrDefault(parent.index.entryKey())
   fragments.expandedCount(children)
 
-template pairs*(fragments: RenderFragments): auto =
-  fragments.base.layers.pairs()
+iterator levels*(fragments: RenderFragments): ZLevel =
+  ## Iterates layer identities without exposing mutable `RenderList` storage.
+  for lvl in fragments.base.layers.keys:
+    yield lvl
 
-proc `[]`*(fragments: RenderFragments, lvl: ZLevel): lent RenderList =
+iterator pairs*(fragments: RenderFragments): (ZLevel, RenderList) =
+  ## Iterates layers as detached diagnostic copies.
+  for lvl, list in fragments.base.layers.pairs():
+    yield (lvl, list.cloneRenderList())
+
+proc `[]`*(fragments: RenderFragments, lvl: ZLevel): RenderList =
+  ## Returns a detached layer copy so raw sequence mutation cannot invalidate
+  ## the fragment tree's traversal metadata.
   if fragments.isNil or lvl notin fragments.base.layers:
     raise newException(KeyError, "render layer does not exist")
-  fragments.base.layers[lvl]
+  fragments.base.layers[lvl].cloneRenderList()
 
 proc setLayer*(fragments: RenderFragments, lvl: ZLevel, list: sink RenderList) =
   if lvl in fragments.layerEntries:
@@ -886,7 +895,7 @@ proc materialize*(fragments: RenderFragments): Renders =
   if fragments.isNil:
     raise newException(RenderFragmentError, "cannot materialize a nil fragment tree")
   result = newRenders()
-  for lvl, _ in fragments.pairs():
+  for lvl in fragments.levels():
     var list = RenderList()
     for root in fragments.roots(lvl):
       discard fragments.appendMaterialized(list, root, (-1).FigIdx)

--- a/src/figdraw/renderfragments.nim
+++ b/src/figdraw/renderfragments.nim
@@ -1,3 +1,69 @@
+## Fragment-backed render trees
+## ============================
+##
+## `RenderFragments` stores independently replaceable render subtrees behind
+## persistent logical attachment slots. A fragment ID belongs to its slot rather
+## than to any physical `FigIdx`, so replacing one fragment does not reindex base
+## nodes or change sibling fragment identities::
+##
+##     parent
+##     +-- fragment A (id 10) -> [A0, A1]
+##     +-- fragment B (id 11) -> [B0]
+##
+##     replace A
+##
+##     parent
+##     +-- fragment A (id 10) -> [A2, A3, A4]
+##     +-- fragment B (id 11) -> [B0]
+##
+## The returned handle for A has a new generation. The old A handle is stale,
+## while the handle and cursors for B remain valid. `materialize` assigns fresh
+## physical indexes only in its independent monolithic output.
+##
+## Persistent empty attachments
+## ----------------------------
+##
+## One fragment edge represents one position, regardless of how many roots its
+## current contents contain::
+##
+##     slots:       [header] [menu fragment]       [footer]
+##     zero roots:   header                         footer
+##     one root:     header   menu                  footer
+##     many roots:   header   item-1 item-2 item-3  footer
+##
+## Replacing the menu with an empty `RenderList` therefore emits no nodes but
+## retains its handle and exact position. It can later receive one or many roots
+## without inspecting or reindexing its neighbours.
+##
+## Stable structure and replaceable drawing
+## ----------------------------------------
+##
+## Nested fragments are useful when stable structural nodes own independently
+## replaceable drawing and child slots::
+##
+##     view shell fragment
+##     +-- stable transform/clip node
+##         +-- self-drawing fragment
+##         +-- child-view fragment
+##         +-- child-view fragment
+##
+## Use `updateNode` for the stable node and `replaceFragment` for a leaf such as
+## self-drawing. Safe replacement rejects fragments that still contain nested
+## attachments. When discarding a whole logical subtree is intended, use
+## `replaceFragmentSubtree`; it explicitly detaches every nested fragment and
+## invalidates their handles.
+##
+## Use `moveFragment` and `moveFragmentToRoot` to reconcile ordering without
+## replacing content. Moving a fragment preserves its ID, generation, node
+## cursors, and all nested attachments::
+##
+##     before: [fragment A] [fragment B] [fragment C]
+##     move C to position 0
+##     after:  [fragment C] [fragment A] [fragment B]
+##
+## Fragment graphs are mutable and are not safe to share concurrently. Use a
+## materialized `Renders` value when an independent snapshot is required.
+
 import std/tables
 
 import ./fignodes
@@ -28,6 +94,12 @@ type
     childEntries: Table[int16, seq[RenderChild]]
     rootEntries: seq[RenderChild]
     ready: bool
+
+  FragmentAttachment = object
+    zlevel: ZLevel
+    owner: RenderFragment
+    parent: FigIdx
+    position: int
 
   RenderFragment = ref object
     id: uint64
@@ -308,6 +380,10 @@ proc fragmentHandle*(cursor: RenderCursor): RenderFragmentHandle =
   cursor.owner.makeHandle(cursor.fragment)
 
 proc fragmentId*(handle: RenderFragmentHandle): uint64 =
+  ## Returns the stable tree-local identity of a fragment attachment.
+  ##
+  ## Replacement and movement preserve this value. A zero value identifies an
+  ## uninitialized handle.
   if handle.fragment.isNil:
     return 0
   handle.fragment.id
@@ -322,6 +398,26 @@ proc expandedCount(fragments: RenderFragments, entries: openArray[RenderChild]):
         result += entry.fragment.entries.rootEntries.len
 
 proc detachFragment(fragment: RenderFragment)
+
+proc hasFragmentEdges(entries: RenderEntries): bool =
+  for entry in entries.rootEntries:
+    if entry.kind == rckFragment:
+      return true
+  for _, children in entries.childEntries:
+    for entry in children:
+      if entry.kind == rckFragment:
+        return true
+
+proc hasNestedFragments*(
+    fragments: RenderFragments, handle: RenderFragmentHandle
+): bool =
+  ## Reports whether `handle` owns any nested fragment attachments.
+  ##
+  ## A fragment with nested attachments cannot be passed to `replaceFragment`.
+  ## Use narrower leaf fragments, or call `replaceFragmentSubtree` when all
+  ## nested attachments should be detached deliberately.
+  fragments.requireHandle(handle)
+  handle.fragment.entries.hasFragmentEdges()
 
 proc detachFragments(entries: RenderEntries) =
   for entry in entries.rootEntries:
@@ -339,6 +435,129 @@ proc detachFragment(fragment: RenderFragment) =
   fragment.attached = false
   fragment.generation.advance()
   fragment.nodeGeneration.advance()
+
+proc containsFragment(entries: RenderEntries, target: RenderFragment): bool =
+  for entry in entries.rootEntries:
+    if entry.kind == rckFragment:
+      if entry.fragment == target or entry.fragment.entries.containsFragment(target):
+        return true
+  for _, children in entries.childEntries:
+    for entry in children:
+      if entry.kind == rckFragment:
+        if entry.fragment == target or entry.fragment.entries.containsFragment(target):
+          return true
+
+proc findFragmentAttachment(
+    entries: RenderEntries,
+    zlevel: ZLevel,
+    owner: RenderFragment,
+    target: RenderFragment,
+    attachment: var FragmentAttachment,
+): bool =
+  for position, entry in entries.rootEntries:
+    if entry.kind == rckFragment:
+      if entry.fragment == target:
+        attachment = FragmentAttachment(
+          zlevel: zlevel, owner: owner, parent: (-1).FigIdx, position: position
+        )
+        return true
+      if entry.fragment.entries.findFragmentAttachment(
+        zlevel, entry.fragment, target, attachment
+      ):
+        return true
+
+  for parent, children in entries.childEntries:
+    for position, entry in children:
+      if entry.kind == rckFragment:
+        if entry.fragment == target:
+          attachment = FragmentAttachment(
+            zlevel: zlevel, owner: owner, parent: parent.FigIdx, position: position
+          )
+          return true
+        if entry.fragment.entries.findFragmentAttachment(
+          zlevel, entry.fragment, target, attachment
+        ):
+          return true
+
+proc findFragmentAttachment(
+    fragments: RenderFragments,
+    target: RenderFragment,
+    attachment: var FragmentAttachment,
+): bool =
+  for zlevel, entries in fragments.layerEntries:
+    if entries.findFragmentAttachment(zlevel, nil, target, attachment):
+      return true
+
+func sameSequence(a, b: FragmentAttachment): bool =
+  a.zlevel == b.zlevel and a.owner == b.owner and a.parent == b.parent
+
+proc entryCount(fragments: RenderFragments, attachment: FragmentAttachment): int =
+  if attachment.owner.isNil:
+    if attachment.parent.int < 0:
+      return fragments.layerEntries[attachment.zlevel].rootEntries.len
+    return fragments.layerEntries[attachment.zlevel].childEntries.getOrDefault(
+      attachment.parent.entryKey()
+    ).len
+
+  if attachment.parent.int < 0:
+    return attachment.owner.entries.rootEntries.len
+  attachment.owner.entries.childEntries.getOrDefault(attachment.parent.entryKey()).len
+
+proc deleteEntry(fragments: RenderFragments, attachment: FragmentAttachment) =
+  if attachment.owner.isNil:
+    if attachment.parent.int < 0:
+      fragments.layerEntries[attachment.zlevel].rootEntries.delete(attachment.position)
+    else:
+      fragments.layerEntries[attachment.zlevel].childEntries[
+        attachment.parent.entryKey()
+      ].delete(attachment.position)
+  elif attachment.parent.int < 0:
+    attachment.owner.entries.rootEntries.delete(attachment.position)
+  else:
+    attachment.owner.entries.childEntries[attachment.parent.entryKey()].delete(
+      attachment.position
+    )
+
+proc insertEntry(
+    fragments: RenderFragments, attachment: FragmentAttachment, fragment: RenderFragment
+) =
+  let entry = fragment.fragmentChild()
+  if attachment.owner.isNil:
+    if attachment.parent.int < 0:
+      fragments.layerEntries[attachment.zlevel].rootEntries.insert(
+        entry, attachment.position
+      )
+    else:
+      fragments.layerEntries[attachment.zlevel].childEntries
+      .mgetOrPut(attachment.parent.entryKey(), @[])
+      .insert(entry, attachment.position)
+  elif attachment.parent.int < 0:
+    attachment.owner.entries.rootEntries.insert(entry, attachment.position)
+  else:
+    attachment.owner.entries.childEntries
+    .mgetOrPut(attachment.parent.entryKey(), @[])
+    .insert(entry, attachment.position)
+
+proc moveFragmentTo(
+    fragments: RenderFragments,
+    handle: RenderFragmentHandle,
+    destination: FragmentAttachment,
+): RenderFragmentHandle =
+  var source: FragmentAttachment
+  if not fragments.findFragmentAttachment(handle.fragment, source):
+    raise newException(RenderFragmentError, "fragment attachment is missing")
+
+  var destinationLength = fragments.entryCount(destination)
+  if source.sameSequence(destination):
+    dec destinationLength
+  if destination.position > destinationLength:
+    raise newException(RenderFragmentError, "fragment destination is out of range")
+  if source.sameSequence(destination) and source.position == destination.position:
+    return handle
+
+  fragments.deleteEntry(source)
+  fragments.insertEntry(destination, handle.fragment)
+  fragments.makeHandle(handle.fragment)
 
 proc newFragment(
     fragments: RenderFragments, lvl: ZLevel, contents: sink RenderList
@@ -792,11 +1011,9 @@ proc attachRootFragment*(
   fragments.layerEntries[lvl].rootEntries.insert(fragment.fragmentChild(), rootPos.int)
   fragments.makeHandle(fragment)
 
-proc replaceFragment*(
+proc installFragmentContents(
     fragments: RenderFragments, handle: RenderFragmentHandle, contents: sink RenderList
 ): RenderFragmentHandle =
-  ## Replaces fragment contents without changing the persistent attachment slot.
-  fragments.requireHandle(handle)
   contents.relevelList(handle.fragment.zlevel)
   contents.validateRootIds()
   var entries: RenderEntries
@@ -808,6 +1025,94 @@ proc replaceFragment*(
   handle.fragment.generation.advance()
   handle.fragment.nodeGeneration.advance()
   fragments.makeHandle(handle.fragment)
+
+proc replaceFragment*(
+    fragments: RenderFragments, handle: RenderFragmentHandle, contents: sink RenderList
+): RenderFragmentHandle =
+  ## Replaces leaf-fragment contents without changing its persistent slot.
+  ##
+  ## The fragment ID is preserved and the returned handle carries its next
+  ## generation. The previous handle and cursors into the replaced fragment
+  ## become stale; sibling and ancestor handles and cursors remain valid.
+  ##
+  ## This safe operation raises `RenderFragmentError` before mutation when the
+  ## fragment contains nested attachments. Replace the narrower leaf fragment
+  ## instead, or use `replaceFragmentSubtree` to detach the entire nested graph.
+  fragments.requireHandle(handle)
+  if handle.fragment.entries.hasFragmentEdges():
+    raise newException(
+      RenderFragmentError,
+      "cannot replace a fragment with nested attachments; use " &
+        "replaceFragmentSubtree to detach them",
+    )
+  fragments.installFragmentContents(handle, move contents)
+
+proc replaceFragmentSubtree*(
+    fragments: RenderFragments, handle: RenderFragmentHandle, contents: sink RenderList
+): RenderFragmentHandle =
+  ## Replaces a complete fragment subtree and detaches every nested fragment.
+  ##
+  ## Use this destructive operation only when the nested attachment identities
+  ## are no longer needed. All descendant handles and cursors become detached.
+  ## The target fragment keeps its ID and receives a new-generation handle.
+  fragments.requireHandle(handle)
+  fragments.installFragmentContents(handle, move contents)
+
+proc moveFragment*(
+    fragments: RenderFragments,
+    handle: RenderFragmentHandle,
+    parent: RenderCursor,
+    childPos: Natural,
+): RenderFragmentHandle =
+  ## Moves or reorders a fragment beneath `parent` without replacing it.
+  ##
+  ## `childPos` is the fragment's position in the final logical child-slot
+  ## sequence and counts both physical nodes and fragment slots. Movement
+  ## preserves the fragment ID, generation, cursors, and nested attachments.
+  ## Moving across layers or beneath the fragment's own subtree raises
+  ## `RenderFragmentError` without changing the graph.
+  fragments.requireHandle(handle)
+  fragments.requireCursor(parent)
+  if handle.fragment.zlevel != parent.zlevel:
+    raise newException(RenderFragmentError, "cannot move a fragment between layers")
+  if not parent.fragment.isNil and (
+    parent.fragment == handle.fragment or
+    handle.fragment.entries.containsFragment(parent.fragment)
+  ):
+    raise newException(RenderFragmentError, "cannot move a fragment beneath itself")
+
+  fragments.moveFragmentTo(
+    handle,
+    FragmentAttachment(
+      zlevel: parent.zlevel,
+      owner: parent.fragment,
+      parent: parent.index,
+      position: childPos.int,
+    ),
+  )
+
+proc moveFragmentToRoot*(
+    fragments: RenderFragments,
+    handle: RenderFragmentHandle,
+    zlevel: ZLevel,
+    rootPos: Natural,
+): RenderFragmentHandle =
+  ## Moves or reorders a fragment in a layer's root sequence without replacing it.
+  ##
+  ## `rootPos` is the fragment's position in the final logical root-slot
+  ## sequence. Movement preserves the fragment ID, generation, cursors, and all
+  ## nested attachments. Moving between layers raises `RenderFragmentError`
+  ## without changing the graph.
+  fragments.requireHandle(handle)
+  if handle.fragment.zlevel != zlevel:
+    raise newException(RenderFragmentError, "cannot move a fragment between layers")
+
+  fragments.moveFragmentTo(
+    handle,
+    FragmentAttachment(
+      zlevel: zlevel, owner: nil, parent: (-1).FigIdx, position: rootPos.int
+    ),
+  )
 
 proc removeFragmentEdge(entries: var RenderEntries, target: RenderFragment): bool =
   for idx, entry in entries.rootEntries:
@@ -870,9 +1175,10 @@ proc updateFragment*(
     fragments: RenderFragments, cursor: RenderCursor, updated: sink RenderList
 ): seq[RenderCursor] {.discardable.} =
   ## Compatibility wrapper. New code should use `replaceFragment` and retain the
-  ## returned handle.
+  ## returned handle. This preserves the wrapper's historical destructive
+  ## replacement behavior for nested fragments.
   let handle = cursor.fragmentHandle()
-  let replacement = fragments.replaceFragment(handle, move updated)
+  let replacement = fragments.replaceFragmentSubtree(handle, move updated)
   fragments.fragmentRoots(replacement)
 
 proc appendMaterialized(

--- a/tests/trenderfragments.nim
+++ b/tests/trenderfragments.nim
@@ -320,6 +320,22 @@ suite "RenderFragments APIs":
     check roots.mapIt(fragments[it].nodeId()) == @[10]
     check fragments.childIds(roots[0]) == @[20]
 
+  test "layer reads cannot mutate fragment topology":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+    discard fragments.addChild(0.ZLevel, root, testFig(20))
+
+    var layerCopy = fragments[0.ZLevel]
+    layerCopy.nodes[0].childCount = 0
+    layerCopy.rootIds.setLen(0)
+    for _, list in fragments.pairs():
+      var pairCopy = list
+      pairCopy.nodes.setLen(0)
+
+    let roots = fragments.rootCursors(0.ZLevel)
+    check roots.mapIt(fragments[it].nodeId()) == @[10]
+    check fragments.childIds(roots[0]) == @[20]
+
   test "controlled node update preserves topology":
     let fragments = newRenderFragments()
     let root = fragments.addRoot(4.ZLevel, testFig(10))

--- a/tests/trenderfragments.nim
+++ b/tests/trenderfragments.nim
@@ -19,6 +19,14 @@ proc rootCursors(fragments: RenderFragments, zlevel: ZLevel): seq[RenderCursor] 
   for root in fragments.roots(zlevel):
     result.add root
 
+proc rootCursors(renders: Renders, zlevel: ZLevel): seq[RenderCursor] =
+  for root in renders.roots(zlevel):
+    result.add root
+
+proc childIds(renders: Renders, parent: RenderCursor): seq[int] =
+  for child in renders.children(parent):
+    result.add renders[child].nodeId()
+
 type RecordingBackend = ref object of BackendContext
   mat: Mat4
   mats: seq[Mat4]
@@ -204,3 +212,152 @@ suite "RenderFragments APIs":
 
     check fragments.childIds(roots[0]) == @[11]
     check renders[2.ZLevel].nodes.mapIt(it.nodeId()) == @[10, 11]
+
+  test "persistent child fragment survives empty replacement":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+    discard fragments.addChild(0.ZLevel, root, testFig(40))
+
+    var initial = RenderList()
+    discard initial.addRoot(testFig(20))
+    discard initial.addRoot(testFig(30))
+    let handle = fragments.attachChildFragment(0.ZLevel, root, 0, move initial)
+
+    let emptyHandle = fragments.replaceFragment(handle, RenderList())
+    let roots = fragments.rootCursors(0.ZLevel)
+    check fragments.fragmentRoots(emptyHandle).len == 0
+    check fragments.childIds(roots[0]) == @[40]
+
+    var restored = RenderList()
+    discard restored.addRoot(testFig(50))
+    discard restored.addRoot(testFig(60))
+    let restoredHandle = fragments.replaceFragment(emptyHandle, move restored)
+
+    check fragments.fragmentRoots(restoredHandle).len == 2
+    check fragments.childIds(roots[0]) == @[50, 60, 40]
+
+  test "persistent root fragment retains layer position":
+    let fragments = newRenderFragments()
+    discard fragments.addRoot(3.ZLevel, testFig(40))
+
+    var initial = RenderList()
+    discard initial.addRoot(testFig(10))
+    discard initial.addRoot(testFig(20))
+    let handle = fragments.attachRootFragment(3.ZLevel, 0, move initial)
+    check fragments.rootCursors(3.ZLevel).mapIt(fragments[it].nodeId()) == @[10, 20, 40]
+
+    let emptyHandle = fragments.replaceFragment(handle, RenderList())
+    check fragments.rootCursors(3.ZLevel).mapIt(fragments[it].nodeId()) == @[40]
+
+    var restored = RenderList()
+    discard restored.addRoot(testFig(30))
+    discard fragments.replaceFragment(emptyHandle, move restored)
+    check fragments.rootCursors(3.ZLevel).mapIt(fragments[it].nodeId()) == @[30, 40]
+
+  test "rejects foreign stale and detached handles":
+    let first = newRenderFragments()
+    let firstRoot = first.addRoot(0.ZLevel, testFig(10))
+    var child = RenderList()
+    discard child.addRoot(testFig(20))
+    let handle = first.attachChildFragment(0.ZLevel, firstRoot, 0, move child)
+
+    let second = newRenderFragments()
+    check second.handleStatus(handle) == rfsForeignTree
+    expect RenderFragmentError:
+      discard second.replaceFragment(handle, RenderList())
+    check first.fragmentRoots(handle).mapIt(first[it].nodeId()) == @[20]
+
+    var replacement = RenderList()
+    discard replacement.addRoot(testFig(30))
+    let current = first.replaceFragment(handle, move replacement)
+    check first.handleStatus(handle) == rfsStaleFragment
+    check first.handleStatus(current) == rfsValid
+    expect RenderFragmentError:
+      discard first.replaceFragment(handle, RenderList())
+
+    first.removeFragment(current)
+    check first.handleStatus(current) == rfsDetached
+    expect RenderFragmentError:
+      discard first.fragmentRoots(current)
+
+  test "invalidates handles after clear and layer replacement":
+    let cleared = newRenderFragments()
+    let clearedRoot = cleared.addRoot(0.ZLevel, testFig(10))
+    let clearHandle =
+      cleared.attachChildFragment(0.ZLevel, clearedRoot, 0, RenderList())
+    cleared.clear()
+    check cleared.handleStatus(clearHandle) == rfsStaleTree
+
+    let replaced = newRenderFragments()
+    let replacedRoot = replaced.addRoot(2.ZLevel, testFig(10))
+    let layerHandle =
+      replaced.attachChildFragment(2.ZLevel, replacedRoot, 0, RenderList())
+    replaced.setLayer(2.ZLevel, RenderList())
+    check replaced.handleStatus(layerHandle) == rfsStaleLayer
+
+  test "rejects cursors from replaced fragments":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+    var initial = RenderList()
+    discard initial.addRoot(testFig(20))
+    let handle = fragments.attachChildFragment(0.ZLevel, root, 0, move initial)
+    let staleCursor = fragments.fragmentRoots(handle)[0]
+
+    var replacement = RenderList()
+    discard replacement.addRoot(testFig(30))
+    discard fragments.replaceFragment(handle, move replacement)
+    expect RenderFragmentError:
+      discard fragments[staleCursor]
+
+  test "wrapping copies source topology":
+    let renders = newRenders()
+    let root = renders.addRoot(0.ZLevel, testFig(10))
+    discard renders.addChild(0.ZLevel, root, testFig(20))
+    let fragments = newRenderFragments(renders)
+
+    renders[0.ZLevel].clear()
+    let roots = fragments.rootCursors(0.ZLevel)
+    check roots.mapIt(fragments[it].nodeId()) == @[10]
+    check fragments.childIds(roots[0]) == @[20]
+
+  test "controlled node update preserves topology":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(4.ZLevel, testFig(10))
+    discard fragments.addChild(4.ZLevel, root, testFig(20))
+    let cursor = fragments.nodeCursor(4.ZLevel, root)
+
+    var replacement = testFig(11, 9.ZLevel)
+    replacement.parent = 99.FigIdx
+    replacement.childCount = 99
+    fragments.updateNode(cursor, replacement)
+
+    check fragments[cursor].nodeId() == 11
+    check fragments[cursor].zlevel == 4.ZLevel
+    check fragments[cursor].parent == (-1).FigIdx
+    check fragments[cursor].childCount == 1
+    check fragments.childIds(cursor) == @[20]
+
+  test "materializes nested fragments in logical order":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+    discard fragments.addChild(0.ZLevel, root, testFig(40))
+
+    var child = RenderList()
+    let childRoot = child.addRoot(testFig(20))
+    discard child.addChild(childRoot, testFig(21))
+    discard child.addRoot(testFig(30))
+    let childHandle = fragments.attachChildFragment(0.ZLevel, root, 0, move child)
+
+    var nested = RenderList()
+    discard nested.addRoot(testFig(22))
+    discard fragments.attachChildFragment(
+      fragments.fragmentRoots(childHandle)[0], 1, move nested
+    )
+
+    let renders = fragments.materialize()
+    let roots = renders.rootCursors(0.ZLevel)
+    check renders[0.ZLevel].nodes.mapIt(it.nodeId()) == @[10, 20, 21, 22, 30, 40]
+    check roots.mapIt(renders[it].nodeId()) == @[10]
+    check renders.childIds(roots[0]) == @[20, 30, 40]
+    let firstChild = toSeq(renders.children(roots[0]))[0]
+    check renders.childIds(firstChild) == @[21, 22]

--- a/tests/trenderfragments.nim
+++ b/tests/trenderfragments.nim
@@ -381,6 +381,81 @@ suite "RenderFragments APIs":
     check restored.fragmentId() == empty.fragmentId()
     check fragments.childIds(fragments.nodeCursor(0.ZLevel, root)) == @[30, 20]
 
+  test "bulk reorders sibling fragments without moving physical nodes":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+    discard fragments.addChild(0.ZLevel, root, testFig(11))
+    let parent = fragments.nodeCursor(0.ZLevel, root)
+
+    var firstContents = RenderList()
+    discard firstContents.addRoot(testFig(20))
+    let first = fragments.attachChildFragment(parent, 0, move firstContents)
+    let firstRoot = fragments.fragmentRoots(first)[0]
+
+    var nestedContents = RenderList()
+    discard nestedContents.addRoot(testFig(21))
+    let nested = fragments.attachChildFragment(firstRoot, 0, move nestedContents)
+    let nestedRoot = fragments.fragmentRoots(nested)[0]
+
+    var secondContents = RenderList()
+    discard secondContents.addRoot(testFig(30))
+    let second = fragments.attachChildFragment(parent, 2, move secondContents)
+
+    var thirdContents = RenderList()
+    discard thirdContents.addRoot(testFig(40))
+    let third = fragments.attachChildFragment(parent, 1, move thirdContents)
+
+    fragments.reorderChildFragments(parent, [third, second, first])
+    check fragments.childIds(parent) == @[40, 30, 11, 20]
+    check fragments.isValid(first)
+    check fragments.isValid(second)
+    check fragments.isValid(third)
+    check fragments.isValid(nested)
+    check fragments[nestedRoot].nodeId() == 21
+
+    var firstRootContents = RenderList()
+    discard firstRootContents.addRoot(testFig(50))
+    let firstRootFragment =
+      fragments.attachRootFragment(0.ZLevel, 0, move firstRootContents)
+    var secondRootContents = RenderList()
+    discard secondRootContents.addRoot(testFig(60))
+    let secondRootFragment =
+      fragments.attachRootFragment(0.ZLevel, 2, move secondRootContents)
+
+    fragments.reorderRootFragments(0.ZLevel, [secondRootFragment, firstRootFragment])
+    check fragments.rootCursors(0.ZLevel).mapIt(fragments[it].nodeId()) == @[60, 10, 50]
+
+  test "invalid bulk reorders leave sibling order unchanged":
+    let
+      fragments = newRenderFragments()
+      other = newRenderFragments()
+      root = fragments.addRoot(0.ZLevel, testFig(10))
+      parent = fragments.nodeCursor(0.ZLevel, root)
+
+    var firstContents = RenderList()
+    discard firstContents.addRoot(testFig(20))
+    let first = fragments.attachChildFragment(parent, 0, move firstContents)
+    var secondContents = RenderList()
+    discard secondContents.addRoot(testFig(30))
+    let second = fragments.attachChildFragment(parent, 1, move secondContents)
+
+    let otherRoot = other.addRoot(0.ZLevel, testFig(40))
+    var foreignContents = RenderList()
+    discard foreignContents.addRoot(testFig(50))
+    let foreign =
+      other.attachChildFragment(0.ZLevel, otherRoot, 0, move foreignContents)
+
+    expect RenderFragmentError:
+      fragments.reorderChildFragments(parent, [first])
+    expect RenderFragmentError:
+      fragments.reorderChildFragments(parent, [first, first])
+    expect RenderFragmentError:
+      fragments.reorderChildFragments(parent, [first, foreign])
+
+    check fragments.childIds(parent) == @[20, 30]
+    check fragments.isValid(first)
+    check fragments.isValid(second)
+
   test "invalid fragment moves leave the graph unchanged":
     let fragments = newRenderFragments()
     let root = fragments.addRoot(0.ZLevel, testFig(10))

--- a/tests/trenderfragments.nim
+++ b/tests/trenderfragments.nim
@@ -254,6 +254,159 @@ suite "RenderFragments APIs":
     discard fragments.replaceFragment(emptyHandle, move restored)
     check fragments.rootCursors(3.ZLevel).mapIt(fragments[it].nodeId()) == @[30, 40]
 
+  test "safe replacement rejects nested attachments":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+
+    var outerContents = RenderList()
+    discard outerContents.addRoot(testFig(20))
+    let outer = fragments.attachChildFragment(0.ZLevel, root, 0, move outerContents)
+    let outerRoot = fragments.fragmentRoots(outer)[0]
+
+    var innerContents = RenderList()
+    discard innerContents.addRoot(testFig(30))
+    let inner = fragments.attachChildFragment(outerRoot, 0, move innerContents)
+
+    check fragments.hasNestedFragments(outer)
+    check not fragments.hasNestedFragments(inner)
+    expect RenderFragmentError:
+      discard fragments.replaceFragment(outer, RenderList())
+    check fragments.isValid(outer)
+    check fragments.isValid(inner)
+    check fragments.childIds(outerRoot) == @[30]
+
+    var replacement = RenderList()
+    discard replacement.addRoot(testFig(40))
+    let replaced = fragments.replaceFragmentSubtree(outer, move replacement)
+    check replaced.fragmentId() == outer.fragmentId()
+    check fragments.handleStatus(outer) == rfsStaleFragment
+    check fragments.handleStatus(inner) == rfsDetached
+    check fragments.fragmentRoots(replaced).mapIt(fragments[it].nodeId()) == @[40]
+
+  test "leaf replacement preserves ancestor and sibling generations":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+
+    var ancestorContents = RenderList()
+    discard ancestorContents.addRoot(testFig(20))
+    let ancestor =
+      fragments.attachChildFragment(0.ZLevel, root, 0, move ancestorContents)
+    let ancestorRoot = fragments.fragmentRoots(ancestor)[0]
+
+    var leafContents = RenderList()
+    discard leafContents.addRoot(testFig(30))
+    let leaf = fragments.attachChildFragment(ancestorRoot, 0, move leafContents)
+
+    var siblingContents = RenderList()
+    discard siblingContents.addRoot(testFig(40))
+    let sibling = fragments.attachChildFragment(ancestorRoot, 1, move siblingContents)
+    let siblingRoot = fragments.fragmentRoots(sibling)[0]
+
+    var replacement = RenderList()
+    discard replacement.addRoot(testFig(31))
+    let updatedLeaf = fragments.replaceFragment(leaf, move replacement)
+
+    check fragments.handleStatus(leaf) == rfsStaleFragment
+    check fragments.isValid(updatedLeaf)
+    check fragments.isValid(ancestor)
+    check fragments.isValid(sibling)
+    check fragments[ancestorRoot].nodeId() == 20
+    check fragments[siblingRoot].nodeId() == 40
+    check fragments.childIds(ancestorRoot) == @[31, 40]
+
+  test "moves and reorders fragments without changing their generations":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+
+    var firstContents = RenderList()
+    discard firstContents.addRoot(testFig(20))
+    let first = fragments.attachChildFragment(0.ZLevel, root, 0, move firstContents)
+    let firstRoot = fragments.fragmentRoots(first)[0]
+
+    var nestedContents = RenderList()
+    discard nestedContents.addRoot(testFig(21))
+    let nested = fragments.attachChildFragment(firstRoot, 0, move nestedContents)
+    let nestedRoot = fragments.fragmentRoots(nested)[0]
+
+    var secondContents = RenderList()
+    discard secondContents.addRoot(testFig(30))
+    let second = fragments.attachChildFragment(0.ZLevel, root, 1, move secondContents)
+    let secondRoot = fragments.fragmentRoots(second)[0]
+
+    var thirdContents = RenderList()
+    discard thirdContents.addRoot(testFig(40))
+    let third = fragments.attachChildFragment(0.ZLevel, root, 2, move thirdContents)
+    let thirdRoot = fragments.fragmentRoots(third)[0]
+
+    let reordered =
+      fragments.moveFragment(third, fragments.nodeCursor(0.ZLevel, root), 0)
+    check reordered == third
+    check fragments.childIds(fragments.nodeCursor(0.ZLevel, root)) == @[40, 20, 30]
+    check fragments[firstRoot].nodeId() == 20
+    check fragments[nestedRoot].nodeId() == 21
+
+    let reparented = fragments.moveFragment(first, secondRoot, 0)
+    check reparented == first
+    check fragments.childIds(fragments.nodeCursor(0.ZLevel, root)) == @[40, 30]
+    check fragments.childIds(secondRoot) == @[20]
+    check fragments.childIds(firstRoot) == @[21]
+    check fragments.isValid(nested)
+
+    let rooted = fragments.moveFragmentToRoot(first, 0.ZLevel, 0)
+    check rooted == first
+    check fragments.rootCursors(0.ZLevel).mapIt(fragments[it].nodeId()) == @[20, 10]
+    check fragments.childIds(firstRoot) == @[21]
+    check fragments[thirdRoot].nodeId() == 40
+
+    let reorderedRoot = fragments.moveFragmentToRoot(first, 0.ZLevel, 1)
+    check reorderedRoot == first
+    check fragments.rootCursors(0.ZLevel).mapIt(fragments[it].nodeId()) == @[10, 20]
+
+  test "moves an empty fragment slot before restoring its contents":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+
+    var visibleContents = RenderList()
+    discard visibleContents.addRoot(testFig(20))
+    discard fragments.attachChildFragment(0.ZLevel, root, 0, move visibleContents)
+    let empty = fragments.attachChildFragment(0.ZLevel, root, 1, RenderList())
+
+    let moved = fragments.moveFragment(empty, fragments.nodeCursor(0.ZLevel, root), 0)
+    check moved == empty
+    check fragments.fragmentRoots(moved).len == 0
+
+    var restoredContents = RenderList()
+    discard restoredContents.addRoot(testFig(30))
+    let restored = fragments.replaceFragment(moved, move restoredContents)
+    check restored.fragmentId() == empty.fragmentId()
+    check fragments.childIds(fragments.nodeCursor(0.ZLevel, root)) == @[30, 20]
+
+  test "invalid fragment moves leave the graph unchanged":
+    let fragments = newRenderFragments()
+    let root = fragments.addRoot(0.ZLevel, testFig(10))
+
+    var outerContents = RenderList()
+    discard outerContents.addRoot(testFig(20))
+    let outer = fragments.attachChildFragment(0.ZLevel, root, 0, move outerContents)
+    let outerRoot = fragments.fragmentRoots(outer)[0]
+
+    var innerContents = RenderList()
+    discard innerContents.addRoot(testFig(30))
+    let inner = fragments.attachChildFragment(outerRoot, 0, move innerContents)
+    let innerRoot = fragments.fragmentRoots(inner)[0]
+
+    expect RenderFragmentError:
+      discard fragments.moveFragment(outer, innerRoot, 0)
+    expect RenderFragmentError:
+      discard fragments.moveFragmentToRoot(outer, 1.ZLevel, 0)
+    expect RenderFragmentError:
+      discard fragments.moveFragment(inner, outerRoot, 2)
+
+    check fragments.isValid(outer)
+    check fragments.isValid(inner)
+    check fragments.childIds(fragments.nodeCursor(0.ZLevel, root)) == @[20]
+    check fragments.childIds(outerRoot) == @[30]
+
   test "rejects foreign stale and detached handles":
     let first = newRenderFragments()
     let firstRoot = first.addRoot(0.ZLevel, testFig(10))


### PR DESCRIPTION
## Summary

- add persistent child and layer-root fragment slots whose contents may transition between empty, one, and multiple roots
- bind fragment handles and cursors to their owning tree, layer, and generation, with explicit stale/foreign/detached rejection
- make `replaceFragment` a safe leaf operation that rejects nested attachments; add explicit destructive `replaceFragmentSubtree` for whole-subtree replacement
- add `moveFragment` and `moveFragmentToRoot` so callers can reparent stable slots without changing fragment IDs, generations, cursors, or nested attachments
- add linear-time `reorderChildFragments` and `reorderRootFragments` for complete sibling reconciliation while physical nodes remain anchored
- make monolithic materialization traverse borrowed topology metadata; this removes an observed quadratic copy cliff
- keep fragment topology behind controlled APIs and add independent monolithic materialization for compatibility and diagnostics
- document stable structure, zero-root slots, nested replacement, movement, and bulk reorder with Nimdoc diagrams and README examples
- retain cursor-based APIs as compatibility wrappers

## Scope

This is the application-thread fragment API foundation. Renderer-thread replacement messages, acknowledgement/resource retirement, and native-dynlib support remain separate follow-up work.

## Performance finding

A 10,000-node flat-fragment materialization loop (100 iterations, release build) fell from 23,027 ms before the borrowed traversal fix to 86 ms after it. Complete sibling reorder now has a separate O(n) bulk API; individual move remains the appropriate O(n) operation for isolated moves.

## Validation

- `nim test` (full tests and example compile sweep; repository-default SDL2 example skip)
- `nim r tests/trenderfragments.nim`
- `nim r -d:danger tests/trenderfragments.nim`
- `nim doc --outdir:/tmp/figdraw-renderfragments-doc src/figdraw/renderfragments.nim`
- `nph src/figdraw/renderfragments.nim tests/trenderfragments.nim`
- `git diff --check`