### PR TITLE
Resolve font families and styles using OpenType metadata

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim,tsiwin_fallback_window.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim,tsiwin_fallback_window.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,12 @@
 
 ## Build, Test, and Development
 - Install deps (atlas workspace): `atlas install` (ensure `atlas` is installed and configured for your environment). *Never* use Nimble - it's horrible. *Always* use Atlas and it's `deps/` folder and `nim.cfg` file to see paths.
-- Run all tests: `nim test` (uses the `test` task in `config.nims` to compile and run every `tests/*.nim`).
-- Run a single test locally:
+- Run multiple or all tests with `atlas-run tests [test-selections]`. Omit selections to run the full suite, or pass one or more test selectors to run focused tests. Selectors match as `foo` -> `tests/tfoo*.nim`, `foo.nim` -> `tests/tfoo.nim`, and `examples/foo*.nim` -> `examples/foo*.nim`. Do not adjust the `--jobs` count or the `--nimcache`.
+- Compile the example bundle with `atlas-run tests --compile-only examples/all_compile.nim`; do not run `examples/all_compile.nim` as a test.
+- Execute a single test locally using Nim:
   - `nim r tests/ttransfer.nim`
+  - `nim r tests/ttransfer.nim -d:debug`
+
 
 ## Coding Style & Naming
 - Indentation: 2 spaces; no tabs.

--- a/README.md
+++ b/README.md
@@ -784,8 +784,10 @@ in a long-running process. Style matching is strict: a missing style advances to
 the caller's ordered fallback names, then platform defaults. To prefer the same
 family's regular face, list that family explicitly as a fallback. Existing
 `loadTypeface` signatures remain unchanged. The additive
-`findSystemTypefaceFile` lookup returns both `path` and `faceIndex`; the existing
-`findSystemFontFile(names, fontFiles)` overload retains filename-only matching.
+`findSystemTypefaceFile` lookup returns an `Option[SystemTypefaceFile]` containing
+both `path` and `faceIndex`; pass the matched value to `loadTypeface` to load that
+exact face. The existing `findSystemFontFile(names, fontFiles)` overload retains
+filename-only matching.
 Explicit `.ttc` and `.otc` paths retain their
 documented filename-based selection, with face zero as the default only when no
 face name matches. FigDraw carries the selected face index through shaping and

--- a/README.md
+++ b/README.md
@@ -776,9 +776,20 @@ Use the source-aware helpers for selection, hit testing, and carets:
 - `caretPositionsFor(sourceRune)`: visual caret rectangles for a source
   insertion index, including split positions at bidi boundaries.
 
-Font collection paths (`.ttc` and `.otc`) are supported; FigDraw selects the
-face whose name best matches the requested font and carries that face index
-through shaping and rasterization. The current Harfbuzzy raster path renders
+Installed named fonts are resolved from their OpenType family and style metadata,
+including typographic family names, rather than their filenames. User font
+directories take precedence over system directories. Font metadata is cached;
+call `refreshSystemFontMetadata()` after installing, replacing, or removing fonts
+in a long-running process. Style matching is strict: a missing style advances to
+the caller's ordered fallback names, then platform defaults. To prefer the same
+family's regular face, list that family explicitly as a fallback. Existing
+`loadTypeface` signatures remain unchanged. The additive
+`findSystemTypefaceFile` lookup returns both `path` and `faceIndex`; the existing
+`findSystemFontFile(names, fontFiles)` overload retains filename-only matching.
+Explicit `.ttc` and `.otc` paths retain their
+documented filename-based selection, with face zero as the default only when no
+face name matches. FigDraw carries the selected face index through shaping and
+rasterization. The current Harfbuzzy raster path renders
 monochrome outlines, not color bitmap, SVG, or COLR glyph paint data.
 
 See [docs/font_shaping.md](docs/font_shaping.md) for the data model details and

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "https://github.com/levovix0/siwin#a70c4666915169867fde3b65cf9d664c58e2cb0b"
+  requires "https://github.com/levovix0/siwin#69b1f6144c9be6331e01471183ace5b3ec13fae5"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "siwin >= 1.1.0"
+  requires "https://github.com/levovix0/siwin#a70c4666915169867fde3b65cf9d664c58e2cb0b"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "https://github.com/levovix0/siwin#69b1f6144c9be6331e01471183ace5b3ec13fae5"
+  requires "gh:elcritch/siwin#fix-x11-popup-border-pixel"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/src/figdraw/common/fonttypes.nim
+++ b/src/figdraw/common/fonttypes.nim
@@ -129,11 +129,7 @@ type
     sskBytes
 
 const figdrawTextBackend* {.strdefine.} =
-  when defined(feature.figdraw.textBackendHarfbuzzy):
-    "harfbuzzy"
-  else:
-    "pixie"
-
+  when defined(feature.figdraw.textBackendHarfbuzzy): "harfbuzzy" else: "pixie"
 
 static:
   doAssert figdrawTextBackend in ["pixie", "harfbuzzy", "hybrid"]
@@ -162,7 +158,7 @@ func textBackendFeatures*(): seq[string] =
 
 func supportedFontFileExtensions*(): seq[string] =
   ## Typeface file extensions accepted by FigDraw's font loader.
-  @[".ttf", ".otf", ".ttc", ".svg"]
+  @[".ttf", ".otf", ".ttc", ".svg", ".otc"]
 
 proc hash*(id: TypefaceId): Hash {.borrow.}
 proc `==`*(a, b: TypefaceId): bool {.borrow.}

--- a/src/figdraw/common/fontutils.nim
+++ b/src/figdraw/common/fontutils.nim
@@ -21,7 +21,9 @@ when defined(figdrawNativeDynlib):
 else:
   {.pragma: nativeAbi.}
 
-export FontRef, TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
+export
+  FontRef, SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName,
+  TypefaceVariationAxis
 export font, fontId, fontRef, loadTypeface, getTypefaceInfo, convertFont
 export registerStaticTypeface
 

--- a/src/figdraw/common/typefaceinfos.nim
+++ b/src/figdraw/common/typefaceinfos.nim
@@ -488,6 +488,28 @@ proc fallbackFamily(sourceName: string): string =
   let fileName = sourceName.extractFilename()
   result = (if fileName.len > 0: fileName else: sourceName).splitFile().name
 
+proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInfo =
+  ## Reads the names and style flags needed to identify one OpenType face.
+  ##
+  ## Unlike `parseTypefaceInfo`, this deliberately does not read cmap, layout,
+  ## or variation tables. It raises for malformed data so font discovery does
+  ## not mistake a filename-derived fallback for OpenType metadata.
+  let tables = data.readTypefaceTables(faceIndex)
+  result.faceIndex = faceIndex
+  result.localizedNames = data.readLocalizedNames(tables)
+  let
+    family = result.localizedNames.preferredName([16'u16, 1'u16])
+    subfamily = result.localizedNames.preferredName([17'u16, 2'u16])
+    fullName = result.localizedNames.preferredName([4'u16])
+    postScriptName = result.localizedNames.preferredName([6'u16])
+  if family.len == 0:
+    raise newException(ValueError, "font has no usable family name")
+  result.family = family
+  result.subfamily = subfamily
+  result.fullName = if fullName.len > 0: fullName else: family
+  result.postScriptName = postScriptName
+  result.applyStyleInfo(data, tables)
+
 proc parseTypefaceInfo*(
     sourceName, data: string, faceIndex = 0, fallbackFullName = ""
 ): TypefaceInfo =

--- a/src/figdraw/common/typefaceinfos.nim
+++ b/src/figdraw/common/typefaceinfos.nim
@@ -24,6 +24,22 @@ type
     maxValue*: float32
     hidden*: bool
 
+  ## Lightweight OpenType names and style metadata for one typeface face.
+  TypefaceNameInfo* = object
+    family*: string
+    subfamily*: string
+    fullName*: string
+    postScriptName*: string
+    faceIndex*: int
+    weightClass*: uint16
+    widthClass*: uint16
+    bold*: bool
+    italic*: bool
+    oblique*: bool
+    regular*: bool
+    monospace*: bool
+    localizedNames*: seq[TypefaceLocalizedName]
+
   ## Backend-neutral metadata for one registered typeface face.
   ##
   ## `layoutScripts` and `layoutLanguages` contain OpenType shaping tags from
@@ -488,12 +504,13 @@ proc fallbackFamily(sourceName: string): string =
   let fileName = sourceName.extractFilename()
   result = (if fileName.len > 0: fileName else: sourceName).splitFile().name
 
-proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInfo =
+proc readTypefaceNameInfo*(data: string, faceIndex: Natural = 0): TypefaceNameInfo =
   ## Reads the names and style flags needed to identify one OpenType face.
   ##
-  ## Unlike `parseTypefaceInfo`, this deliberately does not read cmap, layout,
-  ## or variation tables. It raises for malformed data so font discovery does
-  ## not mistake a filename-derived fallback for OpenType metadata.
+  ## It raises for malformed data, an unavailable collection face, or a nonzero
+  ## face index for a standalone font.
+  if data.len >= 4 and data[0 ..< 4] != "ttcf" and faceIndex != 0:
+    raise newException(ValueError, "standalone font face index must be zero")
   let tables = data.readTypefaceTables(faceIndex)
   result.faceIndex = faceIndex
   result.localizedNames = data.readLocalizedNames(tables)
@@ -508,7 +525,15 @@ proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInf
   result.subfamily = subfamily
   result.fullName = if fullName.len > 0: fullName else: family
   result.postScriptName = postScriptName
-  result.applyStyleInfo(data, tables)
+  var styleInfo: TypefaceInfo
+  styleInfo.applyStyleInfo(data, tables)
+  result.weightClass = styleInfo.weightClass
+  result.widthClass = styleInfo.widthClass
+  result.bold = styleInfo.bold
+  result.italic = styleInfo.italic
+  result.oblique = styleInfo.oblique
+  result.regular = styleInfo.regular
+  result.monospace = styleInfo.monospace
 
 proc parseTypefaceInfo*(
     sourceName, data: string, faceIndex = 0, fallbackFullName = ""

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -142,7 +142,7 @@ proc isTypefaceCollection(path: string): bool =
   splitFile(path).ext.toLowerAscii() in [".ttc", ".otc"]
 
 proc readTypefacePath(
-    path, requestedName: string
+    path, requestedName: string, requestedFaceIndex = -1
 ): tuple[typeface: Typeface, source: TypefaceSource] {.raises: [PixieError].} =
   if path.isTypefaceCollection():
     let typefaces = readTypefaces(path)
@@ -150,14 +150,18 @@ proc readTypefacePath(
       raise newException(PixieError, "typeface collection is empty")
 
     let requested = splitFile(requestedName).name
-    var
+    var faceIndex = requestedFaceIndex
+    if faceIndex >= 0 and faceIndex notin 0 ..< typefaces.len:
+      raise
+        newException(PixieError, "requested typeface collection face is not available")
+    if faceIndex < 0:
       faceIndex = 0
-      matchScore = high(int)
-    for index, typeface in typefaces:
-      let score = fontNameMatchScore(requested, typeface.name())
-      if score >= 0 and score < matchScore:
-        faceIndex = index
-        matchScore = score
+      var matchScore = high(int)
+      for index, typeface in typefaces:
+        let score = fontNameMatchScore(requested, typeface.name())
+        if score >= 0 and score < matchScore:
+          faceIndex = index
+          matchScore = score
 
     result.typeface = typefaces[faceIndex]
     result.typeface.filePath = path & "#" & $faceIndex
@@ -224,24 +228,41 @@ proc loadTypeface*(
 ): TypefaceId {.nativeAbi.} =
   ## loads a font from a file and adds it to the font index
 
-  proc resolveTypefacePath(name: string): string =
+  proc resolveTypefacePath(name: string): SystemTypefaceFile =
     let dataPath = figDataDir() / name
     if fileExists(dataPath):
       info "resolved typeface from figDataDir", requested = name, path = dataPath
-      return dataPath
+      return SystemTypefaceFile(path: dataPath, faceIndex: -1)
 
     if fileExists(name):
       info "resolved typeface from direct path", requested = name, path = name
-      return name
+      return SystemTypefaceFile(path: name, faceIndex: -1)
 
-    let stem = splitFile(name).name
-    let systemPath = findSystemFontFile([name, stem])
-    if systemPath.len > 0:
-      info "resolved typeface from system fonts", requested = name, path = systemPath
-      return systemPath
+    if splitFile(name).ext.len > 0:
+      let filePath = findSystemFontFile([name])
+      if filePath.len > 0:
+        info "resolved typeface from exact system font filename",
+          requested = name, path = filePath
+        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+
+    let systemTypeface = findSystemTypefaceFile([name])
+    if systemTypeface.path.len > 0:
+      info "resolved typeface from system font metadata",
+        requested = name,
+        path = systemTypeface.path,
+        faceIndex = systemTypeface.faceIndex
+      return systemTypeface
+
+    let alias = splitFile(name).name.toLowerAscii().replace("-", "")
+    if alias in ["sfns", "ubuntur"]:
+      let filePath = findSystemFontFile([name])
+      if filePath.len > 0:
+        info "resolved typeface from system font alias",
+          requested = name, path = filePath
+        return SystemTypefaceFile(path: filePath, faceIndex: -1)
 
     warn "unable to resolve typeface path", requested = name, figDataDir = figDataDir()
-    result = ""
+    result.faceIndex = -1
 
   var candidateNames = @[name]
   candidateNames.add(fallbackNames)
@@ -251,15 +272,16 @@ proc loadTypeface*(
   var typeface: Typeface
   var source: TypefaceSource
   for candidate in candidateNames:
-    let typefacePath = resolveTypefacePath(candidate)
-    if typefacePath.len > 0:
+    let resolved = resolveTypefacePath(candidate)
+    if resolved.path.len > 0:
       try:
-        (typeface, source) = readTypefacePath(typefacePath, candidate)
+        (typeface, source) =
+          readTypefacePath(resolved.path, candidate, resolved.faceIndex)
         loaded = true
         break
       except PixieError:
         warn "failed to read resolved typeface path",
-          requested = name, candidate = candidate, path = typefacePath
+          requested = name, candidate = candidate, path = resolved.path
 
     var staticEntry: tuple[name: string, data: string, kind: TypeFaceKinds]
     if candidate.staticTypefaceEntry(staticEntry):

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -2,6 +2,7 @@ import std/os
 import std/strutils
 import std/locks
 import std/math
+import std/options
 import std/tables
 
 import pkg/vmath
@@ -15,7 +16,7 @@ import ./shared
 import ./typefaceinfos
 import ../extras/systemfonts
 
-export TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
+export SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
 
 when defined(figdrawNativeDynlib):
   {.pragma: nativeAbi, exportabi.}
@@ -34,6 +35,10 @@ type TypefaceSource* = object
   faceIndex*: int
 
 type
+  ResolvedTypefacePath = object
+    path: string
+    faceIndex: int
+
   FontRefHandle = object
     value: FigFont
     id: FontId
@@ -175,6 +180,8 @@ proc readTypefacePath(
     except IOError as e:
       raise newException(PixieError, e.msg, e)
   else:
+    if requestedFaceIndex > 0:
+      raise newException(PixieError, "standalone typeface face index must be zero")
     try:
       let data = readFile(path)
       let kind = typefaceKindFromPath(path)
@@ -228,30 +235,33 @@ proc loadTypeface*(
 ): TypefaceId {.nativeAbi.} =
   ## loads a font from a file and adds it to the font index
 
-  proc resolveTypefacePath(name: string): SystemTypefaceFile =
+  proc resolveTypefacePath(name: string): ResolvedTypefacePath =
     let dataPath = figDataDir() / name
     if fileExists(dataPath):
       info "resolved typeface from figDataDir", requested = name, path = dataPath
-      return SystemTypefaceFile(path: dataPath, faceIndex: -1)
+      return ResolvedTypefacePath(path: dataPath, faceIndex: -1)
 
     if fileExists(name):
       info "resolved typeface from direct path", requested = name, path = name
-      return SystemTypefaceFile(path: name, faceIndex: -1)
+      return ResolvedTypefacePath(path: name, faceIndex: -1)
 
     if splitFile(name).ext.len > 0:
       let filePath = findSystemFontFile([name])
       if filePath.len > 0:
         info "resolved typeface from exact system font filename",
           requested = name, path = filePath
-        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+        return ResolvedTypefacePath(path: filePath, faceIndex: -1)
 
     let systemTypeface = findSystemTypefaceFile([name])
-    if systemTypeface.path.len > 0:
+    if systemTypeface.isSome:
+      let matchedTypeface = systemTypeface.get()
       info "resolved typeface from system font metadata",
         requested = name,
-        path = systemTypeface.path,
-        faceIndex = systemTypeface.faceIndex
-      return systemTypeface
+        path = matchedTypeface.path,
+        faceIndex = matchedTypeface.faceIndex
+      return ResolvedTypefacePath(
+        path: matchedTypeface.path, faceIndex: matchedTypeface.faceIndex
+      )
 
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
@@ -259,7 +269,7 @@ proc loadTypeface*(
       if filePath.len > 0:
         info "resolved typeface from system font alias",
           requested = name, path = filePath
-        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+        return ResolvedTypefacePath(path: filePath, faceIndex: -1)
 
     warn "unable to resolve typeface path", requested = name, figDataDir = figDataDir()
     result.faceIndex = -1
@@ -310,6 +320,15 @@ proc loadTypeface*(
 
 proc loadTypeface*(name: string): TypefaceId {.nativeAbi.} =
   loadTypeface(name, [])
+
+proc loadTypeface*(file: SystemTypefaceFile): TypefaceId =
+  ## Loads the exact face returned by `findSystemTypefaceFile`.
+  if file.path.len == 0:
+    raise newException(PixieError, "typeface path is empty")
+  if file.faceIndex < 0:
+    raise newException(PixieError, "typeface face index must not be negative")
+  let (typeface, source) = readTypefacePath(file.path, file.path, file.faceIndex)
+  registerTypeface(typeface, source)
 
 proc loadTypeface*(name, data: string, kind: TypeFaceKinds): TypefaceId {.nativeAbi.} =
   ## loads a font from buffer and adds it to the font index

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, locks, os, sets, strutils, tables, unicode]
+import std/[algorithm, locks, options, os, sets, strutils, tables, unicode]
 
 import ../common/fonttypes
 import ../common/typefaceinfos
@@ -16,14 +16,15 @@ type
   SystemTypefaceFile* = object
     ## An installed font file and the selected face within it.
     path*: string
-    faceIndex*: int
+    faceIndex*: int ## Zero-based face index, including for standalone fonts.
 
   CachedFontMetadata = object
     valid: bool
-    faces: seq[TypefaceInfo]
+    faces: seq[TypefaceNameInfo]
 
 var
   fontMetadataCache: Table[string, CachedFontMetadata]
+  fontMetadataGeneration: uint64
   fontMetadataLock: Lock
 
 fontMetadataLock.initLock()
@@ -101,26 +102,33 @@ proc readFontMetadata(path: string): CachedFontMetadata =
     if count == 0:
       return
     for faceIndex in 0 ..< count:
-      result.faces.add readTypefaceNameInfo(path, data, faceIndex)
+      result.faces.add readTypefaceNameInfo(data, faceIndex)
     result.valid = result.faces.len > 0
   except CatchableError:
     discard
 
 proc fontMetadata(path: string): CachedFontMetadata =
   let key = fontMetadataKey(path)
+  var generation: uint64
   withLock(fontMetadataLock):
     if key in fontMetadataCache:
       return fontMetadataCache[key]
+    generation = fontMetadataGeneration
   result = readFontMetadata(path)
   withLock(fontMetadataLock):
-    fontMetadataCache[key] = result
+    if generation == fontMetadataGeneration:
+      if key in fontMetadataCache:
+        result = fontMetadataCache[key]
+      else:
+        fontMetadataCache[key] = result
 
 proc refreshSystemFontMetadata*() =
   ## Clears cached installed-font metadata after font directories change.
   withLock(fontMetadataLock):
+    inc fontMetadataGeneration
     fontMetadataCache.clear()
 
-proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
+proc metadataMatchScore(requestedName: string, info: TypefaceNameInfo): int =
   let
     requested = requestedName.normalizeMetadataName()
     family = info.family.normalizeMetadataName()
@@ -145,13 +153,14 @@ proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
 
 proc findSystemTypefaceFile*(
     names, fontFiles: openArray[string], preserveInputOrder = false
-): SystemTypefaceFile =
+): Option[SystemTypefaceFile] =
   ## Finds an installed face by OpenType family/style metadata.
   ##
   ## Directories are ranked by their first appearance in `fontFiles`, with
   ## paths sorted within each directory for deterministic ties. Set
   ## `preserveInputOrder` to use the supplied path order without sorting.
   ## Platform discovery supplies user directories before system directories.
+  ## Returns `none` when no requested name matches.
   var paths: seq[string]
   if preserveInputOrder:
     paths = @fontFiles
@@ -178,7 +187,7 @@ proc findSystemTypefaceFile*(
         if metadata.valid:
           for info in metadata.faces:
             if metadataMatchScore(name, info) == score:
-              return SystemTypefaceFile(path: path, faceIndex: info.faceIndex)
+              return some(SystemTypefaceFile(path: path, faceIndex: info.faceIndex))
 
 proc detectDisplayServer*(): DisplayServer =
   ## Detects the display server on non-macOS POSIX platforms.
@@ -284,7 +293,7 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
 
 proc findSystemTypefaceFile*(
     names: openArray[string], displayServer = detectDisplayServer()
-): SystemTypefaceFile =
+): Option[SystemTypefaceFile] =
   ## Finds an installed face by OpenType metadata using platform font folders.
   findSystemTypefaceFile(
     names, systemFontFiles(displayServer), preserveInputOrder = true
@@ -321,8 +330,8 @@ proc findSystemFontFile*(
       if path.len > 0:
         return path
     let typeface = findSystemTypefaceFile([name], fontFiles, preserveInputOrder = true)
-    if typeface.path.len > 0:
-      return typeface.path
+    if typeface.isSome:
+      return typeface.get().path
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
       let path = findSystemFontFile([name], fontFiles)

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -1,6 +1,7 @@
-import std/[os, strutils, sets]
+import std/[algorithm, locks, os, sets, strutils, tables, unicode]
 
 import ../common/fonttypes
+import ../common/typefaceinfos
 
 type
   DisplayServer* = enum
@@ -12,12 +13,34 @@ type
     sfrSans
     sfrMono
 
+  SystemTypefaceFile* = object
+    ## An installed font file and the selected face within it.
+    path*: string
+    faceIndex*: int
+
+  CachedFontMetadata = object
+    valid: bool
+    faces: seq[TypefaceInfo]
+
+var
+  fontMetadataCache: Table[string, CachedFontMetadata]
+  fontMetadataLock: Lock
+
+fontMetadataLock.initLock()
+
 proc normalizeName(name: string): string =
-  ## Normalizes a font/file name for loose matching.
+  ## Normalizes a filename for legacy loose matching.
   result = newStringOfCap(name.len)
   for ch in name.toLowerAscii():
     if ch in {'a' .. 'z', '0' .. '9'}:
       result.add(ch)
+
+proc normalizeMetadataName(name: string): string =
+  ## Normalizes OpenType names while retaining non-ASCII letters.
+  result = newStringOfCap(name.len)
+  for rune in name.runes:
+    if $rune notin [" ", "-", "_", "."]:
+      result.add($rune.toLower)
 
 proc fontNameMatchScore*(requestedName, fontName: string): int =
   ## Ranks a filename or face name for a family request.
@@ -55,7 +78,107 @@ proc systemFontFileMatchScore(requestedName, path: string): int =
   -1
 
 proc normalizePathKey(path: string): string =
-  path.toLowerAscii().replace('\\', '/')
+  when defined(windows) or defined(macosx):
+    path.toLowerAscii().replace('\\', '/')
+  else:
+    path.replace('\\', '/')
+
+proc fontMetadataKey(path: string): string =
+  path.replace('\\', '/')
+
+proc fontFaceCount(data: string): int =
+  if data.len < 12 or data[0 ..< 4] != "ttcf":
+    return 1
+  result =
+    data[8].ord shl 24 or data[9].ord shl 16 or data[10].ord shl 8 or data[11].ord
+  if result < 0 or result > (data.len - 12) div 4:
+    result = 0
+
+proc readFontMetadata(path: string): CachedFontMetadata =
+  try:
+    let data = readFile(path)
+    let count = data.fontFaceCount()
+    if count == 0:
+      return
+    for faceIndex in 0 ..< count:
+      result.faces.add readTypefaceNameInfo(path, data, faceIndex)
+    result.valid = result.faces.len > 0
+  except CatchableError:
+    discard
+
+proc fontMetadata(path: string): CachedFontMetadata =
+  let key = fontMetadataKey(path)
+  withLock(fontMetadataLock):
+    if key in fontMetadataCache:
+      return fontMetadataCache[key]
+  result = readFontMetadata(path)
+  withLock(fontMetadataLock):
+    fontMetadataCache[key] = result
+
+proc refreshSystemFontMetadata*() =
+  ## Clears cached installed-font metadata after font directories change.
+  withLock(fontMetadataLock):
+    fontMetadataCache.clear()
+
+proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
+  let
+    requested = requestedName.normalizeMetadataName()
+    family = info.family.normalizeMetadataName()
+    subfamily = info.subfamily.normalizeMetadataName()
+    fullName = info.fullName.normalizeMetadataName()
+    postScriptName = info.postScriptName.normalizeMetadataName()
+    familyStyle = family & subfamily
+  if requested.len == 0 or family.len == 0:
+    return -1
+  if requested == family:
+    let regular =
+      if subfamily.len > 0:
+        subfamily in ["regular", "normal", "book", "roman"]
+      else:
+        info.regular
+    if regular and not (info.bold or info.italic or info.oblique):
+      return 1
+    return -1
+  if requested == fullName or requested == postScriptName or requested == familyStyle:
+    return 0
+  -1
+
+proc findSystemTypefaceFile*(
+    names, fontFiles: openArray[string], preserveInputOrder = false
+): SystemTypefaceFile =
+  ## Finds an installed face by OpenType family/style metadata.
+  ##
+  ## Directories are ranked by their first appearance in `fontFiles`, with
+  ## paths sorted within each directory for deterministic ties. Set
+  ## `preserveInputOrder` to use the supplied path order without sorting.
+  ## Platform discovery supplies user directories before system directories.
+  var paths: seq[string]
+  if preserveInputOrder:
+    paths = @fontFiles
+  else:
+    var directories: seq[string]
+    for path in fontFiles:
+      let directory = normalizePathKey(path.parentDir)
+      if directory notin directories:
+        directories.add(directory)
+    for directory in directories:
+      var directoryPaths: seq[string]
+      for path in fontFiles:
+        if normalizePathKey(path.parentDir) == directory:
+          directoryPaths.add(path)
+      directoryPaths.sort(
+        proc(a, b: string): int =
+          cmp(normalizePathKey(a), normalizePathKey(b))
+      )
+      paths.add(directoryPaths)
+  for name in names:
+    for score in 0 .. 1:
+      for path in paths:
+        let metadata = path.fontMetadata()
+        if metadata.valid:
+          for info in metadata.faces:
+            if metadataMatchScore(name, info) == score:
+              return SystemTypefaceFile(path: path, faceIndex: info.faceIndex)
 
 proc detectDisplayServer*(): DisplayServer =
   ## Detects the display server on non-macOS POSIX platforms.
@@ -115,31 +238,26 @@ proc systemFontDirs*(displayServer = detectDisplayServer()): seq[string] =
   var dirs: seq[string]
 
   when defined(windows):
-    dirs.addIfDir(getEnv("WINDIR", r"C:\Windows") / "Fonts")
     dirs.addIfDir(getEnv("LOCALAPPDATA", "") / "Microsoft" / "Windows" / "Fonts")
     dirs.addIfDir(getEnv("APPDATA", "") / "Microsoft" / "Windows" / "Fonts")
+    dirs.addIfDir(getEnv("WINDIR", r"C:\Windows") / "Fonts")
   elif defined(macosx):
-    dirs.addIfDir("/System/Library/Fonts")
-    dirs.addIfDir("/Library/Fonts")
     dirs.addIfDir("~/Library/Fonts")
+    dirs.addIfDir("/Library/Fonts")
+    dirs.addIfDir("/System/Library/Fonts")
   elif defined(posix) and not defined(macosx):
     let home = getHomeDir()
     let xdgDataHome = getEnv("XDG_DATA_HOME", home / ".local" / "share")
     dirs.addIfDir(xdgDataHome / "fonts")
+
+    if displayServer != dsWayland:
+      dirs.addIfDir(home / ".fonts")
 
     for base in splitPathList(getEnv("XDG_DATA_DIRS", "/usr/local/share:/usr/share")):
       dirs.addIfDir(base / "fonts")
 
     dirs.addIfDir("/usr/share/fonts")
     dirs.addIfDir("/usr/local/share/fonts")
-
-    if displayServer == dsX11:
-      dirs.addIfDir(home / ".fonts")
-    elif displayServer == dsWayland:
-      # Wayland desktops typically use XDG font directories.
-      discard
-    else:
-      dirs.addIfDir(home / ".fonts")
 
   result = dedupePaths(dirs)
 
@@ -150,15 +268,27 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
 
   for dir in dirs:
     try:
+      var files: seq[string]
       for file in walkDirRec(dir):
         let ext = file.splitFile.ext.toLowerAscii()
         if ext in supportedFontFileExtensions():
-          let key = normalizePathKey(file)
-          if key notin seen:
-            seen.incl(key)
-            result.add(file)
+          files.add(file)
+      files.sort()
+      for file in files:
+        let key = normalizePathKey(file)
+        if key notin seen:
+          seen.incl(key)
+          result.add(file)
     except OSError:
       discard
+
+proc findSystemTypefaceFile*(
+    names: openArray[string], displayServer = detectDisplayServer()
+): SystemTypefaceFile =
+  ## Finds an installed face by OpenType metadata using platform font folders.
+  findSystemTypefaceFile(
+    names, systemFontFiles(displayServer), preserveInputOrder = true
+  )
 
 proc findSystemFontFile*(names, fontFiles: openArray[string]): string =
   ## Finds a preferred font from `fontFiles` matching one of `names`.
@@ -181,4 +311,20 @@ proc findSystemFontFile*(
     names: openArray[string], displayServer = detectDisplayServer()
 ): string =
   ## Finds the preferred installed system font path matching one of `names`.
-  findSystemFontFile(names, systemFontFiles(displayServer))
+  ##
+  ## Named requests use OpenType metadata. The two-array overload remains a
+  ## filename-only helper for callers that supply synthetic paths.
+  let fontFiles = systemFontFiles(displayServer)
+  for name in names:
+    if splitFile(name).ext.len > 0:
+      let path = findSystemFontFile([name], fontFiles)
+      if path.len > 0:
+        return path
+    let typeface = findSystemTypefaceFile([name], fontFiles, preserveInputOrder = true)
+    if typeface.path.len > 0:
+      return typeface.path
+    let alias = splitFile(name).name.toLowerAscii().replace("-", "")
+    if alias in ["sfns", "ubuntur"]:
+      let path = findSystemFontFile([name], fontFiles)
+      if path.len > 0:
+        return path

--- a/tests/tfontmetadata.nim
+++ b/tests/tfontmetadata.nim
@@ -1,5 +1,6 @@
-import std/[os, tempfiles, unicode, unittest]
+import std/[options, os, tempfiles, unicode, unittest]
 
+import figdraw/common/typefaceinfos
 import figdraw/extras/systemfonts
 
 type NameEntry = tuple[id: int, text: string]
@@ -101,14 +102,15 @@ suite "installed font metadata resolution":
   test "family metadata overrides an unrelated filename":
     let path = fixtureDir / "MisleadingName-Bold.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path == path
-    check findSystemTypefaceFile(["MisleadingName"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["MisleadingName"], [path]).isNone
 
   test "related families cannot consume a regular family as a prefix":
     let path = fixtureDir / "regular.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
     for name in ["Fixture Sans CJK", "Fixture Sans Mono", "Fixture Sans Unknown"]:
-      check findSystemTypefaceFile([name], [path]).path.len == 0
+      check findSystemTypefaceFile([name], [path]).isNone
 
   test "unstyled family skips bold italic and oblique faces for the next fallback":
     let
@@ -129,7 +131,7 @@ suite "installed font metadata resolution":
     writeFile(fallback, fontMetadata("Other Sans"))
     check findSystemTypefaceFile(
       ["Fixture Sans", "Other Sans"], [bold, italic, oblique, fallback]
-    ).path == fallback
+    ) == some(SystemTypefaceFile(path: fallback, faceIndex: 0))
 
   test "missing bold and italic styles preserve explicit fallback order":
     let
@@ -138,8 +140,8 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(fallback, fontMetadata("Other Sans"))
     for name in ["Fixture Sans Bold", "Fixture Sans Italic"]:
-      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]).path ==
-        fallback
+      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]) ==
+        some(SystemTypefaceFile(path: fallback, faceIndex: 0))
 
   test "explicit styles use the matching face even with opaque filenames":
     let
@@ -149,10 +151,10 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(bold, fontMetadata("Fixture Sans", "Bold", 700, 32))
     writeFile(italic, fontMetadata("Fixture Sans", "Italic", 400, 1))
-    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]).path ==
-      bold
-    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]).path ==
-      italic
+    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]) ==
+      some(SystemTypefaceFile(path: bold, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]) ==
+      some(SystemTypefaceFile(path: italic, faceIndex: 0))
 
   test "typographic family and subfamily retain semibold style":
     let path = fixtureDir / "font.ttf"
