### PR TITLE
Fix system font family selection

### DIFF
--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -149,16 +149,15 @@ proc readTypefacePath(
     if typefaces.len == 0:
       raise newException(PixieError, "typeface collection is empty")
 
-    let requested = requestedName.normalizeTypefaceLookupName()
-    var faceIndex = 0
+    let requested = splitFile(requestedName).name
+    var
+      faceIndex = 0
+      matchScore = high(int)
     for index, typeface in typefaces:
-      let faceName = typeface.name().normalizeTypefaceLookupName()
-      if requested.len > 0 and faceName.len > 0 and (
-        faceName == requested or faceName.contains(requested) or
-        requested.contains(faceName)
-      ):
+      let score = fontNameMatchScore(requested, typeface.name())
+      if score >= 0 and score < matchScore:
         faceIndex = index
-        break
+        matchScore = score
 
     result.typeface = typefaces[faceIndex]
     result.typeface.filePath = path & "#" & $faceIndex

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -47,7 +47,8 @@ proc systemFontFileMatchScore(requestedName, path: string): int =
   let
     requested = splitFile(requestedName).name.normalizeName()
     stem = splitFile(path).name.normalizeName()
-  if requested.startsWith(stem):
+    extension = splitFile(path).ext.toLowerAscii()
+  if extension in [".ttc", ".otc"] and requested.startsWith(stem):
     let suffix = requested[stem.len .. ^1]
     if suffix in ["sc", "tc", "hk", "jp", "kr"]:
       return 2

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -19,6 +19,40 @@ proc normalizeName(name: string): string =
     if ch in {'a' .. 'z', '0' .. '9'}:
       result.add(ch)
 
+proc fontNameMatchScore*(requestedName, fontName: string): int =
+  ## Ranks a filename or face name for a family request.
+  ##
+  ## A family name may resolve to an explicitly named regular face, but it
+  ## must not resolve to a related family or a styled face. For example,
+  ## "Noto Sans" may match "NotoSans-Regular", but not
+  ## "NotoSansCJK-Bold" or "NotoSansMono".
+  let
+    requested = splitFile(requestedName).name.normalizeName()
+    candidate = fontName.normalizeName()
+  if requested.len == 0 or candidate.len == 0:
+    return -1
+  if candidate == requested:
+    return 0
+  if candidate.startsWith(requested):
+    let suffix = candidate[requested.len .. ^1]
+    if suffix in ["regular", "book", "roman", "normal", "plain", "r"]:
+      return 1
+  -1
+
+proc systemFontFileMatchScore(requestedName, path: string): int =
+  let score = fontNameMatchScore(requestedName, splitFile(path).name)
+  if score >= 0:
+    return score
+
+  let
+    requested = splitFile(requestedName).name.normalizeName()
+    stem = splitFile(path).name.normalizeName()
+  if requested.startsWith(stem):
+    let suffix = requested[stem.len .. ^1]
+    if suffix in ["sc", "tc", "hk", "jp", "kr"]:
+      return 2
+  -1
+
 proc normalizePathKey(path: string): string =
   path.toLowerAscii().replace('\\', '/')
 
@@ -125,36 +159,25 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
     except OSError:
       discard
 
-proc findSystemFontFile*(
-    names: openArray[string], displayServer = detectDisplayServer()
-): string =
-  ## Finds the preferred system font path matching one of the candidate names.
+proc findSystemFontFile*(names, fontFiles: openArray[string]): string =
+  ## Finds a preferred font from `fontFiles` matching one of `names`.
   ##
-  ## Exact normalized file and stem matches take precedence over loose partial
-  ## matches, so a request such as "Times New Roman" is not captured by
-  ## "Times.ttc" before "Times New Roman.ttf" is considered.
+  ## An unstyled family request can match a conventional regular suffix, but
+  ## related families and bold, italic, or monospace faces do not qualify.
   if names.len == 0:
     return ""
 
-  let fontFiles = systemFontFiles(displayServer)
   for name in names:
-    let candidate = name.normalizeName()
-    if candidate.len == 0:
-      continue
-    for path in fontFiles:
-      let
-        parts = splitFile(path)
-        stem = parts.name.normalizeName()
-        fileName = (parts.name & parts.ext).normalizeName()
-      if candidate == stem or candidate == fileName:
-        return path
-
-  for name in names:
-    let candidate = name.normalizeName()
-    if candidate.len == 0:
-      continue
-    for path in fontFiles:
-      let stem = splitFile(path).name.normalizeName()
-      if stem.contains(candidate) or candidate.contains(stem):
-        return path
+    let requestedExt = splitFile(name).ext.toLowerAscii()
+    for score in 0 .. 2:
+      for path in fontFiles:
+        if (requestedExt.len == 0 or splitFile(path).ext.toLowerAscii() == requestedExt) and
+            systemFontFileMatchScore(name, path) == score:
+          return path
   ""
+
+proc findSystemFontFile*(
+    names: openArray[string], displayServer = detectDisplayServer()
+): string =
+  ## Finds the preferred installed system font path matching one of `names`.
+  findSystemFontFile(names, systemFontFiles(displayServer))

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -24,6 +24,13 @@ proc drainImageMessages() =
   while tryRecvImageMsg(msg):
     discard
 
+proc swapTtcFaceOffsets(data: var string, first, second: int) =
+  let
+    firstOffset = 12 + first * 4
+    secondOffset = 12 + second * 4
+  for index in 0 .. 3:
+    swap(data[firstOffset + index], data[secondOffset + index])
+
 type FontCacheThreadArgs = object
   typefaceId: TypefaceId
   fontId: FontId
@@ -217,11 +224,25 @@ suite "fontutils":
     check info.supportsCodepoint(0x0627'u32)
     check not info.supportsCodepoint(0x05d0'u32)
 
-  test "typeface collection selects the regular face for a family request":
-    let typefaceId = loadTypeface(getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc")
+  test "typeface collection selects regular after a bold first face":
+    let
+      tempDir = getTempDir() / "figdraw-regular-collection-test"
+      sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
+      collectionPath = tempDir / "PTSans.ttc"
+    if not dirExists(tempDir):
+      createDir(tempDir)
+    defer:
+      if dirExists(tempDir):
+        removeDir(tempDir)
+
+    var collectionData = readFile(sourcePath)
+    collectionData.swapTtcFaceOffsets(0, 1)
+    writeFile(collectionPath, collectionData)
+
+    let typefaceId = loadTypeface(collectionPath)
     let info = getTypefaceInfo(typefaceId)
 
-    check getTypefaceSource(typefaceId).faceIndex == 0
+    check getTypefaceSource(typefaceId).faceIndex == 1
     check info.family == "PT Sans"
     check info.regular
     check not info.bold

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -217,6 +217,16 @@ suite "fontutils":
     check info.supportsCodepoint(0x0627'u32)
     check not info.supportsCodepoint(0x05d0'u32)
 
+  test "typeface collection selects the regular face for a family request":
+    let typefaceId = loadTypeface(getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc")
+    let info = getTypefaceInfo(typefaceId)
+
+    check getTypefaceSource(typefaceId).faceIndex == 0
+    check info.family == "PT Sans"
+    check info.regular
+    check not info.bold
+    check not info.italic
+
   test "unknown typeface metadata lookup raises ValueError":
     expect ValueError:
       discard getTypefaceInfo(TypefaceId(Hash(9_999_999)))

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -39,6 +39,49 @@ suite "system fonts":
     for font in fonts:
       check font.splitFile.ext.toLowerAscii() in supportedFontFileExtensions()
 
+  test "family lookup rejects related and styled font filenames":
+    let font = findSystemFontFile(
+      ["Noto Sans", "DejaVu Sans"],
+      [
+        "/fonts/NotoSansCJK-Bold.ttc", "/fonts/NotoSansMono-Regular.ttf",
+        "/fonts/NotoSans-Italic.ttf", "/fonts/DejaVuSans.ttf",
+      ],
+    )
+    check font == "/fonts/DejaVuSans.ttf"
+
+  test "family lookup prefers a regular face over later fallbacks":
+    let font = findSystemFontFile(
+      ["Noto Sans", "DejaVu Sans"],
+      [
+        "/fonts/NotoSansCJK-Bold.ttc", "/fonts/NotoSans-Regular.ttf",
+        "/fonts/DejaVuSans.ttf",
+      ],
+    )
+    check font == "/fonts/NotoSans-Regular.ttf"
+
+  test "family lookup supports conventional regular filename aliases":
+    check findSystemFontFile(["Ubuntu"], ["/fonts/Ubuntu-R.ttf"]) ==
+      "/fonts/Ubuntu-R.ttf"
+
+  test "filename requests retain exact matching":
+    check findSystemFontFile(
+      ["Noto Sans.ttf"], ["/fonts/NotoSans.otf", "/fonts/NotoSans.ttf"]
+    ) == "/fonts/NotoSans.ttf"
+
+  test "explicit style requests match only that style":
+    check findSystemFontFile(
+      ["Noto Sans Bold"], ["/fonts/NotoSans-Regular.ttf", "/fonts/NotoSans-Bold.ttf"]
+    ) == "/fonts/NotoSans-Bold.ttf"
+
+  test "collection face scoring excludes bold before a regular face":
+    check fontNameMatchScore("PT Sans", "PT Sans Bold") == -1
+    check fontNameMatchScore("PT Sans", "PT Sans Regular") == 1
+
+  test "regional family aliases resolve their base collection":
+    check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==
+      "/fonts/PingFang.ttc"
+    check findSystemFontFile(["Noto Sans"], ["/fonts/NotoSansCJK-Bold.ttc"]).len == 0
+
   when defined(windows):
     test "find common windows system font":
       let font =


### PR DESCRIPTION
Fixes system font resolution so an unstyled family request only selects an exact name or a conventional regular face. This prevents `NotoSansCJK-Bold.ttc`, italic, and monospace faces from capturing `Noto Sans` based on filesystem traversal order. TTC face selection now uses the same scoring and keeps the selected face index for rasterization and shaping. Known regional collection aliases such as `PingFang SC` to `PingFang.ttc` remain supported.

Tests: `atlas-run tests tsystemfonts tfontutils`.