@@ -167,8 +169,9 @@ suite "installed font metadata resolution":
         typographicStyle = "SemiBold",
       ),
     )
-    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]).path == path
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
 
   test "style words are matched exactly and combined styles require both traits":
     let path = fixtureDir / "bold.ttf"
@@ -176,20 +179,22 @@ suite "installed font metadata resolution":
     for name in [
       "Fixture Sans SemiBold", "Fixture Sans NotBold", "Fixture Sans Bold Italic"
     ]:
-      check findSystemTypefaceFile([name], [path]).path.len == 0
+      check findSystemTypefaceFile([name], [path]).isNone
 
   test "regional collection family names remain distinct":
     let path = fixtureDir / "regional.ttf"
     writeFile(path, fontMetadata("Fixture Sans CJK JP"))
-    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]).path == path
-    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).path.len == 0
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).isNone
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
 
   test "Unicode family names remain distinct":
     let path = fixtureDir / "unicode.ttf"
     writeFile(path, fontMetadata("明朝"))
-    check findSystemTypefaceFile(["明朝"], [path]).path == path
-    check findSystemTypefaceFile(["黑体"], [path]).path.len == 0
+    check findSystemTypefaceFile(["明朝"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["黑体"], [path]).isNone
 
   test "matches in one directory do not depend on enumeration order":
     let
@@ -197,19 +202,22 @@ suite "installed font metadata resolution":
       second = fixtureDir / "z.ttf"
     writeFile(first, fontMetadata("Fixture Sans"))
     writeFile(second, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(["Fixture Sans"], [first, second]).path == first
-    check findSystemTypefaceFile(["Fixture Sans"], [second, first]).path == first
+    let expected = some(SystemTypefaceFile(path: first, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans"], [first, second]) == expected
+    check findSystemTypefaceFile(["Fixture Sans"], [second, first]) == expected
 
   test "metadata is cached until explicit refresh":
     let path = fixtureDir / "font.ttf"
     writeFile(path, fontMetadata("First Family"))
-    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    check findSystemTypefaceFile(["First Family"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
     writeFile(path, fontMetadata("Second Family"))
-    check findSystemTypefaceFile(["First Family"], [path]).path == path
-    check findSystemTypefaceFile(["Second Family"], [path]).path.len == 0
+    check findSystemTypefaceFile(["First Family"], [path]).isSome
+    check findSystemTypefaceFile(["Second Family"], [path]).isNone
     refreshSystemFontMetadata()
-    check findSystemTypefaceFile(["Second Family"], [path]).path == path
-    check findSystemTypefaceFile(["First Family"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Second Family"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["First Family"], [path]).isNone
 
   test "caller directory precedence wins over alphabetical file order":
     let
@@ -223,9 +231,19 @@ suite "installed font metadata resolution":
     writeFile(systemFont, fontMetadata("Fixture Sans"))
     check findSystemTypefaceFile(
       ["Fixture Sans"], [userFont, systemFont], preserveInputOrder = true
-    ).path == userFont
+    ) == some(SystemTypefaceFile(path: userFont, faceIndex: 0))
 
   test "malformed metadata cannot fall back to the filename":
     let path = fixtureDir / "FixtureSans-Regular.ttf"
     writeFile(path, "invalid font data")
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
+
+  test "lightweight name metadata has a distinct result type":
+    let info = readTypefaceNameInfo(fontMetadata("Fixture Sans"))
+    check info.family == "Fixture Sans"
+    check info.faceIndex == 0
+    check info.regular
+
+  test "lightweight name metadata rejects a standalone nonzero face":
+    expect ValueError:
+      discard readTypefaceNameInfo(fontMetadata("Fixture Sans"), faceIndex = 1)

--- a/tests/tfontmetadata.nim
+++ b/tests/tfontmetadata.nim
@@ -1,0 +1,231 @@
+import std/[os, tempfiles, unicode, unittest]
+
+import figdraw/extras/systemfonts
+
+type NameEntry = tuple[id: int, text: string]
+
+proc putUint16(data: var string, offset, value: int) =
+  data[offset] = char((value shr 8) and 255)
+  data[offset + 1] = char(value and 255)
+
+proc putUint32(data: var string, offset, value: int) =
+  data.putUint16(offset, value shr 16)
+  data.putUint16(offset + 2, value and 65535)
+
+proc utf16(text: string): string =
+  for rune in text.runes:
+    let codepoint = rune.int
+    if codepoint <= 65535:
+      result.add char(codepoint shr 8)
+      result.add char(codepoint and 255)
+    else:
+      let
+        highSurrogate = 0xd800 + ((codepoint - 0x10000) shr 10)
+        lowSurrogate = 0xdc00 + ((codepoint - 0x10000) and 1023)
+      result.add char(highSurrogate shr 8)
+      result.add char(highSurrogate and 255)
+      result.add char(lowSurrogate shr 8)
+      result.add char(lowSurrogate and 255)
+
+proc fontMetadata(
+    family: string,
+    style = "Regular",
+    weight = 400,
+    selection = 64,
+    fullName = "",
+    typographicFamily = "",
+    typographicStyle = "",
+    monospace = false,
+): string =
+  ## Minimal SFNT metadata fixture; deliberately contains no glyph outlines.
+  var names: seq[NameEntry] = @[(1, family), (2, style)]
+  names.add(
+    (
+      4,
+      if fullName.len > 0:
+        fullName
+      else:
+        family & " " & style,
+    )
+  )
+  if typographicFamily.len > 0:
+    names.add((16, typographicFamily))
+  if typographicStyle.len > 0:
+    names.add((17, typographicStyle))
+
+  var nameTable = newString(6 + names.len * 12)
+  nameTable.putUint16(2, names.len)
+  nameTable.putUint16(4, nameTable.len)
+  var strings: string
+  for index, entry in names:
+    let
+      encoded = utf16(entry.text)
+      offset = 6 + index * 12
+    nameTable.putUint16(offset, 3)
+    nameTable.putUint16(offset + 2, 1)
+    nameTable.putUint16(offset + 4, 0x0409)
+    nameTable.putUint16(offset + 6, entry.id)
+    nameTable.putUint16(offset + 8, encoded.len)
+    nameTable.putUint16(offset + 10, strings.len)
+    strings.add encoded
+  nameTable.add strings
+
+  var
+    styleTable = newString(86)
+    postTable = newString(16)
+  styleTable.putUint16(4, weight)
+  styleTable.putUint16(6, 5)
+  styleTable.putUint16(62, selection)
+  postTable.putUint32(12, ord(monospace))
+  let tables = [("name", nameTable), ("OS/2", styleTable), ("post", postTable)]
+  result = newString(12 + tables.len * 16)
+  result.putUint32(0, 0x00010000)
+  result.putUint16(4, tables.len)
+  for index, table in tables:
+    let offset = 12 + index * 16
+    for tagIndex in 0 .. 3:
+      result[offset + tagIndex] = table[0][tagIndex]
+    result.putUint32(offset + 8, result.len)
+    result.putUint32(offset + 12, table[1].len)
+    result.add table[1]
+
+suite "installed font metadata resolution":
+  setup:
+    let fixtureDir = createTempDir("figdraw-font-metadata-", "")
+    refreshSystemFontMetadata()
+
+  teardown:
+    refreshSystemFontMetadata()
+    removeDir(fixtureDir)
+
+  test "family metadata overrides an unrelated filename":
+    let path = fixtureDir / "MisleadingName-Bold.ttf"
+    writeFile(path, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path == path
+    check findSystemTypefaceFile(["MisleadingName"], [path]).path.len == 0
+
+  test "related families cannot consume a regular family as a prefix":
+    let path = fixtureDir / "regular.ttf"
+    writeFile(path, fontMetadata("Fixture Sans"))
+    for name in ["Fixture Sans CJK", "Fixture Sans Mono", "Fixture Sans Unknown"]:
+      check findSystemTypefaceFile([name], [path]).path.len == 0
+
+  test "unstyled family skips bold italic and oblique faces for the next fallback":
+    let
+      bold = fixtureDir / "bold.ttf"
+      italic = fixtureDir / "italic.ttf"
+      oblique = fixtureDir / "oblique.ttf"
+      fallback = fixtureDir / "fallback.ttf"
+    writeFile(
+      bold, fontMetadata("Fixture Sans", "Bold", 700, 32, fullName = "Fixture Sans")
+    )
+    writeFile(
+      italic, fontMetadata("Fixture Sans", "Italic", 400, 1, fullName = "Fixture Sans")
+    )
+    writeFile(
+      oblique,
+      fontMetadata("Fixture Sans", "Oblique", 400, 512, fullName = "Fixture Sans"),
+    )
+    writeFile(fallback, fontMetadata("Other Sans"))
+    check findSystemTypefaceFile(
+      ["Fixture Sans", "Other Sans"], [bold, italic, oblique, fallback]
+    ).path == fallback
+
+  test "missing bold and italic styles preserve explicit fallback order":
+    let
+      regular = fixtureDir / "regular.ttf"
+      fallback = fixtureDir / "fallback.ttf"
+    writeFile(regular, fontMetadata("Fixture Sans"))
+    writeFile(fallback, fontMetadata("Other Sans"))
+    for name in ["Fixture Sans Bold", "Fixture Sans Italic"]:
+      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]).path ==
+        fallback
+
+  test "explicit styles use the matching face even with opaque filenames":
+    let
+      regular = fixtureDir / "font-a.ttf"
+      bold = fixtureDir / "font-b.ttf"
+      italic = fixtureDir / "font-c.ttf"
+    writeFile(regular, fontMetadata("Fixture Sans"))
+    writeFile(bold, fontMetadata("Fixture Sans", "Bold", 700, 32))
+    writeFile(italic, fontMetadata("Fixture Sans", "Italic", 400, 1))
+    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]).path ==
+      bold
+    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]).path ==
+      italic
+
+  test "typographic family and subfamily retain semibold style":
+    let path = fixtureDir / "font.ttf"
+    writeFile(
+      path,
+      fontMetadata(
+        "Fixture Sans SemiBold",
+        "Regular",
+        600,
+        64,
+        typographicFamily = "Fixture Sans",
+        typographicStyle = "SemiBold",
+      ),
+    )
+    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]).path == path
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+
+  test "style words are matched exactly and combined styles require both traits":
+    let path = fixtureDir / "bold.ttf"
+    writeFile(path, fontMetadata("Fixture Sans", "Bold", 700, 32))
+    for name in [
+      "Fixture Sans SemiBold", "Fixture Sans NotBold", "Fixture Sans Bold Italic"
+    ]:
+      check findSystemTypefaceFile([name], [path]).path.len == 0
+
+  test "regional collection family names remain distinct":
+    let path = fixtureDir / "regional.ttf"
+    writeFile(path, fontMetadata("Fixture Sans CJK JP"))
+    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]).path == path
+    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+
+  test "Unicode family names remain distinct":
+    let path = fixtureDir / "unicode.ttf"
+    writeFile(path, fontMetadata("明朝"))
+    check findSystemTypefaceFile(["明朝"], [path]).path == path
+    check findSystemTypefaceFile(["黑体"], [path]).path.len == 0
+
+  test "matches in one directory do not depend on enumeration order":
+    let
+      first = fixtureDir / "a.ttf"
+      second = fixtureDir / "z.ttf"
+    writeFile(first, fontMetadata("Fixture Sans"))
+    writeFile(second, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(["Fixture Sans"], [first, second]).path == first
+    check findSystemTypefaceFile(["Fixture Sans"], [second, first]).path == first
+
+  test "metadata is cached until explicit refresh":
+    let path = fixtureDir / "font.ttf"
+    writeFile(path, fontMetadata("First Family"))
+    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    writeFile(path, fontMetadata("Second Family"))
+    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    check findSystemTypefaceFile(["Second Family"], [path]).path.len == 0
+    refreshSystemFontMetadata()
+    check findSystemTypefaceFile(["Second Family"], [path]).path == path
+    check findSystemTypefaceFile(["First Family"], [path]).path.len == 0
+
+  test "caller directory precedence wins over alphabetical file order":
+    let
+      userDir = fixtureDir / "user"
+      systemDir = fixtureDir / "system"
+      userFont = userDir / "z.ttf"
+      systemFont = systemDir / "a.ttf"
+    createDir(userDir)
+    createDir(systemDir)
+    writeFile(userFont, fontMetadata("Fixture Sans"))
+    writeFile(systemFont, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(
+      ["Fixture Sans"], [userFont, systemFont], preserveInputOrder = true
+    ).path == userFont
+
+  test "malformed metadata cannot fall back to the filename":
+    let path = fixtureDir / "FixtureSans-Regular.ttf"
+    writeFile(path, "invalid font data")
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,4 +1,4 @@
-import std/[hashes, os, tables, unicode, unittest]
+import std/[hashes, os, tables, tempfiles, unicode, unittest]
 
 import pkg/pixie
 import pkg/pixie/fonts
@@ -245,8 +245,86 @@ suite "fontutils":
     check getTypefaceSource(typefaceId).faceIndex == 1
     check info.family == "PT Sans"
     check info.regular
+
     check not info.bold
     check not info.italic
+
+  test "named system-family lookup selects metadata face in a renamed collection":
+    let
+      tempDir = createTempDir("figdraw-named-system-font-test-", "")
+      sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
+    var fontDir: string
+    when defined(windows):
+      let
+        oldLocalAppData = getEnv("LOCALAPPDATA", "")
+        hadLocalAppData = existsEnv("LOCALAPPDATA")
+      fontDir = tempDir / "Microsoft" / "Windows" / "Fonts"
+    elif defined(macosx):
+      let
+        oldHome = getEnv("HOME", "")
+        hadHome = existsEnv("HOME")
+      fontDir = tempDir / "Library" / "Fonts"
+    else:
+      let
+        oldXdgDataHome = getEnv("XDG_DATA_HOME", "")
+        hadXdgDataHome = existsEnv("XDG_DATA_HOME")
+      fontDir = tempDir / "fonts"
+    let collectionPath = fontDir / "unrelated-name.otc"
+    if not dirExists(fontDir):
+      createDir(fontDir)
+    defer:
+      when defined(windows):
+        if hadLocalAppData:
+          putEnv("LOCALAPPDATA", oldLocalAppData)
+        else:
+          delEnv("LOCALAPPDATA")
+      elif defined(macosx):
+        if hadHome:
+          putEnv("HOME", oldHome)
+        else:
+          delEnv("HOME")
+      else:
+        if hadXdgDataHome:
+          putEnv("XDG_DATA_HOME", oldXdgDataHome)
+        else:
+          delEnv("XDG_DATA_HOME")
+      refreshSystemFontMetadata()
+      if dirExists(tempDir):
+        removeDir(tempDir)
+
+    var collectionData = readFile(sourcePath)
+    collectionData.swapTtcFaceOffsets(0, 1)
+    writeFile(collectionPath, collectionData)
+    when defined(windows):
+      putEnv("LOCALAPPDATA", tempDir)
+    elif defined(macosx):
+      putEnv("HOME", tempDir)
+    else:
+      putEnv("XDG_DATA_HOME", tempDir)
+    refreshSystemFontMetadata()
+
+    let typefaceId = loadTypeface("PT Sans")
+    let info = getTypefaceInfo(typefaceId)
+    check getTypefaceSource(typefaceId).name == collectionPath
+    check getTypefaceSource(typefaceId).faceIndex == 1
+    check info.family == "PT Sans"
+    check info.regular
+
+    let arrangement = typeset(
+      rect(0, 0, 120, 50),
+      FigFont(typefaceId: typefaceId, size: 24.0'f32),
+      "A",
+      minContent = false,
+      wrap = false,
+    )
+    require arrangement.arrangedGlyphs.len == 1
+    for glyph in arrangement.glyphs():
+      check getFigFont(glyph.fontId).typefaceId == typefaceId
+      check glyph.glyphId != FontGlyphId(0)
+      let image = glyph.generateGlyph(force = true, upload = false)
+      require image != nil
+      check image.opaqueBounds().w > 0
+      check image.opaqueBounds().h > 0
 
   test "unknown typeface metadata lookup raises ValueError":
     expect ValueError:

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,4 +1,4 @@
-import std/[hashes, os, tables, tempfiles, unicode, unittest]
+import std/[hashes, options, os, tables, tempfiles, unicode, unittest]
 
 import pkg/pixie
 import pkg/pixie/fonts
@@ -303,8 +303,17 @@ suite "fontutils":
       putEnv("XDG_DATA_HOME", tempDir)
     refreshSystemFontMetadata()
 
+    let systemTypeface = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    require systemTypeface.isSome
+    let resolvedTypefaceId = loadTypeface(systemTypeface.get())
+    let resolvedInfo = getTypefaceInfo(resolvedTypefaceId)
+    check getTypefaceSource(resolvedTypefaceId).faceIndex == 1
+    check resolvedInfo.family == "PT Sans"
+    check resolvedInfo.regular
+
     let typefaceId = loadTypeface("PT Sans")
     let info = getTypefaceInfo(typefaceId)
+    check typefaceId == resolvedTypefaceId
     check getTypefaceSource(typefaceId).name == collectionPath
     check getTypefaceSource(typefaceId).faceIndex == 1
     check info.family == "PT Sans"

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -1,4 +1,4 @@
-import std/[os, strutils, unittest]
+import std/[options, os, strutils, unittest]
 
 import figdraw/common/fonttypes
 
@@ -99,8 +99,9 @@ suite "system fonts":
     refreshSystemFontMetadata()
 
     let match = findSystemTypefaceFile(["PT Sans"], [collectionPath])
-    check match.path == collectionPath
-    check match.faceIndex == 1
+    require match.isSome
+    check match.get().path == collectionPath
+    check match.get().faceIndex == 1
 
   test "regional family aliases resolve their base collection":
     check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -5,7 +5,8 @@ import figdraw/common/fonttypes
 when defined(useNativeDynlib):
   import figdraw/dynlib
   from figdraw/extras/systemfonts import
-    systemDefaultFontNames, findSystemFontFile, sfrMono
+    systemDefaultFontNames, findSystemFontFile, findSystemTypefaceFile,
+    refreshSystemFontMetadata, fontNameMatchScore, sfrMono
 else:
   import figdraw
 
@@ -37,7 +38,7 @@ suite "system fonts":
     let fonts = systemFontFiles()
     check fonts.len > 0
     for font in fonts:
-      check font.splitFile.ext.toLowerAscii() in supportedFontFileExtensions()
+      check font.splitFile.ext.toLowerAscii() in fonttypes.supportedFontFileExtensions()
 
   test "family lookup rejects related and styled font filenames":
     let font = findSystemFontFile(
@@ -76,6 +77,30 @@ suite "system fonts":
   test "collection face scoring excludes bold before a regular face":
     check fontNameMatchScore("PT Sans", "PT Sans Bold") == -1
     check fontNameMatchScore("PT Sans", "PT Sans Regular") == 1
+
+  test "OpenType metadata selects a regular collection face independent of filename":
+    let
+      tempDir = getTempDir() / "figdraw-system-font-metadata-test"
+      sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
+      collectionPath = tempDir / "unrelated-name.ttc"
+    if not dirExists(tempDir):
+      createDir(tempDir)
+    defer:
+      refreshSystemFontMetadata()
+      if dirExists(tempDir):
+        removeDir(tempDir)
+
+    var data = readFile(sourcePath)
+    swap(data[12], data[16])
+    swap(data[13], data[17])
+    swap(data[14], data[18])
+    swap(data[15], data[19])
+    writeFile(collectionPath, data)
+    refreshSystemFontMetadata()
+
+    let match = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    check match.path == collectionPath
+    check match.faceIndex == 1
 
   test "regional family aliases resolve their base collection":
     check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==

--- a/tests/ttext_backend_info.nim
+++ b/tests/ttext_backend_info.nim
@@ -26,4 +26,4 @@ suite "text backend information":
       discard
 
   test "reports supported typeface file extensions":
-    check supportedFontFileExtensions() == @[".ttf", ".otf", ".ttc", ".svg"]
+    check supportedFontFileExtensions() == @[".ttf", ".otf", ".ttc", ".svg", ".otc"]


### PR DESCRIPTION
Named font requests previously depended on filenames, which could select a related family, the wrong style, or the wrong collection face. Resolve installed families and styles from OpenType metadata, including typographic names, and carry the selected collection face through Pixie and HarfBuzz layout and rasterization.

Closes #74.

- Keep existing API signatures, explicit file loading, platform aliases, static registrations, and ordered fallback names. Add `findSystemTypefaceFile` to return a path and face index; retain filename-only behavior for `findSystemFontFile(names, fontFiles)`.
- Match styles strictly and advance through fallback names and platform defaults when a requested style is unavailable. Explicit collection files retain their existing face-selection default.
- Prefer user font directories, sort equally ranked file matches deterministically, and discover `.otc` files alongside `.ttc` files.
- Cache lightweight name/style metadata behind a lock and expose `refreshSystemFontMetadata()` for font installation, replacement, or removal. Existing font ownership and ARC/ORC contracts remain unchanged.

Validation on macOS with Nim 2.2.10:

- `nim test`: 34 test files passed and enabled examples compiled; optional SDL2 examples skipped by the default task configuration.
- Final targeted tests passed for metadata resolution, system fonts, backend information, and `tfontutils` with both Pixie and HarfBuzz.
- Deterministic fixtures cover misleading filenames, related families, missing styles, typographic subfamilies, Unicode names, directory precedence, stable ties, malformed metadata, and cache refresh.
- A renamed collection with reordered faces is resolved by family name, typeset, and rasterized with visible glyph pixels in both backends.
- Native-library system-font API compile check and `git diff --check` passed.
