### PR TITLE
Use native OS font services for discovery and matching

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim,tsiwin_fallback_window.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -63,7 +63,7 @@ jobs:
             nimflags: '-d:figdraw.opengl=off -d:figdraw.vulkan=on -d:figdraw.openglFallback=off --passC:-IC:/msys64/mingw64/include/harfbuzz -d:harfbuzzyDynlib=libharfbuzz-0.dll -d:harfbuzzyFribidiDynlib=libfribidi-0.dll'
             force_opengl: '0'
             require_graphics: '0'
-            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim,tsiwin_dedicated_render.nim,tsiwin_fallback_window.nim'
+            test_exclude: 'tfigrender_oneframe_screenshot.nim,trender_3d_overlay.nim,trender_extras.nim,trender_image.nim,trender_image_msdf_invert.nim,trender_layers_clip.nim,trender_linear_gradient.nim,trender_rgb_boxes.nim,trender_rgb_boxes_sdf.nim,trender_rgb_boxes_sdf_siwin.nim,trender_text_invert.nim,tsiwin_rect_mask_vulkan.nim'
             vulkan_icd: 'C:/swiftshader/vk_swiftshader_icd.json'
     steps:
     - uses: actions/checkout@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,12 @@
 
 ## Build, Test, and Development
 - Install deps (atlas workspace): `atlas install` (ensure `atlas` is installed and configured for your environment). *Never* use Nimble - it's horrible. *Always* use Atlas and it's `deps/` folder and `nim.cfg` file to see paths.
-- Run all tests: `nim test` (uses the `test` task in `config.nims` to compile and run every `tests/*.nim`).
-- Run a single test locally:
+- Run multiple or all tests with `atlas-run tests [test-selections]`. Omit selections to run the full suite, or pass one or more test selectors to run focused tests. Selectors match as `foo` -> `tests/tfoo*.nim`, `foo.nim` -> `tests/tfoo.nim`, and `examples/foo*.nim` -> `examples/foo*.nim`. Do not adjust the `--jobs` count or the `--nimcache`.
+- Compile the example bundle with `atlas-run tests --compile-only examples/all_compile.nim`; do not run `examples/all_compile.nim` as a test.
+- Execute a single test locally using Nim:
   - `nim r tests/ttransfer.nim`
+  - `nim r tests/ttransfer.nim -d:debug`
+
 
 ## Coding Style & Naming
 - Indentation: 2 spaces; no tabs.

--- a/README.md
+++ b/README.md
@@ -784,8 +784,10 @@ in a long-running process. Style matching is strict: a missing style advances to
 the caller's ordered fallback names, then platform defaults. To prefer the same
 family's regular face, list that family explicitly as a fallback. Existing
 `loadTypeface` signatures remain unchanged. The additive
-`findSystemTypefaceFile` lookup returns both `path` and `faceIndex`; the existing
-`findSystemFontFile(names, fontFiles)` overload retains filename-only matching.
+`findSystemTypefaceFile` lookup returns an `Option[SystemTypefaceFile]` containing
+both `path` and `faceIndex`; pass the matched value to `loadTypeface` to load that
+exact face. The existing `findSystemFontFile(names, fontFiles)` overload retains
+filename-only matching.
 Explicit `.ttc` and `.otc` paths retain their
 documented filename-based selection, with face zero as the default only when no
 face name matches. FigDraw carries the selected face index through shaping and

--- a/README.md
+++ b/README.md
@@ -791,6 +791,16 @@ exact face. Native matches must resolve to one readable local font file and a
 concrete collection face. Synthetic or remote faces, multi-file faces, and
 variable named instances that require implicit axis coordinates are skipped.
 
+Use the `systemTypefaces()` iterator to enumerate those installed local faces
+without first building a sequence. Each yielded `SystemTypefaceInfo` owns its
+provider-selected family, subfamily, full, and PostScript names and identifies
+the file by both path and collection face index. An optional
+`SystemTypefaceQuery` applies exact, case- and separator-insensitive `family`
+and `subfamily` filters; empty fields are wildcards, populated fields are ANDed,
+and a family query returns every style without closest-font substitution.
+Enumeration order is platform-native and unspecified, and each `(path,
+faceIndex)` identity is emitted at most once.
+
 The OpenType metadata reader remains the portable source of metadata for loaded,
 embedded, in-memory, and caller-supplied font files. The
 `findSystemTypefaceFile(names, fontFiles)` overload uses it for deterministic

--- a/README.md
+++ b/README.md
@@ -776,17 +776,26 @@ Use the source-aware helpers for selection, hit testing, and carets:
 - `caretPositionsFor(sourceRune)`: visual caret rectangles for a source
   insertion index, including split positions at bidi boundaries.
 
-Installed named fonts are resolved from their OpenType family and style metadata,
-including typographic family names, rather than their filenames. User font
-directories take precedence over system directories. Font metadata is cached;
-call `refreshSystemFontMetadata()` after installing, replacing, or removing fonts
-in a long-running process. Style matching is strict: a missing style advances to
-the caller's ordered fallback names, then platform defaults. To prefer the same
-family's regular face, list that family explicitly as a fallback. Existing
-`loadTypeface` signatures remain unchanged. The additive
+Installed named fonts are discovered and matched by the host font service:
+DirectWrite on Windows, Core Text on macOS, and Fontconfig on Linux and FreeBSD.
+FigDraw validates the selected family, full, or PostScript name so a platform's
+closest-font substitution cannot satisfy an unrelated request. If a native
+provider is unavailable at runtime, installed-font lookup falls back to scanning
+the conventional font directories. Style matching is strict: a missing style
+advances to the caller's ordered fallback names, then platform defaults. To
+prefer the same family's regular face, list that family explicitly as a fallback.
+Existing `loadTypeface` signatures remain unchanged. The additive
 `findSystemTypefaceFile` lookup returns an `Option[SystemTypefaceFile]` containing
 both `path` and `faceIndex`; pass the matched value to `loadTypeface` to load that
-exact face. The existing `findSystemFontFile(names, fontFiles)` overload retains
+exact face. Native matches must resolve to one readable local font file and a
+concrete collection face. Synthetic or remote faces, multi-file faces, and
+variable named instances that require implicit axis coordinates are skipped.
+
+The OpenType metadata reader remains the portable source of metadata for loaded,
+embedded, in-memory, and caller-supplied font files. The
+`findSystemTypefaceFile(names, fontFiles)` overload uses it for deterministic
+matching within an explicit file list; `refreshSystemFontMetadata()` clears that
+scan cache. The existing `findSystemFontFile(names, fontFiles)` overload retains
 filename-only matching.
 Explicit `.ttc` and `.otc` paths retain their
 documented filename-based selection, with face zero as the default only when no

--- a/README.md
+++ b/README.md
@@ -776,9 +776,20 @@ Use the source-aware helpers for selection, hit testing, and carets:
 - `caretPositionsFor(sourceRune)`: visual caret rectangles for a source
   insertion index, including split positions at bidi boundaries.
 
-Font collection paths (`.ttc` and `.otc`) are supported; FigDraw selects the
-face whose name best matches the requested font and carries that face index
-through shaping and rasterization. The current Harfbuzzy raster path renders
+Installed named fonts are resolved from their OpenType family and style metadata,
+including typographic family names, rather than their filenames. User font
+directories take precedence over system directories. Font metadata is cached;
+call `refreshSystemFontMetadata()` after installing, replacing, or removing fonts
+in a long-running process. Style matching is strict: a missing style advances to
+the caller's ordered fallback names, then platform defaults. To prefer the same
+family's regular face, list that family explicitly as a fallback. Existing
+`loadTypeface` signatures remain unchanged. The additive
+`findSystemTypefaceFile` lookup returns both `path` and `faceIndex`; the existing
+`findSystemFontFile(names, fontFiles)` overload retains filename-only matching.
+Explicit `.ttc` and `.otc` paths retain their
+documented filename-based selection, with face zero as the default only when no
+face name matches. FigDraw carries the selected face index through shaping and
+rasterization. The current Harfbuzzy raster path renders
 monochrome outlines, not color bitmap, SVG, or COLR glyph paint data.
 
 See [docs/font_shaping.md](docs/font_shaping.md) for the data model details and

--- a/README.md
+++ b/README.md
@@ -784,26 +784,30 @@ provider is unavailable at runtime, installed-font lookup falls back to scanning
 the conventional font directories. Style matching is strict: a missing style
 advances to the caller's ordered fallback names, then platform defaults. To
 prefer the same family's regular face, list that family explicitly as a fallback.
-Existing `loadTypeface` signatures remain unchanged. The additive
-`findSystemTypefaceFile` lookup returns an `Option[SystemTypefaceFile]` containing
-both `path` and `faceIndex`; pass the matched value to `loadTypeface` to load that
-exact face. Native matches must resolve to one readable local font file and a
-concrete collection face. Synthetic or remote faces, multi-file faces, and
-variable named instances that require implicit axis coordinates are skipped.
+The `findSystemTypeface` lookup returns an `Option[SystemTypeface]`. Its `file`
+contains the local `path` and physical `faceIndex`, while `variations` contains
+the canonical variable-axis coordinates needed to distinguish named instances.
+Call `fontWithSize` on the matched value to load the physical face and retain
+those coordinates. `loadTypeface(SystemTypefaceFile)` remains available when a
+caller intentionally needs only a physical `TypefaceId`. Native matches must
+resolve to one readable local font file and a concrete collection face.
+Synthetic or remote faces and multi-file faces are skipped. Core Text provides
+named-instance coordinates on macOS; providers that cannot report them omit
+those instances instead of returning a different design.
 
 Use the `systemTypefaces()` iterator to enumerate those installed local faces
 without first building a sequence. Each yielded `SystemTypefaceInfo` owns its
 provider-selected family, subfamily, full, and PostScript names and identifies
-the file by both path and collection face index. An optional
+the exact typeface by file, collection face index, and variation coordinates. An optional
 `SystemTypefaceQuery` applies exact, case- and separator-insensitive `family`
 and `subfamily` filters; empty fields are wildcards, populated fields are ANDed,
 and a family query returns every style without closest-font substitution.
 Enumeration order is platform-native and unspecified, and each `(path,
-faceIndex)` identity is emitted at most once.
+faceIndex, variations)` identity is emitted at most once.
 
 The OpenType metadata reader remains the portable source of metadata for loaded,
 embedded, in-memory, and caller-supplied font files. The
-`findSystemTypefaceFile(names, fontFiles)` overload uses it for deterministic
+`findSystemTypeface(names, fontFiles)` overload uses it for deterministic
 matching within an explicit file list; `refreshSystemFontMetadata()` clears that
 scan cache. The existing `findSystemFontFile(names, fontFiles)` overload retains
 filename-only matching.

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "gh:elcritch/siwin#5bc4ce6122a8515de00c85da48c847d568600b74"
+  requires "gh:elcritch/siwin#master"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "gh:elcritch/siwin#master"
+  requires "siwin#master"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "https://github.com/levovix0/siwin#a70c4666915169867fde3b65cf9d664c58e2cb0b"
+  requires "https://github.com/levovix0/siwin#69b1f6144c9be6331e01471183ace5b3ec13fae5"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -1,4 +1,4 @@
-version = "0.36.1"
+version = "0.37.0"
 author = "Jaremy Creechley"
 description = "UI Engine for Nim"
 license = "MIT"
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "gh:elcritch/siwin#fix-x11-popup-border-pixel"
+  requires "gh:elcritch/siwin#5bc4ce6122a8515de00c85da48c847d568600b74"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "siwin >= 1.1.0"
+  requires "https://github.com/levovix0/siwin#a70c4666915169867fde3b65cf9d664c58e2cb0b"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -39,7 +39,7 @@ feature "surfer":
   requires "xkb#b4d50f4cccad1cd9e39d2f5a5e1fef2710edcc31"
   # TODO: Put this in surfer's manifest.
 feature "siwin":
-  requires "https://github.com/levovix0/siwin#69b1f6144c9be6331e01471183ace5b3ec13fae5"
+  requires "gh:elcritch/siwin#fix-x11-popup-border-pixel"
 feature "vulkan":
   requires "https://github.com/planetis-m/vulkan#b223dc9"
 feature "metal":

--- a/src/figdraw/common/fonttypes.nim
+++ b/src/figdraw/common/fonttypes.nim
@@ -129,11 +129,7 @@ type
     sskBytes
 
 const figdrawTextBackend* {.strdefine.} =
-  when defined(feature.figdraw.textBackendHarfbuzzy):
-    "harfbuzzy"
-  else:
-    "pixie"
-
+  when defined(feature.figdraw.textBackendHarfbuzzy): "harfbuzzy" else: "pixie"
 
 static:
   doAssert figdrawTextBackend in ["pixie", "harfbuzzy", "hybrid"]
@@ -162,7 +158,7 @@ func textBackendFeatures*(): seq[string] =
 
 func supportedFontFileExtensions*(): seq[string] =
   ## Typeface file extensions accepted by FigDraw's font loader.
-  @[".ttf", ".otf", ".ttc", ".svg"]
+  @[".ttf", ".otf", ".ttc", ".svg", ".otc"]
 
 proc hash*(id: TypefaceId): Hash {.borrow.}
 proc `==`*(a, b: TypefaceId): bool {.borrow.}

--- a/src/figdraw/common/fontutils.nim
+++ b/src/figdraw/common/fontutils.nim
@@ -21,7 +21,9 @@ when defined(figdrawNativeDynlib):
 else:
   {.pragma: nativeAbi.}
 
-export FontRef, TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
+export
+  FontRef, SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName,
+  TypefaceVariationAxis
 export font, fontId, fontRef, loadTypeface, getTypefaceInfo, convertFont
 export registerStaticTypeface
 

--- a/src/figdraw/common/fontutils.nim
+++ b/src/figdraw/common/fontutils.nim
@@ -22,9 +22,9 @@ else:
   {.pragma: nativeAbi.}
 
 export
-  FontRef, SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName,
+  FontRef, SystemTypefaceFile, SystemTypeface, TypefaceInfo, TypefaceLocalizedName,
   TypefaceVariationAxis
-export font, fontId, fontRef, loadTypeface, getTypefaceInfo, convertFont
+export font, fontId, fontRef, loadTypeface, getTypefaceInfo, convertFont, fontWithSize
 export registerStaticTypeface
 
 when figdrawTextBackend == "harfbuzzy" or figdrawTextBackend == "hybrid":

--- a/src/figdraw/common/typefaceinfos.nim
+++ b/src/figdraw/common/typefaceinfos.nim
@@ -488,6 +488,28 @@ proc fallbackFamily(sourceName: string): string =
   let fileName = sourceName.extractFilename()
   result = (if fileName.len > 0: fileName else: sourceName).splitFile().name
 
+proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInfo =
+  ## Reads the names and style flags needed to identify one OpenType face.
+  ##
+  ## Unlike `parseTypefaceInfo`, this deliberately does not read cmap, layout,
+  ## or variation tables. It raises for malformed data so font discovery does
+  ## not mistake a filename-derived fallback for OpenType metadata.
+  let tables = data.readTypefaceTables(faceIndex)
+  result.faceIndex = faceIndex
+  result.localizedNames = data.readLocalizedNames(tables)
+  let
+    family = result.localizedNames.preferredName([16'u16, 1'u16])
+    subfamily = result.localizedNames.preferredName([17'u16, 2'u16])
+    fullName = result.localizedNames.preferredName([4'u16])
+    postScriptName = result.localizedNames.preferredName([6'u16])
+  if family.len == 0:
+    raise newException(ValueError, "font has no usable family name")
+  result.family = family
+  result.subfamily = subfamily
+  result.fullName = if fullName.len > 0: fullName else: family
+  result.postScriptName = postScriptName
+  result.applyStyleInfo(data, tables)
+
 proc parseTypefaceInfo*(
     sourceName, data: string, faceIndex = 0, fallbackFullName = ""
 ): TypefaceInfo =

--- a/src/figdraw/common/typefaceinfos.nim
+++ b/src/figdraw/common/typefaceinfos.nim
@@ -24,6 +24,22 @@ type
     maxValue*: float32
     hidden*: bool
 
+  ## Lightweight OpenType names and style metadata for one typeface face.
+  TypefaceNameInfo* = object
+    family*: string
+    subfamily*: string
+    fullName*: string
+    postScriptName*: string
+    faceIndex*: int
+    weightClass*: uint16
+    widthClass*: uint16
+    bold*: bool
+    italic*: bool
+    oblique*: bool
+    regular*: bool
+    monospace*: bool
+    localizedNames*: seq[TypefaceLocalizedName]
+
   ## Backend-neutral metadata for one registered typeface face.
   ##
   ## `layoutScripts` and `layoutLanguages` contain OpenType shaping tags from
@@ -488,12 +504,13 @@ proc fallbackFamily(sourceName: string): string =
   let fileName = sourceName.extractFilename()
   result = (if fileName.len > 0: fileName else: sourceName).splitFile().name
 
-proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInfo =
+proc readTypefaceNameInfo*(data: string, faceIndex: Natural = 0): TypefaceNameInfo =
   ## Reads the names and style flags needed to identify one OpenType face.
   ##
-  ## Unlike `parseTypefaceInfo`, this deliberately does not read cmap, layout,
-  ## or variation tables. It raises for malformed data so font discovery does
-  ## not mistake a filename-derived fallback for OpenType metadata.
+  ## It raises for malformed data, an unavailable collection face, or a nonzero
+  ## face index for a standalone font.
+  if data.len >= 4 and data[0 ..< 4] != "ttcf" and faceIndex != 0:
+    raise newException(ValueError, "standalone font face index must be zero")
   let tables = data.readTypefaceTables(faceIndex)
   result.faceIndex = faceIndex
   result.localizedNames = data.readLocalizedNames(tables)
@@ -508,7 +525,15 @@ proc readTypefaceNameInfo*(sourceName, data: string, faceIndex = 0): TypefaceInf
   result.subfamily = subfamily
   result.fullName = if fullName.len > 0: fullName else: family
   result.postScriptName = postScriptName
-  result.applyStyleInfo(data, tables)
+  var styleInfo: TypefaceInfo
+  styleInfo.applyStyleInfo(data, tables)
+  result.weightClass = styleInfo.weightClass
+  result.widthClass = styleInfo.widthClass
+  result.bold = styleInfo.bold
+  result.italic = styleInfo.italic
+  result.oblique = styleInfo.oblique
+  result.regular = styleInfo.regular
+  result.monospace = styleInfo.monospace
 
 proc parseTypefaceInfo*(
     sourceName, data: string, faceIndex = 0, fallbackFullName = ""

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -330,7 +330,8 @@ proc loadTypeface*(file: SystemTypefaceFile): TypefaceId {.nativeAbi.} =
   if file.faceIndex < 0:
     raise newException(PixieError, "typeface face index must not be negative")
   let (typeface, source) = readTypefacePath(file.path, file.path, file.faceIndex)
-  registerTypeface(typeface, source)
+  result = registerTypeface(typeface, source)
+  info "loaded typeface from exact file", path = file.path, faceIndex = file.faceIndex
 
 proc fontWithSize*(typeface: SystemTypeface, size: float32): FigFont =
   ## Loads an exact installed typeface and applies its variable-axis coordinates.

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -255,7 +255,7 @@ proc loadTypeface*(
     let systemTypeface = findSystemTypefaceFile([name])
     if systemTypeface.isSome:
       let matchedTypeface = systemTypeface.get()
-      info "resolved typeface from system font metadata",
+      info "resolved typeface from system font service",
         requested = name,
         path = matchedTypeface.path,
         faceIndex = matchedTypeface.faceIndex

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -16,7 +16,9 @@ import ./shared
 import ./typefaceinfos
 import ../extras/systemfonts
 
-export SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
+export
+  SystemTypefaceFile, SystemTypeface, TypefaceInfo, TypefaceLocalizedName,
+  TypefaceVariationAxis
 
 when defined(figdrawNativeDynlib):
   {.pragma: nativeAbi, exportabi.}
@@ -252,15 +254,15 @@ proc loadTypeface*(
           requested = name, path = filePath
         return ResolvedTypefacePath(path: filePath, faceIndex: -1)
 
-    let systemTypeface = findSystemTypefaceFile([name])
+    let systemTypeface = findSystemTypeface([name])
     if systemTypeface.isSome:
       let matchedTypeface = systemTypeface.get()
       info "resolved typeface from system font service",
         requested = name,
-        path = matchedTypeface.path,
-        faceIndex = matchedTypeface.faceIndex
+        path = matchedTypeface.file.path,
+        faceIndex = matchedTypeface.file.faceIndex
       return ResolvedTypefacePath(
-        path: matchedTypeface.path, faceIndex: matchedTypeface.faceIndex
+        path: matchedTypeface.file.path, faceIndex: matchedTypeface.file.faceIndex
       )
 
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
@@ -322,13 +324,18 @@ proc loadTypeface*(name: string): TypefaceId {.nativeAbi.} =
   loadTypeface(name, [])
 
 proc loadTypeface*(file: SystemTypefaceFile): TypefaceId {.nativeAbi.} =
-  ## Loads the exact face returned by `findSystemTypefaceFile`.
+  ## Loads the physical face in `file`.
   if file.path.len == 0:
     raise newException(PixieError, "typeface path is empty")
   if file.faceIndex < 0:
     raise newException(PixieError, "typeface face index must not be negative")
   let (typeface, source) = readTypefacePath(file.path, file.path, file.faceIndex)
   registerTypeface(typeface, source)
+
+proc fontWithSize*(typeface: SystemTypeface, size: float32): FigFont =
+  ## Loads an exact installed typeface and applies its variable-axis coordinates.
+  result = loadTypeface(typeface.file).fontWithSize(size)
+  result.variations = typeface.variations
 
 proc loadTypeface*(name, data: string, kind: TypeFaceKinds): TypefaceId {.nativeAbi.} =
   ## loads a font from buffer and adds it to the font index

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -321,7 +321,7 @@ proc loadTypeface*(
 proc loadTypeface*(name: string): TypefaceId {.nativeAbi.} =
   loadTypeface(name, [])
 
-proc loadTypeface*(file: SystemTypefaceFile): TypefaceId =
+proc loadTypeface*(file: SystemTypefaceFile): TypefaceId {.nativeAbi.} =
   ## Loads the exact face returned by `findSystemTypefaceFile`.
   if file.path.len == 0:
     raise newException(PixieError, "typeface path is empty")

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -142,7 +142,7 @@ proc isTypefaceCollection(path: string): bool =
   splitFile(path).ext.toLowerAscii() in [".ttc", ".otc"]
 
 proc readTypefacePath(
-    path, requestedName: string
+    path, requestedName: string, requestedFaceIndex = -1
 ): tuple[typeface: Typeface, source: TypefaceSource] {.raises: [PixieError].} =
   if path.isTypefaceCollection():
     let typefaces = readTypefaces(path)
@@ -150,14 +150,18 @@ proc readTypefacePath(
       raise newException(PixieError, "typeface collection is empty")
 
     let requested = splitFile(requestedName).name
-    var
+    var faceIndex = requestedFaceIndex
+    if faceIndex >= 0 and faceIndex notin 0 ..< typefaces.len:
+      raise
+        newException(PixieError, "requested typeface collection face is not available")
+    if faceIndex < 0:
       faceIndex = 0
-      matchScore = high(int)
-    for index, typeface in typefaces:
-      let score = fontNameMatchScore(requested, typeface.name())
-      if score >= 0 and score < matchScore:
-        faceIndex = index
-        matchScore = score
+      var matchScore = high(int)
+      for index, typeface in typefaces:
+        let score = fontNameMatchScore(requested, typeface.name())
+        if score >= 0 and score < matchScore:
+          faceIndex = index
+          matchScore = score
 
     result.typeface = typefaces[faceIndex]
     result.typeface.filePath = path & "#" & $faceIndex
@@ -224,24 +228,41 @@ proc loadTypeface*(
 ): TypefaceId {.nativeAbi.} =
   ## loads a font from a file and adds it to the font index
 
-  proc resolveTypefacePath(name: string): string =
+  proc resolveTypefacePath(name: string): SystemTypefaceFile =
     let dataPath = figDataDir() / name
     if fileExists(dataPath):
       info "resolved typeface from figDataDir", requested = name, path = dataPath
-      return dataPath
+      return SystemTypefaceFile(path: dataPath, faceIndex: -1)
 
     if fileExists(name):
       info "resolved typeface from direct path", requested = name, path = name
-      return name
+      return SystemTypefaceFile(path: name, faceIndex: -1)
 
-    let stem = splitFile(name).name
-    let systemPath = findSystemFontFile([name, stem])
-    if systemPath.len > 0:
-      info "resolved typeface from system fonts", requested = name, path = systemPath
-      return systemPath
+    if splitFile(name).ext.len > 0:
+      let filePath = findSystemFontFile([name])
+      if filePath.len > 0:
+        info "resolved typeface from exact system font filename",
+          requested = name, path = filePath
+        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+
+    let systemTypeface = findSystemTypefaceFile([name])
+    if systemTypeface.path.len > 0:
+      info "resolved typeface from system font metadata",
+        requested = name,
+        path = systemTypeface.path,
+        faceIndex = systemTypeface.faceIndex
+      return systemTypeface
+
+    let alias = splitFile(name).name.toLowerAscii().replace("-", "")
+    if alias in ["sfns", "ubuntur"]:
+      let filePath = findSystemFontFile([name])
+      if filePath.len > 0:
+        info "resolved typeface from system font alias",
+          requested = name, path = filePath
+        return SystemTypefaceFile(path: filePath, faceIndex: -1)
 
     warn "unable to resolve typeface path", requested = name, figDataDir = figDataDir()
-    result = ""
+    result.faceIndex = -1
 
   var candidateNames = @[name]
   candidateNames.add(fallbackNames)
@@ -251,15 +272,16 @@ proc loadTypeface*(
   var typeface: Typeface
   var source: TypefaceSource
   for candidate in candidateNames:
-    let typefacePath = resolveTypefacePath(candidate)
-    if typefacePath.len > 0:
+    let resolved = resolveTypefacePath(candidate)
+    if resolved.path.len > 0:
       try:
-        (typeface, source) = readTypefacePath(typefacePath, candidate)
+        (typeface, source) =
+          readTypefacePath(resolved.path, candidate, resolved.faceIndex)
         loaded = true
         break
       except PixieError:
         warn "failed to read resolved typeface path",
-          requested = name, candidate = candidate, path = typefacePath
+          requested = name, candidate = candidate, path = resolved.path
 
     var staticEntry: tuple[name: string, data: string, kind: TypeFaceKinds]
     if candidate.staticTypefaceEntry(staticEntry):

--- a/src/figdraw/common/typefaces.nim
+++ b/src/figdraw/common/typefaces.nim
@@ -2,6 +2,7 @@ import std/os
 import std/strutils
 import std/locks
 import std/math
+import std/options
 import std/tables
 
 import pkg/vmath
@@ -15,7 +16,7 @@ import ./shared
 import ./typefaceinfos
 import ../extras/systemfonts
 
-export TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
+export SystemTypefaceFile, TypefaceInfo, TypefaceLocalizedName, TypefaceVariationAxis
 
 when defined(figdrawNativeDynlib):
   {.pragma: nativeAbi, exportabi.}
@@ -34,6 +35,10 @@ type TypefaceSource* = object
   faceIndex*: int
 
 type
+  ResolvedTypefacePath = object
+    path: string
+    faceIndex: int
+
   FontRefHandle = object
     value: FigFont
     id: FontId
@@ -175,6 +180,8 @@ proc readTypefacePath(
     except IOError as e:
       raise newException(PixieError, e.msg, e)
   else:
+    if requestedFaceIndex > 0:
+      raise newException(PixieError, "standalone typeface face index must be zero")
     try:
       let data = readFile(path)
       let kind = typefaceKindFromPath(path)
@@ -228,30 +235,33 @@ proc loadTypeface*(
 ): TypefaceId {.nativeAbi.} =
   ## loads a font from a file and adds it to the font index
 
-  proc resolveTypefacePath(name: string): SystemTypefaceFile =
+  proc resolveTypefacePath(name: string): ResolvedTypefacePath =
     let dataPath = figDataDir() / name
     if fileExists(dataPath):
       info "resolved typeface from figDataDir", requested = name, path = dataPath
-      return SystemTypefaceFile(path: dataPath, faceIndex: -1)
+      return ResolvedTypefacePath(path: dataPath, faceIndex: -1)
 
     if fileExists(name):
       info "resolved typeface from direct path", requested = name, path = name
-      return SystemTypefaceFile(path: name, faceIndex: -1)
+      return ResolvedTypefacePath(path: name, faceIndex: -1)
 
     if splitFile(name).ext.len > 0:
       let filePath = findSystemFontFile([name])
       if filePath.len > 0:
         info "resolved typeface from exact system font filename",
           requested = name, path = filePath
-        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+        return ResolvedTypefacePath(path: filePath, faceIndex: -1)
 
     let systemTypeface = findSystemTypefaceFile([name])
-    if systemTypeface.path.len > 0:
+    if systemTypeface.isSome:
+      let matchedTypeface = systemTypeface.get()
       info "resolved typeface from system font metadata",
         requested = name,
-        path = systemTypeface.path,
-        faceIndex = systemTypeface.faceIndex
-      return systemTypeface
+        path = matchedTypeface.path,
+        faceIndex = matchedTypeface.faceIndex
+      return ResolvedTypefacePath(
+        path: matchedTypeface.path, faceIndex: matchedTypeface.faceIndex
+      )
 
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
@@ -259,7 +269,7 @@ proc loadTypeface*(
       if filePath.len > 0:
         info "resolved typeface from system font alias",
           requested = name, path = filePath
-        return SystemTypefaceFile(path: filePath, faceIndex: -1)
+        return ResolvedTypefacePath(path: filePath, faceIndex: -1)
 
     warn "unable to resolve typeface path", requested = name, figDataDir = figDataDir()
     result.faceIndex = -1
@@ -310,6 +320,15 @@ proc loadTypeface*(
 
 proc loadTypeface*(name: string): TypefaceId {.nativeAbi.} =
   loadTypeface(name, [])
+
+proc loadTypeface*(file: SystemTypefaceFile): TypefaceId =
+  ## Loads the exact face returned by `findSystemTypefaceFile`.
+  if file.path.len == 0:
+    raise newException(PixieError, "typeface path is empty")
+  if file.faceIndex < 0:
+    raise newException(PixieError, "typeface face index must not be negative")
+  let (typeface, source) = readTypefacePath(file.path, file.path, file.faceIndex)
+  registerTypeface(typeface, source)
 
 proc loadTypeface*(name, data: string, kind: TypeFaceKinds): TypefaceId {.nativeAbi.} =
   ## loads a font from buffer and adds it to the font index

--- a/src/figdraw/dynlib.nim
+++ b/src/figdraw/dynlib.nim
@@ -5,11 +5,13 @@ import pkg/bumpy as bumpy
 import pkg/chroma as chroma
 import pkg/vmath as vmath
 import figdraw_native_abi
+from figdraw/extras/systemfonttypes import SystemTypeface
 
 export tables, bumpy, chroma, vmath
 export figdraw_native_abi except
   Rect, ColorRGBA, Vec2, Mat4, Rune, FigSelectionRange, figDashedRoundedRectBorder,
   figDottedRoundedRectBorder, figRoundedRectBorder, placeGlyphs, typeset
+export SystemTypeface
 
 const
   UseVulkanBackend* = false
@@ -484,6 +486,16 @@ proc span*(font: FigFont, color: Fill, text: string): (FontStyle, string) {.inli
 
 proc fontWithSize*(fontId: TypefaceId, size: float32): FigFont {.inline.} =
   FigFont(typefaceId: fontId, size: size)
+
+proc fontWithSize*(typeface: SystemTypeface, size: float32): FigFont =
+  ## Loads an exact installed typeface through the native ABI.
+  let file = figdraw_native_abi.SystemTypefaceFile(
+    path: typeface.file.path, faceIndex: typeface.file.faceIndex
+  )
+  result = loadTypeface(file).fontWithSize(size)
+  result.variations = newSeqOfCap[FontVariation](typeface.variations.len)
+  for variation in typeface.variations:
+    result.variations.add FontVariation(tag: variation.tag, value: variation.value)
 
 func fontFeature*(
     tag: string, value = 1'u32, start = 0'u32, ending = uint32.high

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -2,6 +2,10 @@ import std/[algorithm, locks, options, os, sets, strutils, tables, unicode]
 
 import ../common/fonttypes
 import ../common/typefaceinfos
+import ./systemfonts_native
+import ./systemfonttypes
+
+export SystemTypefaceFile
 
 type
   DisplayServer* = enum
@@ -12,11 +16,6 @@ type
   SystemFontRole* = enum
     sfrSans
     sfrMono
-
-  SystemTypefaceFile* = object
-    ## An installed font file and the selected face within it.
-    path*: string
-    faceIndex*: int ## Zero-based face index, including for standalone fonts.
 
   CachedFontMetadata = object
     valid: bool
@@ -123,7 +122,7 @@ proc fontMetadata(path: string): CachedFontMetadata =
         fontMetadataCache[key] = result
 
 proc refreshSystemFontMetadata*() =
-  ## Clears cached installed-font metadata after font directories change.
+  ## Clears metadata cached by explicit-file and native-provider fallback scans.
   withLock(fontMetadataLock):
     inc fontMetadataGeneration
     fontMetadataCache.clear()
@@ -154,7 +153,7 @@ proc metadataMatchScore(requestedName: string, info: TypefaceNameInfo): int =
 proc findSystemTypefaceFile*(
     names, fontFiles: openArray[string], preserveInputOrder = false
 ): Option[SystemTypefaceFile] =
-  ## Finds an installed face by OpenType family/style metadata.
+  ## Finds a face in caller-supplied files by OpenType family/style metadata.
   ##
   ## Directories are ranked by their first appearance in `fontFiles`, with
   ## paths sorted within each directory for deterministic ties. Set
@@ -294,7 +293,13 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
 proc findSystemTypefaceFile*(
     names: openArray[string], displayServer = detectDisplayServer()
 ): Option[SystemTypefaceFile] =
-  ## Finds an installed face by OpenType metadata using platform font folders.
+  ## Finds an installed face with the host platform's font service.
+  ##
+  ## The metadata scanner is retained for hosts where the native provider is
+  ## unavailable at runtime.
+  let nativeResult = findNativeSystemTypefaceFile(names)
+  if nativeResult.available:
+    return nativeResult.match
   findSystemTypefaceFile(
     names, systemFontFiles(displayServer), preserveInputOrder = true
   )
@@ -321,19 +326,18 @@ proc findSystemFontFile*(
 ): string =
   ## Finds the preferred installed system font path matching one of `names`.
   ##
-  ## Named requests use OpenType metadata. The two-array overload remains a
-  ## filename-only helper for callers that supply synthetic paths.
-  let fontFiles = systemFontFiles(displayServer)
+  ## Named requests use the host platform's font service. The two-array
+  ## overload remains a filename-only helper for caller-supplied paths.
   for name in names:
     if splitFile(name).ext.len > 0:
-      let path = findSystemFontFile([name], fontFiles)
+      let path = findSystemFontFile([name], systemFontFiles(displayServer))
       if path.len > 0:
         return path
-    let typeface = findSystemTypefaceFile([name], fontFiles, preserveInputOrder = true)
+    let typeface = findSystemTypefaceFile([name], displayServer)
     if typeface.isSome:
       return typeface.get().path
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
-      let path = findSystemFontFile([name], fontFiles)
+      let path = findSystemFontFile([name], systemFontFiles(displayServer))
       if path.len > 0:
         return path

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -5,7 +5,7 @@ import ../common/typefaceinfos
 import ./systemfonts_native
 import ./systemfonttypes
 
-export SystemTypefaceFile
+export SystemTypefaceFile, SystemTypefaceInfo, SystemTypefaceQuery
 
 type
   DisplayServer* = enum
@@ -41,6 +41,13 @@ proc normalizeMetadataName(name: string): string =
   for rune in name.runes:
     if $rune notin [" ", "-", "_", "."]:
       result.add($rune.toLower)
+
+func matches(query: SystemTypefaceQuery, info: SystemTypefaceInfo): bool =
+  let
+    family = query.family.normalizeMetadataName()
+    subfamily = query.subfamily.normalizeMetadataName()
+  (family.len == 0 or family == info.family.normalizeMetadataName()) and
+    (subfamily.len == 0 or subfamily == info.subfamily.normalizeMetadataName())
 
 proc fontNameMatchScore*(requestedName, fontName: string): int =
   ## Ranks a filename or face name for a family request.
@@ -289,6 +296,42 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
           result.add(file)
     except OSError:
       discard
+
+iterator systemTypefaces*(query = SystemTypefaceQuery()): SystemTypefaceInfo =
+  ## Enumerates installed, locally readable typeface files and collection faces.
+  ##
+  ## `family` and `subfamily` are exact, separator-insensitive filters. Empty
+  ## fields are wildcards and populated fields are combined with AND. A family
+  ## query returns every matching style; it does not perform font substitution.
+  ## Each `(path, faceIndex)` identity is yielded at most once. Order is native
+  ## and unspecified. Simulated, remote, multi-file, and variable named-instance
+  ## faces that cannot be represented by `SystemTypefaceFile` are omitted.
+  var
+    nativeAvailable = false
+    seen = initHashSet[(string, int)]()
+  for info in nativeSystemTypefaces(nativeAvailable):
+    let key = (info.file.path.normalizePathKey(), info.file.faceIndex)
+    if key notin seen and query.matches(info):
+      seen.incl(key)
+      yield info
+  if not nativeAvailable:
+    for path in systemFontFiles():
+      let metadata = path.fontMetadata()
+      if not metadata.valid:
+        continue
+      for face in metadata.faces:
+        let
+          info = SystemTypefaceInfo(
+            file: SystemTypefaceFile(path: path, faceIndex: face.faceIndex),
+            family: face.family,
+            subfamily: face.subfamily,
+            fullName: face.fullName,
+            postScriptName: face.postScriptName,
+          )
+          key = (path.normalizePathKey(), face.faceIndex)
+        if key notin seen and query.matches(info):
+          seen.incl(key)
+          yield info
 
 proc findSystemTypefaceFile*(
     names: openArray[string], displayServer = detectDisplayServer()

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, locks, os, sets, strutils, tables, unicode]
+import std/[algorithm, locks, options, os, sets, strutils, tables, unicode]
 
 import ../common/fonttypes
 import ../common/typefaceinfos
@@ -16,14 +16,15 @@ type
   SystemTypefaceFile* = object
     ## An installed font file and the selected face within it.
     path*: string
-    faceIndex*: int
+    faceIndex*: int ## Zero-based face index, including for standalone fonts.
 
   CachedFontMetadata = object
     valid: bool
-    faces: seq[TypefaceInfo]
+    faces: seq[TypefaceNameInfo]
 
 var
   fontMetadataCache: Table[string, CachedFontMetadata]
+  fontMetadataGeneration: uint64
   fontMetadataLock: Lock
 
 fontMetadataLock.initLock()
@@ -101,26 +102,33 @@ proc readFontMetadata(path: string): CachedFontMetadata =
     if count == 0:
       return
     for faceIndex in 0 ..< count:
-      result.faces.add readTypefaceNameInfo(path, data, faceIndex)
+      result.faces.add readTypefaceNameInfo(data, faceIndex)
     result.valid = result.faces.len > 0
   except CatchableError:
     discard
 
 proc fontMetadata(path: string): CachedFontMetadata =
   let key = fontMetadataKey(path)
+  var generation: uint64
   withLock(fontMetadataLock):
     if key in fontMetadataCache:
       return fontMetadataCache[key]
+    generation = fontMetadataGeneration
   result = readFontMetadata(path)
   withLock(fontMetadataLock):
-    fontMetadataCache[key] = result
+    if generation == fontMetadataGeneration:
+      if key in fontMetadataCache:
+        result = fontMetadataCache[key]
+      else:
+        fontMetadataCache[key] = result
 
 proc refreshSystemFontMetadata*() =
   ## Clears cached installed-font metadata after font directories change.
   withLock(fontMetadataLock):
+    inc fontMetadataGeneration
     fontMetadataCache.clear()
 
-proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
+proc metadataMatchScore(requestedName: string, info: TypefaceNameInfo): int =
   let
     requested = requestedName.normalizeMetadataName()
     family = info.family.normalizeMetadataName()
@@ -145,13 +153,14 @@ proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
 
 proc findSystemTypefaceFile*(
     names, fontFiles: openArray[string], preserveInputOrder = false
-): SystemTypefaceFile =
+): Option[SystemTypefaceFile] =
   ## Finds an installed face by OpenType family/style metadata.
   ##
   ## Directories are ranked by their first appearance in `fontFiles`, with
   ## paths sorted within each directory for deterministic ties. Set
   ## `preserveInputOrder` to use the supplied path order without sorting.
   ## Platform discovery supplies user directories before system directories.
+  ## Returns `none` when no requested name matches.
   var paths: seq[string]
   if preserveInputOrder:
     paths = @fontFiles
@@ -178,7 +187,7 @@ proc findSystemTypefaceFile*(
         if metadata.valid:
           for info in metadata.faces:
             if metadataMatchScore(name, info) == score:
-              return SystemTypefaceFile(path: path, faceIndex: info.faceIndex)
+              return some(SystemTypefaceFile(path: path, faceIndex: info.faceIndex))
 
 proc detectDisplayServer*(): DisplayServer =
   ## Detects the display server on non-macOS POSIX platforms.
@@ -284,7 +293,7 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
 
 proc findSystemTypefaceFile*(
     names: openArray[string], displayServer = detectDisplayServer()
-): SystemTypefaceFile =
+): Option[SystemTypefaceFile] =
   ## Finds an installed face by OpenType metadata using platform font folders.
   findSystemTypefaceFile(
     names, systemFontFiles(displayServer), preserveInputOrder = true
@@ -321,8 +330,8 @@ proc findSystemFontFile*(
       if path.len > 0:
         return path
     let typeface = findSystemTypefaceFile([name], fontFiles, preserveInputOrder = true)
-    if typeface.path.len > 0:
-      return typeface.path
+    if typeface.isSome:
+      return typeface.get().path
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
       let path = findSystemFontFile([name], fontFiles)

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -5,7 +5,9 @@ import ../common/typefaceinfos
 import ./systemfonts_native
 import ./systemfonttypes
 
-export SystemTypefaceFile, SystemTypefaceInfo, SystemTypefaceQuery
+export
+  SystemTypefaceFile, SystemTypeface, SystemTypefaceInfo, SystemTypefaceQuery,
+  initSystemTypefaceFile, initSystemTypeface
 
 type
   DisplayServer* = enum
@@ -157,9 +159,9 @@ proc metadataMatchScore(requestedName: string, info: TypefaceNameInfo): int =
     return 0
   -1
 
-proc findSystemTypefaceFile*(
+proc findSystemTypeface*(
     names, fontFiles: openArray[string], preserveInputOrder = false
-): Option[SystemTypefaceFile] =
+): Option[SystemTypeface] =
   ## Finds a face in caller-supplied files by OpenType family/style metadata.
   ##
   ## Directories are ranked by their first appearance in `fontFiles`, with
@@ -193,7 +195,7 @@ proc findSystemTypefaceFile*(
         if metadata.valid:
           for info in metadata.faces:
             if metadataMatchScore(name, info) == score:
-              return some(SystemTypefaceFile(path: path, faceIndex: info.faceIndex))
+              return some(initSystemTypeface(path, info.faceIndex))
 
 proc detectDisplayServer*(): DisplayServer =
   ## Detects the display server on non-macOS POSIX platforms.
@@ -303,14 +305,18 @@ iterator systemTypefaces*(query = SystemTypefaceQuery()): SystemTypefaceInfo =
   ## `family` and `subfamily` are exact, separator-insensitive filters. Empty
   ## fields are wildcards and populated fields are combined with AND. A family
   ## query returns every matching style; it does not perform font substitution.
-  ## Each `(path, faceIndex)` identity is yielded at most once. Order is native
-  ## and unspecified. Simulated, remote, multi-file, and variable named-instance
-  ## faces that cannot be represented by `SystemTypefaceFile` are omitted.
+  ## Each `(path, faceIndex, variations)` identity is yielded at most once.
+  ## Order is native and unspecified. Simulated, remote, and multi-file faces
+  ## that cannot be represented by `SystemTypeface` are omitted.
   var
     nativeAvailable = false
-    seen = initHashSet[(string, int)]()
+    seen = initHashSet[(string, int, seq[FontVariation])]()
   for info in nativeSystemTypefaces(nativeAvailable):
-    let key = (info.file.path.normalizePathKey(), info.file.faceIndex)
+    let key = (
+      info.typeface.file.path.normalizePathKey(),
+      info.typeface.file.faceIndex,
+      info.typeface.variations,
+    )
     if key notin seen and query.matches(info):
       seen.incl(key)
       yield info
@@ -322,30 +328,28 @@ iterator systemTypefaces*(query = SystemTypefaceQuery()): SystemTypefaceInfo =
       for face in metadata.faces:
         let
           info = SystemTypefaceInfo(
-            file: SystemTypefaceFile(path: path, faceIndex: face.faceIndex),
+            typeface: initSystemTypeface(path, face.faceIndex),
             family: face.family,
             subfamily: face.subfamily,
             fullName: face.fullName,
             postScriptName: face.postScriptName,
           )
-          key = (path.normalizePathKey(), face.faceIndex)
+          key = (path.normalizePathKey(), face.faceIndex, newSeq[FontVariation]())
         if key notin seen and query.matches(info):
           seen.incl(key)
           yield info
 
-proc findSystemTypefaceFile*(
+proc findSystemTypeface*(
     names: openArray[string], displayServer = detectDisplayServer()
-): Option[SystemTypefaceFile] =
+): Option[SystemTypeface] =
   ## Finds an installed face with the host platform's font service.
   ##
   ## The metadata scanner is retained for hosts where the native provider is
   ## unavailable at runtime.
-  let nativeResult = findNativeSystemTypefaceFile(names)
+  let nativeResult = findNativeSystemTypeface(names)
   if nativeResult.available:
     return nativeResult.match
-  findSystemTypefaceFile(
-    names, systemFontFiles(displayServer), preserveInputOrder = true
-  )
+  findSystemTypeface(names, systemFontFiles(displayServer), preserveInputOrder = true)
 
 proc findSystemFontFile*(names, fontFiles: openArray[string]): string =
   ## Finds a preferred font from `fontFiles` matching one of `names`.
@@ -376,9 +380,9 @@ proc findSystemFontFile*(
       let path = findSystemFontFile([name], systemFontFiles(displayServer))
       if path.len > 0:
         return path
-    let typeface = findSystemTypefaceFile([name], displayServer)
+    let typeface = findSystemTypeface([name], displayServer)
     if typeface.isSome:
-      return typeface.get().path
+      return typeface.get().file.path
     let alias = splitFile(name).name.toLowerAscii().replace("-", "")
     if alias in ["sfns", "ubuntur"]:
       let path = findSystemFontFile([name], systemFontFiles(displayServer))

--- a/src/figdraw/extras/systemfonts.nim
+++ b/src/figdraw/extras/systemfonts.nim
@@ -1,6 +1,7 @@
-import std/[os, strutils, sets]
+import std/[algorithm, locks, os, sets, strutils, tables, unicode]
 
 import ../common/fonttypes
+import ../common/typefaceinfos
 
 type
   DisplayServer* = enum
@@ -12,12 +13,34 @@ type
     sfrSans
     sfrMono
 
+  SystemTypefaceFile* = object
+    ## An installed font file and the selected face within it.
+    path*: string
+    faceIndex*: int
+
+  CachedFontMetadata = object
+    valid: bool
+    faces: seq[TypefaceInfo]
+
+var
+  fontMetadataCache: Table[string, CachedFontMetadata]
+  fontMetadataLock: Lock
+
+fontMetadataLock.initLock()
+
 proc normalizeName(name: string): string =
-  ## Normalizes a font/file name for loose matching.
+  ## Normalizes a filename for legacy loose matching.
   result = newStringOfCap(name.len)
   for ch in name.toLowerAscii():
     if ch in {'a' .. 'z', '0' .. '9'}:
       result.add(ch)
+
+proc normalizeMetadataName(name: string): string =
+  ## Normalizes OpenType names while retaining non-ASCII letters.
+  result = newStringOfCap(name.len)
+  for rune in name.runes:
+    if $rune notin [" ", "-", "_", "."]:
+      result.add($rune.toLower)
 
 proc fontNameMatchScore*(requestedName, fontName: string): int =
   ## Ranks a filename or face name for a family request.
@@ -55,7 +78,107 @@ proc systemFontFileMatchScore(requestedName, path: string): int =
   -1
 
 proc normalizePathKey(path: string): string =
-  path.toLowerAscii().replace('\\', '/')
+  when defined(windows) or defined(macosx):
+    path.toLowerAscii().replace('\\', '/')
+  else:
+    path.replace('\\', '/')
+
+proc fontMetadataKey(path: string): string =
+  path.replace('\\', '/')
+
+proc fontFaceCount(data: string): int =
+  if data.len < 12 or data[0 ..< 4] != "ttcf":
+    return 1
+  result =
+    data[8].ord shl 24 or data[9].ord shl 16 or data[10].ord shl 8 or data[11].ord
+  if result < 0 or result > (data.len - 12) div 4:
+    result = 0
+
+proc readFontMetadata(path: string): CachedFontMetadata =
+  try:
+    let data = readFile(path)
+    let count = data.fontFaceCount()
+    if count == 0:
+      return
+    for faceIndex in 0 ..< count:
+      result.faces.add readTypefaceNameInfo(path, data, faceIndex)
+    result.valid = result.faces.len > 0
+  except CatchableError:
+    discard
+
+proc fontMetadata(path: string): CachedFontMetadata =
+  let key = fontMetadataKey(path)
+  withLock(fontMetadataLock):
+    if key in fontMetadataCache:
+      return fontMetadataCache[key]
+  result = readFontMetadata(path)
+  withLock(fontMetadataLock):
+    fontMetadataCache[key] = result
+
+proc refreshSystemFontMetadata*() =
+  ## Clears cached installed-font metadata after font directories change.
+  withLock(fontMetadataLock):
+    fontMetadataCache.clear()
+
+proc metadataMatchScore(requestedName: string, info: TypefaceInfo): int =
+  let
+    requested = requestedName.normalizeMetadataName()
+    family = info.family.normalizeMetadataName()
+    subfamily = info.subfamily.normalizeMetadataName()
+    fullName = info.fullName.normalizeMetadataName()
+    postScriptName = info.postScriptName.normalizeMetadataName()
+    familyStyle = family & subfamily
+  if requested.len == 0 or family.len == 0:
+    return -1
+  if requested == family:
+    let regular =
+      if subfamily.len > 0:
+        subfamily in ["regular", "normal", "book", "roman"]
+      else:
+        info.regular
+    if regular and not (info.bold or info.italic or info.oblique):
+      return 1
+    return -1
+  if requested == fullName or requested == postScriptName or requested == familyStyle:
+    return 0
+  -1
+
+proc findSystemTypefaceFile*(
+    names, fontFiles: openArray[string], preserveInputOrder = false
+): SystemTypefaceFile =
+  ## Finds an installed face by OpenType family/style metadata.
+  ##
+  ## Directories are ranked by their first appearance in `fontFiles`, with
+  ## paths sorted within each directory for deterministic ties. Set
+  ## `preserveInputOrder` to use the supplied path order without sorting.
+  ## Platform discovery supplies user directories before system directories.
+  var paths: seq[string]
+  if preserveInputOrder:
+    paths = @fontFiles
+  else:
+    var directories: seq[string]
+    for path in fontFiles:
+      let directory = normalizePathKey(path.parentDir)
+      if directory notin directories:
+        directories.add(directory)
+    for directory in directories:
+      var directoryPaths: seq[string]
+      for path in fontFiles:
+        if normalizePathKey(path.parentDir) == directory:
+          directoryPaths.add(path)
+      directoryPaths.sort(
+        proc(a, b: string): int =
+          cmp(normalizePathKey(a), normalizePathKey(b))
+      )
+      paths.add(directoryPaths)
+  for name in names:
+    for score in 0 .. 1:
+      for path in paths:
+        let metadata = path.fontMetadata()
+        if metadata.valid:
+          for info in metadata.faces:
+            if metadataMatchScore(name, info) == score:
+              return SystemTypefaceFile(path: path, faceIndex: info.faceIndex)
 
 proc detectDisplayServer*(): DisplayServer =
   ## Detects the display server on non-macOS POSIX platforms.
@@ -115,31 +238,26 @@ proc systemFontDirs*(displayServer = detectDisplayServer()): seq[string] =
   var dirs: seq[string]
 
   when defined(windows):
-    dirs.addIfDir(getEnv("WINDIR", r"C:\Windows") / "Fonts")
     dirs.addIfDir(getEnv("LOCALAPPDATA", "") / "Microsoft" / "Windows" / "Fonts")
     dirs.addIfDir(getEnv("APPDATA", "") / "Microsoft" / "Windows" / "Fonts")
+    dirs.addIfDir(getEnv("WINDIR", r"C:\Windows") / "Fonts")
   elif defined(macosx):
-    dirs.addIfDir("/System/Library/Fonts")
-    dirs.addIfDir("/Library/Fonts")
     dirs.addIfDir("~/Library/Fonts")
+    dirs.addIfDir("/Library/Fonts")
+    dirs.addIfDir("/System/Library/Fonts")
   elif defined(posix) and not defined(macosx):
     let home = getHomeDir()
     let xdgDataHome = getEnv("XDG_DATA_HOME", home / ".local" / "share")
     dirs.addIfDir(xdgDataHome / "fonts")
+
+    if displayServer != dsWayland:
+      dirs.addIfDir(home / ".fonts")
 
     for base in splitPathList(getEnv("XDG_DATA_DIRS", "/usr/local/share:/usr/share")):
       dirs.addIfDir(base / "fonts")
 
     dirs.addIfDir("/usr/share/fonts")
     dirs.addIfDir("/usr/local/share/fonts")
-
-    if displayServer == dsX11:
-      dirs.addIfDir(home / ".fonts")
-    elif displayServer == dsWayland:
-      # Wayland desktops typically use XDG font directories.
-      discard
-    else:
-      dirs.addIfDir(home / ".fonts")
 
   result = dedupePaths(dirs)
 
@@ -150,15 +268,27 @@ proc systemFontFiles*(displayServer = detectDisplayServer()): seq[string] =
 
   for dir in dirs:
     try:
+      var files: seq[string]
       for file in walkDirRec(dir):
         let ext = file.splitFile.ext.toLowerAscii()
         if ext in supportedFontFileExtensions():
-          let key = normalizePathKey(file)
-          if key notin seen:
-            seen.incl(key)
-            result.add(file)
+          files.add(file)
+      files.sort()
+      for file in files:
+        let key = normalizePathKey(file)
+        if key notin seen:
+          seen.incl(key)
+          result.add(file)
     except OSError:
       discard
+
+proc findSystemTypefaceFile*(
+    names: openArray[string], displayServer = detectDisplayServer()
+): SystemTypefaceFile =
+  ## Finds an installed face by OpenType metadata using platform font folders.
+  findSystemTypefaceFile(
+    names, systemFontFiles(displayServer), preserveInputOrder = true
+  )
 
 proc findSystemFontFile*(names, fontFiles: openArray[string]): string =
   ## Finds a preferred font from `fontFiles` matching one of `names`.
@@ -181,4 +311,20 @@ proc findSystemFontFile*(
     names: openArray[string], displayServer = detectDisplayServer()
 ): string =
   ## Finds the preferred installed system font path matching one of `names`.
-  findSystemFontFile(names, systemFontFiles(displayServer))
+  ##
+  ## Named requests use OpenType metadata. The two-array overload remains a
+  ## filename-only helper for callers that supply synthetic paths.
+  let fontFiles = systemFontFiles(displayServer)
+  for name in names:
+    if splitFile(name).ext.len > 0:
+      let path = findSystemFontFile([name], fontFiles)
+      if path.len > 0:
+        return path
+    let typeface = findSystemTypefaceFile([name], fontFiles, preserveInputOrder = true)
+    if typeface.path.len > 0:
+      return typeface.path
+    let alias = splitFile(name).name.toLowerAscii().replace("-", "")
+    if alias in ["sfns", "ubuntur"]:
+      let path = findSystemFontFile([name], fontFiles)
+      if path.len > 0:
+        return path

--- a/src/figdraw/extras/systemfonts_fontconfig.nim
+++ b/src/figdraw/extras/systemfonts_fontconfig.nim
@@ -1,0 +1,256 @@
+## Native installed-font matching through Fontconfig on Linux and FreeBSD.
+##
+## The ABI is loaded at runtime so systems without Fontconfig can fall back to
+## directory scanning without failing to start or link.
+
+import std/[dynlib, locks, options, os, unicode]
+
+import ./systemfonttypes
+
+type
+  FcBool = cint
+  FcChar8 = uint8
+  FcResult = cint
+  FcMatchKind = cint
+  FcPattern {.incompleteStruct.} = object
+  FcConfig {.incompleteStruct.} = object
+
+  FcInitLoadConfigAndFontsProc = proc(): ptr FcConfig {.cdecl.}
+  FcConfigDestroyProc = proc(config: ptr FcConfig) {.cdecl.}
+  FcPatternCreateProc = proc(): ptr FcPattern {.cdecl.}
+  FcPatternDestroyProc = proc(pattern: ptr FcPattern) {.cdecl.}
+  FcPatternAddStringProc = proc(
+    pattern: ptr FcPattern, objectName: cstring, value: ptr FcChar8
+  ): FcBool {.cdecl.}
+  FcPatternAddIntegerProc =
+    proc(pattern: ptr FcPattern, objectName: cstring, value: cint): FcBool {.cdecl.}
+  FcConfigSubstituteProc = proc(
+    config: ptr FcConfig, pattern: ptr FcPattern, kind: FcMatchKind
+  ): FcBool {.cdecl.}
+  FcDefaultSubstituteProc = proc(pattern: ptr FcPattern) {.cdecl.}
+  FcFontMatchProc = proc(
+    config: ptr FcConfig, pattern: ptr FcPattern, matchResult: ptr FcResult
+  ): ptr FcPattern {.cdecl.}
+  FcPatternGetStringProc = proc(
+    pattern: ptr FcPattern, objectName: cstring, index: cint, value: ptr ptr FcChar8
+  ): FcResult {.cdecl.}
+  FcPatternGetIntegerProc = proc(
+    pattern: ptr FcPattern, objectName: cstring, index: cint, value: ptr cint
+  ): FcResult {.cdecl.}
+
+  FontconfigApi = object
+    library: LibHandle
+    initLoadConfigAndFonts: FcInitLoadConfigAndFontsProc
+    configDestroy: FcConfigDestroyProc
+    patternCreate: FcPatternCreateProc
+    patternDestroy: FcPatternDestroyProc
+    patternAddString: FcPatternAddStringProc
+    patternAddInteger: FcPatternAddIntegerProc
+    configSubstitute: FcConfigSubstituteProc
+    defaultSubstitute: FcDefaultSubstituteProc
+    fontMatch: FcFontMatchProc
+    patternGetString: FcPatternGetStringProc
+    patternGetInteger: FcPatternGetIntegerProc
+
+const
+  fcResultMatch = FcResult(0)
+  fcMatchPattern = FcMatchKind(0)
+  fcWeightRegular = cint(80)
+  fcSlantRoman = cint(0)
+  fcFamily: cstring = "family"
+  fcFullName: cstring = "fullname"
+  fcPostscriptName: cstring = "postscriptname"
+  fcStyle: cstring = "style"
+  fcFile: cstring = "file"
+  fcIndex: cstring = "index"
+  fcWeight: cstring = "weight"
+  fcSlant: cstring = "slant"
+
+var
+  apiLock: Lock
+  apiLoadAttempted: bool
+  apiLoaded: bool
+  api: FontconfigApi
+
+apiLock.initLock()
+
+proc loadSymbol[T](library: LibHandle, name: cstring): T {.inline.} =
+  cast[T](library.symAddr(name))
+
+proc loadFontconfigApi(): bool =
+  withLock(apiLock):
+    if apiLoadAttempted:
+      return apiLoaded
+    apiLoadAttempted = true
+
+    const libraryNames = ["libfontconfig.so.1", "libfontconfig.so"]
+    for name in libraryNames:
+      api.library = loadLib(name)
+      if api.library != nil:
+        break
+    if api.library == nil:
+      return false
+
+    api.initLoadConfigAndFonts =
+      loadSymbol[FcInitLoadConfigAndFontsProc](api.library, "FcInitLoadConfigAndFonts")
+    api.configDestroy = loadSymbol[FcConfigDestroyProc](api.library, "FcConfigDestroy")
+    api.patternCreate = loadSymbol[FcPatternCreateProc](api.library, "FcPatternCreate")
+    api.patternDestroy =
+      loadSymbol[FcPatternDestroyProc](api.library, "FcPatternDestroy")
+    api.patternAddString =
+      loadSymbol[FcPatternAddStringProc](api.library, "FcPatternAddString")
+    api.patternAddInteger =
+      loadSymbol[FcPatternAddIntegerProc](api.library, "FcPatternAddInteger")
+    api.configSubstitute =
+      loadSymbol[FcConfigSubstituteProc](api.library, "FcConfigSubstitute")
+    api.defaultSubstitute =
+      loadSymbol[FcDefaultSubstituteProc](api.library, "FcDefaultSubstitute")
+    api.fontMatch = loadSymbol[FcFontMatchProc](api.library, "FcFontMatch")
+    api.patternGetString =
+      loadSymbol[FcPatternGetStringProc](api.library, "FcPatternGetString")
+    api.patternGetInteger =
+      loadSymbol[FcPatternGetIntegerProc](api.library, "FcPatternGetInteger")
+
+    apiLoaded =
+      api.initLoadConfigAndFonts != nil and api.configDestroy != nil and
+      api.patternCreate != nil and api.patternDestroy != nil and
+      api.patternAddString != nil and api.patternAddInteger != nil and
+      api.configSubstitute != nil and api.defaultSubstitute != nil and
+      api.fontMatch != nil and api.patternGetString != nil and
+      api.patternGetInteger != nil
+    if not apiLoaded:
+      unloadLib(api.library)
+      api.library = nil
+    result = apiLoaded
+
+proc normalizeFontName(name: string): string =
+  result = newStringOfCap(name.len)
+  for rune in name.runes:
+    if $rune notin [" ", "-", "_", "."]:
+      result.add($rune.toLower)
+
+proc patternStrings(pattern: ptr FcPattern, objectName: cstring): seq[string] =
+  var index = cint(0)
+  while true:
+    var value: ptr FcChar8
+    if api.patternGetString(pattern, objectName, index, addr value) != fcResultMatch:
+      break
+    if value != nil:
+      result.add($cast[cstring](value))
+    inc index
+
+proc patternInteger(
+    pattern: ptr FcPattern, objectName: cstring, value: var cint
+): bool =
+  api.patternGetInteger(pattern, objectName, 0, addr value) == fcResultMatch
+
+proc isRegularFace(pattern: ptr FcPattern): bool =
+  let styles = pattern.patternStrings(fcStyle)
+  for style in styles:
+    if style.normalizeFontName() in ["regular", "normal", "book", "roman", "plain"]:
+      var slant: cint
+      return not pattern.patternInteger(fcSlant, slant) or slant == fcSlantRoman
+
+  var weight, slant: cint
+  pattern.patternInteger(fcWeight, weight) and weight == fcWeightRegular and
+    (not pattern.patternInteger(fcSlant, slant) or slant == fcSlantRoman)
+
+proc matchesRequestedName(pattern: ptr FcPattern, requestedName: string): bool =
+  let
+    requested = requestedName.normalizeFontName()
+    families = pattern.patternStrings(fcFamily)
+    fullNames = pattern.patternStrings(fcFullName)
+    postscriptNames = pattern.patternStrings(fcPostscriptName)
+    styles = pattern.patternStrings(fcStyle)
+
+  if requested.len == 0:
+    return false
+  for fullName in fullNames:
+    if fullName.normalizeFontName() == requested:
+      return true
+  for postscriptName in postscriptNames:
+    if postscriptName.normalizeFontName() == requested:
+      return true
+  for family in families:
+    let normalizedFamily = family.normalizeFontName()
+    for style in styles:
+      if normalizedFamily & style.normalizeFontName() == requested:
+        return true
+    if normalizedFamily == requested and pattern.isRegularFace():
+      return true
+
+proc queryFontconfig(
+    config: ptr FcConfig,
+    requestedName: string,
+    queryObject: cstring,
+    regularFamily: bool,
+): Option[SystemTypefaceFile] =
+  let query = api.patternCreate()
+  if query == nil:
+    return
+  defer:
+    api.patternDestroy(query)
+
+  if api.patternAddString(query, queryObject, cast[ptr FcChar8](requestedName.cstring)) ==
+      0:
+    return
+  if regularFamily:
+    if api.patternAddInteger(query, fcWeight, fcWeightRegular) == 0 or
+        api.patternAddInteger(query, fcSlant, fcSlantRoman) == 0:
+      return
+  if api.configSubstitute(config, query, fcMatchPattern) == 0:
+    return
+  api.defaultSubstitute(query)
+
+  var matchResult: FcResult
+  let matched = api.fontMatch(config, query, addr matchResult)
+  if matched == nil:
+    return
+  defer:
+    api.patternDestroy(matched)
+  if matchResult != fcResultMatch or not matched.matchesRequestedName(requestedName):
+    return
+
+  var
+    fileValue: ptr FcChar8
+    faceIndex: cint
+  if api.patternGetString(matched, fcFile, 0, addr fileValue) != fcResultMatch or
+      fileValue == nil or
+      api.patternGetInteger(matched, fcIndex, 0, addr faceIndex) != fcResultMatch or
+      faceIndex < 0:
+    return
+  let
+    path = $cast[cstring](fileValue)
+    packedIndex = cast[uint32](faceIndex)
+  # Fontconfig packs a variable-font named-instance number above the low
+  # 16-bit collection index. FigDraw cannot represent those coordinates in a
+  # SystemTypefaceFile, so accepting one would load a different design.
+  if packedIndex > 0xFFFF'u32 or not path.isAbsolute() or not path.fileExists():
+    return
+  some(SystemTypefaceFile(path: path, faceIndex: int(packedIndex)))
+
+proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+  ## Finds the first exact installed face requested through Fontconfig.
+  ##
+  ## Fontconfig deliberately returns a closest match. This provider validates
+  ## that match's family, full name, or PostScript name before accepting it.
+  if not loadFontconfigApi():
+    return unavailableSystemFontProvider()
+
+  let config = api.initLoadConfigAndFonts()
+  if config == nil:
+    return unavailableSystemFontProvider()
+  defer:
+    api.configDestroy(config)
+
+  for name in names:
+    if name.len == 0:
+      continue
+    for queryObject in [fcFullName, fcPostscriptName]:
+      let matched = queryFontconfig(config, name, queryObject, false)
+      if matched.isSome:
+        return systemFontProviderMatch(matched)
+    let matched = queryFontconfig(config, name, fcFamily, true)
+    if matched.isSome:
+      return systemFontProviderMatch(matched)
+  systemFontProviderMatch(none(SystemTypefaceFile))

--- a/src/figdraw/extras/systemfonts_fontconfig.nim
+++ b/src/figdraw/extras/systemfonts_fontconfig.nim
@@ -205,7 +205,7 @@ proc patternTypefaceInfo(pattern: ptr FcPattern): Option[SystemTypefaceInfo] =
     postScriptNames = pattern.patternStrings(fcPostscriptName)
   result = some(
     SystemTypefaceInfo(
-      file: SystemTypefaceFile(path: localFile.path, faceIndex: localFile.faceIndex),
+      typeface: initSystemTypeface(localFile.path, localFile.faceIndex),
       family:
         if families.len > 0:
           families[0]
@@ -314,7 +314,7 @@ proc queryFontconfig(
     requestedName: string,
     queryObject: cstring,
     regularFamily: bool,
-): Option[SystemTypefaceFile] =
+): Option[SystemTypeface] =
   let query = api.patternCreate()
   if query == nil:
     return
@@ -354,12 +354,13 @@ proc queryFontconfig(
     packedIndex = cast[uint32](faceIndex)
   # Fontconfig packs a variable-font named-instance number above the low
   # 16-bit collection index. FigDraw cannot represent those coordinates in a
-  # SystemTypefaceFile, so accepting one would load a different design.
+  # SystemTypeface without its variation coordinates, so accepting one would
+  # load a different design.
   if packedIndex > 0xFFFF'u32 or not path.isAbsolute() or not path.fileExists():
     return
-  some(SystemTypefaceFile(path: path, faceIndex: int(packedIndex)))
+  some(initSystemTypeface(path, int(packedIndex)))
 
-proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+proc findNativeSystemTypeface*(names: openArray[string]): SystemFontProviderResult =
   ## Finds the first exact installed face requested through Fontconfig.
   ##
   ## Fontconfig deliberately returns a closest match. This provider validates
@@ -383,4 +384,4 @@ proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProvider
     let matched = queryFontconfig(config, name, fcFamily, true)
     if matched.isSome:
       return systemFontProviderMatch(matched)
-  systemFontProviderMatch(none(SystemTypefaceFile))
+  systemFontProviderMatch(none(SystemTypeface))

--- a/src/figdraw/extras/systemfonts_fontconfig.nim
+++ b/src/figdraw/extras/systemfonts_fontconfig.nim
@@ -14,6 +14,11 @@ type
   FcMatchKind = cint
   FcPattern {.incompleteStruct.} = object
   FcConfig {.incompleteStruct.} = object
+  FcObjectSet {.incompleteStruct.} = object
+  FcFontSet = object
+    nfont: cint
+    sfont: cint
+    fonts: ptr UncheckedArray[ptr FcPattern]
 
   FcInitLoadConfigAndFontsProc = proc(): ptr FcConfig {.cdecl.}
   FcConfigDestroyProc = proc(config: ptr FcConfig) {.cdecl.}
@@ -31,6 +36,14 @@ type
   FcFontMatchProc = proc(
     config: ptr FcConfig, pattern: ptr FcPattern, matchResult: ptr FcResult
   ): ptr FcPattern {.cdecl.}
+  FcObjectSetCreateProc = proc(): ptr FcObjectSet {.cdecl.}
+  FcObjectSetAddProc =
+    proc(objectSet: ptr FcObjectSet, objectName: cstring): FcBool {.cdecl.}
+  FcObjectSetDestroyProc = proc(objectSet: ptr FcObjectSet) {.cdecl.}
+  FcFontListProc = proc(
+    config: ptr FcConfig, pattern: ptr FcPattern, objectSet: ptr FcObjectSet
+  ): ptr FcFontSet {.cdecl.}
+  FcFontSetDestroyProc = proc(fontSet: ptr FcFontSet) {.cdecl.}
   FcPatternGetStringProc = proc(
     pattern: ptr FcPattern, objectName: cstring, index: cint, value: ptr ptr FcChar8
   ): FcResult {.cdecl.}
@@ -49,6 +62,11 @@ type
     configSubstitute: FcConfigSubstituteProc
     defaultSubstitute: FcDefaultSubstituteProc
     fontMatch: FcFontMatchProc
+    objectSetCreate: FcObjectSetCreateProc
+    objectSetAdd: FcObjectSetAddProc
+    objectSetDestroy: FcObjectSetDestroyProc
+    fontList: FcFontListProc
+    fontSetDestroy: FcFontSetDestroyProc
     patternGetString: FcPatternGetStringProc
     patternGetInteger: FcPatternGetIntegerProc
 
@@ -106,6 +124,14 @@ proc loadFontconfigApi(): bool =
     api.defaultSubstitute =
       loadSymbol[FcDefaultSubstituteProc](api.library, "FcDefaultSubstitute")
     api.fontMatch = loadSymbol[FcFontMatchProc](api.library, "FcFontMatch")
+    api.objectSetCreate =
+      loadSymbol[FcObjectSetCreateProc](api.library, "FcObjectSetCreate")
+    api.objectSetAdd = loadSymbol[FcObjectSetAddProc](api.library, "FcObjectSetAdd")
+    api.objectSetDestroy =
+      loadSymbol[FcObjectSetDestroyProc](api.library, "FcObjectSetDestroy")
+    api.fontList = loadSymbol[FcFontListProc](api.library, "FcFontList")
+    api.fontSetDestroy =
+      loadSymbol[FcFontSetDestroyProc](api.library, "FcFontSetDestroy")
     api.patternGetString =
       loadSymbol[FcPatternGetStringProc](api.library, "FcPatternGetString")
     api.patternGetInteger =
@@ -116,8 +142,9 @@ proc loadFontconfigApi(): bool =
       api.patternCreate != nil and api.patternDestroy != nil and
       api.patternAddString != nil and api.patternAddInteger != nil and
       api.configSubstitute != nil and api.defaultSubstitute != nil and
-      api.fontMatch != nil and api.patternGetString != nil and
-      api.patternGetInteger != nil
+      api.fontMatch != nil and api.objectSetCreate != nil and api.objectSetAdd != nil and
+      api.objectSetDestroy != nil and api.fontList != nil and api.fontSetDestroy != nil and
+      api.patternGetString != nil and api.patternGetInteger != nil
     if not apiLoaded:
       unloadLib(api.library)
       api.library = nil
@@ -143,6 +170,109 @@ proc patternInteger(
     pattern: ptr FcPattern, objectName: cstring, value: var cint
 ): bool =
   api.patternGetInteger(pattern, objectName, 0, addr value) == fcResultMatch
+
+proc readableFontPath(pattern: ptr FcPattern): tuple[path: string, faceIndex: int] =
+  var
+    fileValue: ptr FcChar8
+    faceIndex: cint
+  if api.patternGetString(pattern, fcFile, 0, addr fileValue) != fcResultMatch or
+      fileValue == nil or
+      api.patternGetInteger(pattern, fcIndex, 0, addr faceIndex) != fcResultMatch or
+      faceIndex < 0:
+    return
+  let
+    path = $cast[cstring](fileValue)
+    packedIndex = cast[uint32](faceIndex)
+  if packedIndex > 0xFFFF'u32 or not path.isAbsolute() or not path.fileExists():
+    return
+  try:
+    var file: File
+    if not open(file, path, fmRead):
+      return
+    close(file)
+  except IOError, OSError:
+    return
+  result = (path, int(packedIndex))
+
+proc patternTypefaceInfo(pattern: ptr FcPattern): Option[SystemTypefaceInfo] =
+  let localFile = pattern.readableFontPath()
+  if localFile.path.len == 0:
+    return
+  let
+    families = pattern.patternStrings(fcFamily)
+    subfamilies = pattern.patternStrings(fcStyle)
+    fullNames = pattern.patternStrings(fcFullName)
+    postScriptNames = pattern.patternStrings(fcPostscriptName)
+  result = some(
+    SystemTypefaceInfo(
+      file: SystemTypefaceFile(path: localFile.path, faceIndex: localFile.faceIndex),
+      family:
+        if families.len > 0:
+          families[0]
+        else:
+          "",
+      subfamily:
+        if subfamilies.len > 0:
+          subfamilies[0]
+        else:
+          "",
+      fullName:
+        if fullNames.len > 0:
+          fullNames[0]
+        else:
+          "",
+      postScriptName:
+        if postScriptNames.len > 0:
+          postScriptNames[0]
+        else:
+          "",
+    )
+  )
+
+iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
+  ## Enumerates locally readable Fontconfig faces in native order.
+  block provider:
+    if not loadFontconfigApi():
+      available = false
+      break provider
+
+    let config = api.initLoadConfigAndFonts()
+    if config == nil:
+      available = false
+      break provider
+    defer:
+      api.configDestroy(config)
+
+    let pattern = api.patternCreate()
+    if pattern == nil:
+      available = false
+      break provider
+    defer:
+      api.patternDestroy(pattern)
+
+    let objectSet = api.objectSetCreate()
+    if objectSet == nil:
+      available = false
+      break provider
+    defer:
+      api.objectSetDestroy(objectSet)
+    for objectName in [fcFamily, fcStyle, fcFullName, fcPostscriptName, fcFile, fcIndex]:
+      if api.objectSetAdd(objectSet, objectName) == 0:
+        available = false
+        break provider
+
+    let fontSet = api.fontList(config, pattern, objectSet)
+    if fontSet == nil:
+      available = false
+      break provider
+    defer:
+      api.fontSetDestroy(fontSet)
+    available = true
+
+    for index in 0 ..< fontSet.nfont.int:
+      let info = fontSet.fonts[index].patternTypefaceInfo()
+      if info.isSome:
+        yield info.get()
 
 proc isRegularFace(pattern: ptr FcPattern): bool =
   let styles = pattern.patternStrings(fcStyle)

--- a/src/figdraw/extras/systemfonts_macos.nim
+++ b/src/figdraw/extras/systemfonts_macos.nim
@@ -197,6 +197,64 @@ proc resolvedTypeface(font: CTFontRef): Option[SystemTypefaceFile] =
   if path.len > 0 and index >= 0:
     result = some(SystemTypefaceFile(path: path, faceIndex: index))
 
+proc typefaceInfo(font: CTFontRef): Option[SystemTypefaceInfo] =
+  let file = font.resolvedTypeface()
+  if file.isNone:
+    return
+
+  let
+    family = CTFontCopyFamilyName(font)
+    subfamily = CTFontCopyName(font, kCTFontStyleNameKey)
+    fullName = CTFontCopyFullName(font)
+    postScriptName = CTFontCopyPostScriptName(font)
+  defer:
+    if family != nil:
+      CFRelease(family)
+    if subfamily != nil:
+      CFRelease(subfamily)
+    if fullName != nil:
+      CFRelease(fullName)
+    if postScriptName != nil:
+      CFRelease(postScriptName)
+  result = some(
+    SystemTypefaceInfo(
+      file: file.get(),
+      family: family.nimString(),
+      subfamily: subfamily.nimString(),
+      fullName: fullName.nimString(),
+      postScriptName: postScriptName.nimString(),
+    )
+  )
+
+iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
+  ## Enumerates locally readable Core Text faces in native order.
+  block provider:
+    let names = CTFontManagerCopyAvailablePostScriptNames()
+    if names == nil:
+      available = false
+      break provider
+    available = true
+    defer:
+      CFRelease(names)
+
+    for index in 0 ..< CFArrayGetCount(names).int:
+      let postScriptName =
+        cast[CFStringRef](CFArrayGetValueAtIndex(names, index.CFIndex))
+      if postScriptName == nil:
+        continue
+      let font = CTFontCreateWithNameAndOptions(
+        postScriptName,
+        0.0,
+        nil,
+        kCTFontOptionsPreventAutoActivation or kCTFontOptionsPreventAutoDownload,
+      )
+      if font == nil:
+        continue
+      let info = font.typefaceInfo()
+      CFRelease(font)
+      if info.isSome:
+        yield info.get()
+
 proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
   ## Finds the first exact installed face requested in `names` using Core Text.
   ## A bare family name resolves only to its regular face.

--- a/src/figdraw/extras/systemfonts_macos.nim
+++ b/src/figdraw/extras/systemfonts_macos.nim
@@ -1,0 +1,229 @@
+## Native installed-font lookup for macOS.
+##
+## Core Text may substitute a fallback when asked to create an unknown font.
+## Every result is therefore checked against the requested family, full, or
+## PostScript name before its file URL is accepted.
+
+import std/[options, os, unicode]
+
+import ./systemfonttypes
+
+{.passL: "-framework CoreFoundation".}
+{.passL: "-framework CoreText".}
+
+type
+  CFIndex = clong
+  CFStringEncoding = uint32
+  CFStringRef = pointer
+  CFURLRef = pointer
+  CFArrayRef = pointer
+  CTFontRef = pointer
+  CTFontDescriptorRef = pointer
+  CTFontOptions = uint32
+
+const
+  kCFStringEncodingUTF8 = 0x08000100'u32
+  kCTFontOptionsPreventAutoActivation = 1'u32
+  kCTFontOptionsPreventAutoDownload = 2'u32
+  kCTFontTraitItalic = 1'u32
+  kCTFontTraitBold = 2'u32
+  maxFileSystemPath = 32 * 1024
+
+var
+  kCTFontURLAttribute {.importc, header: "<CoreText/CoreText.h>".}: CFStringRef
+  kCTFontNameAttribute {.importc, header: "<CoreText/CoreText.h>".}: CFStringRef
+  kCTFontStyleNameKey {.importc, header: "<CoreText/CoreText.h>".}: CFStringRef
+
+{.push cdecl, importc, header: "<CoreFoundation/CoreFoundation.h>".}
+proc CFRelease(value: pointer)
+proc CFStringCreateWithBytes(
+  allocator, bytes: pointer,
+  byteCount: CFIndex,
+  encoding: CFStringEncoding,
+  isExternalRepresentation: uint8,
+): CFStringRef
+
+proc CFStringGetLength(value: CFStringRef): CFIndex
+proc CFStringGetMaximumSizeForEncoding(
+  length: CFIndex, encoding: CFStringEncoding
+): CFIndex
+
+proc CFStringGetCString(
+  value: CFStringRef, buffer: cstring, bufferSize: CFIndex, encoding: CFStringEncoding
+): uint8
+
+proc CFArrayGetCount(value: CFArrayRef): CFIndex
+proc CFArrayGetValueAtIndex(value: CFArrayRef, index: CFIndex): pointer
+proc CFURLGetFileSystemRepresentation(
+  url: CFURLRef, resolveAgainstBase: uint8, buffer: ptr uint8, maxBufferLength: CFIndex
+): uint8
+
+{.pop.}
+
+{.push cdecl, importc, header: "<CoreText/CoreText.h>".}
+proc CTFontCreateWithNameAndOptions(
+  name: CFStringRef, size: cdouble, matrix: pointer, options: CTFontOptions
+): CTFontRef
+
+proc CTFontCopyPostScriptName(font: CTFontRef): CFStringRef
+proc CTFontCopyFamilyName(font: CTFontRef): CFStringRef
+proc CTFontCopyFullName(font: CTFontRef): CFStringRef
+proc CTFontCopyName(font: CTFontRef, nameKey: CFStringRef): CFStringRef
+proc CTFontGetSymbolicTraits(font: CTFontRef): uint32
+proc CTFontCopyAttribute(font: CTFontRef, attribute: CFStringRef): pointer
+proc CTFontDescriptorCopyAttribute(
+  descriptor: CTFontDescriptorRef, attribute: CFStringRef
+): pointer
+
+proc CTFontManagerCopyAvailablePostScriptNames(): CFArrayRef
+proc CTFontManagerCreateFontDescriptorsFromURL(url: CFURLRef): CFArrayRef
+{.pop.}
+
+proc cfString(value: string): CFStringRef =
+  if value.len == 0:
+    return CFStringCreateWithBytes(nil, nil, 0, kCFStringEncodingUTF8, 0'u8)
+  CFStringCreateWithBytes(
+    nil, unsafeAddr value[0], value.len.CFIndex, kCFStringEncodingUTF8, 0'u8
+  )
+
+proc nimString(value: CFStringRef): string =
+  if value == nil:
+    return
+  let capacity =
+    CFStringGetMaximumSizeForEncoding(CFStringGetLength(value), kCFStringEncodingUTF8) +
+    1
+  if capacity <= 1:
+    return
+  var buffer = newString(capacity.int)
+  if CFStringGetCString(
+    value, cast[cstring](addr buffer[0]), capacity, kCFStringEncodingUTF8
+  ) != 0'u8:
+    buffer.setLen(len(cast[cstring](addr buffer[0])))
+    result = move(buffer)
+
+proc normalizedName(value: string): string =
+  ## Ignore separators commonly interchanged between full and PostScript names.
+  result = newStringOfCap(value.len)
+  for rune in value.runes:
+    if rune notin [Rune(' '), Rune('-'), Rune('_'), Rune('.')]:
+      result.add($rune.toLower)
+
+proc isRegularFace(styleName: string, traits: uint32): bool =
+  if (traits and (kCTFontTraitBold or kCTFontTraitItalic)) != 0:
+    return false
+  styleName.normalizedName() in ["regular", "normal", "book", "roman", "plain"]
+
+proc fontMatchesRequest(font: CTFontRef, requested: string): bool =
+  let
+    requestedName = requested.normalizedName()
+    postScript = CTFontCopyPostScriptName(font)
+    family = CTFontCopyFamilyName(font)
+    full = CTFontCopyFullName(font)
+    style = CTFontCopyName(font, kCTFontStyleNameKey)
+  defer:
+    if postScript != nil:
+      CFRelease(postScript)
+    if family != nil:
+      CFRelease(family)
+    if full != nil:
+      CFRelease(full)
+    if style != nil:
+      CFRelease(style)
+
+  if requestedName.len == 0:
+    return false
+  if requestedName in
+      [postScript.nimString().normalizedName(), full.nimString().normalizedName()]:
+    return true
+  requestedName == family.nimString().normalizedName() and
+    isRegularFace(style.nimString(), CTFontGetSymbolicTraits(font))
+
+proc readableFilePath(url: CFURLRef): string =
+  var buffer = newSeq[uint8](maxFileSystemPath)
+  if CFURLGetFileSystemRepresentation(url, 1'u8, addr buffer[0], buffer.len.CFIndex) ==
+      0'u8:
+    return
+  result = $cast[cstring](addr buffer[0])
+  if not result.fileExists:
+    result.setLen(0)
+    return
+  try:
+    var file: File
+    if not open(file, result, fmRead):
+      result.setLen(0)
+    else:
+      close(file)
+  except IOError, OSError:
+    result.setLen(0)
+
+proc descriptorPostScriptName(descriptor: CTFontDescriptorRef): string =
+  let value =
+    cast[CFStringRef](CTFontDescriptorCopyAttribute(descriptor, kCTFontNameAttribute))
+  if value != nil:
+    result = value.nimString()
+    CFRelease(value)
+
+proc faceIndex(url: CFURLRef, postScriptName: string): int =
+  result = -1
+  let descriptors = CTFontManagerCreateFontDescriptorsFromURL(url)
+  if descriptors == nil:
+    return
+  defer:
+    CFRelease(descriptors)
+
+  let selectedName = postScriptName.normalizedName()
+  for index in 0 ..< CFArrayGetCount(descriptors).int:
+    let descriptor =
+      cast[CTFontDescriptorRef](CFArrayGetValueAtIndex(descriptors, index.CFIndex))
+    if descriptor != nil and
+        descriptor.descriptorPostScriptName().normalizedName() == selectedName:
+      return index
+
+proc resolvedTypeface(font: CTFontRef): Option[SystemTypefaceFile] =
+  let
+    postScript = CTFontCopyPostScriptName(font)
+    url = cast[CFURLRef](CTFontCopyAttribute(font, kCTFontURLAttribute))
+  defer:
+    if postScript != nil:
+      CFRelease(postScript)
+    if url != nil:
+      CFRelease(url)
+  if postScript == nil or url == nil:
+    return
+
+  let
+    path = url.readableFilePath()
+    index = url.faceIndex(postScript.nimString())
+  if path.len > 0 and index >= 0:
+    result = some(SystemTypefaceFile(path: path, faceIndex: index))
+
+proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+  ## Finds the first exact installed face requested in `names` using Core Text.
+  ## A bare family name resolves only to its regular face.
+  let availableNames = CTFontManagerCopyAvailablePostScriptNames()
+  if availableNames == nil:
+    return unavailableSystemFontProvider()
+  CFRelease(availableNames)
+
+  result = systemFontProviderMatch(none(SystemTypefaceFile))
+  for name in names:
+    if name.normalizedName().len == 0:
+      continue
+    let requestedName = name.cfString()
+    if requestedName == nil:
+      return unavailableSystemFontProvider()
+    let font = CTFontCreateWithNameAndOptions(
+      requestedName,
+      0.0,
+      nil,
+      kCTFontOptionsPreventAutoActivation or kCTFontOptionsPreventAutoDownload,
+    )
+    CFRelease(requestedName)
+    if font == nil:
+      continue
+    if font.fontMatchesRequest(name):
+      let match = font.resolvedTypeface()
+      if match.isSome:
+        CFRelease(font)
+        return systemFontProviderMatch(match)
+    CFRelease(font)

--- a/src/figdraw/extras/systemfonts_macos.nim
+++ b/src/figdraw/extras/systemfonts_macos.nim
@@ -6,6 +6,8 @@
 
 import std/[options, os, unicode]
 
+from ../common/fonttypes import FontVariation, fontVariation
+
 import ./systemfonttypes
 
 {.passL: "-framework CoreFoundation".}
@@ -17,12 +19,17 @@ type
   CFStringRef = pointer
   CFURLRef = pointer
   CFArrayRef = pointer
+  CFDictionaryRef = pointer
+  CFNumberRef = pointer
+  CFNumberType = CFIndex
   CTFontRef = pointer
   CTFontDescriptorRef = pointer
   CTFontOptions = uint32
 
 const
   kCFStringEncodingUTF8 = 0x08000100'u32
+  kCFNumberSInt64Type = CFNumberType(4)
+  kCFNumberFloat64Type = CFNumberType(6)
   kCTFontOptionsPreventAutoActivation = 1'u32
   kCTFontOptionsPreventAutoDownload = 2'u32
   kCTFontTraitItalic = 1'u32
@@ -54,6 +61,15 @@ proc CFStringGetCString(
 
 proc CFArrayGetCount(value: CFArrayRef): CFIndex
 proc CFArrayGetValueAtIndex(value: CFArrayRef, index: CFIndex): pointer
+proc CFDictionaryGetCount(value: CFDictionaryRef): CFIndex
+proc CFDictionaryGetKeysAndValues(
+  value: CFDictionaryRef, keys, values: ptr UncheckedArray[pointer]
+)
+
+proc CFNumberGetValue(
+  number: CFNumberRef, numberType: CFNumberType, value: pointer
+): uint8
+
 proc CFURLGetFileSystemRepresentation(
   url: CFURLRef, resolveAgainstBase: uint8, buffer: ptr uint8, maxBufferLength: CFIndex
 ): uint8
@@ -70,6 +86,7 @@ proc CTFontCopyFamilyName(font: CTFontRef): CFStringRef
 proc CTFontCopyFullName(font: CTFontRef): CFStringRef
 proc CTFontCopyName(font: CTFontRef, nameKey: CFStringRef): CFStringRef
 proc CTFontGetSymbolicTraits(font: CTFontRef): uint32
+proc CTFontCopyVariation(font: CTFontRef): CFDictionaryRef
 proc CTFontCopyAttribute(font: CTFontRef, attribute: CFStringRef): pointer
 proc CTFontDescriptorCopyAttribute(
   descriptor: CTFontDescriptorRef, attribute: CFStringRef
@@ -163,7 +180,31 @@ proc descriptorPostScriptName(descriptor: CTFontDescriptorRef): string =
     result = value.nimString()
     CFRelease(value)
 
-proc faceIndex(url: CFURLRef, postScriptName: string): int =
+proc collectionFaceCount(path: string): int =
+  var file: File
+  try:
+    if not open(file, path, fmRead):
+      return
+    defer:
+      close(file)
+    var header: array[12, uint8]
+    if file.readBuffer(addr header[0], header.len) != header.len:
+      return
+    if header[0] != uint8(ord('t')) or header[1] != uint8(ord('t')) or
+        header[2] != uint8(ord('c')) or header[3] != uint8(ord('f')):
+      return 1
+    result =
+      header[8].int shl 24 or header[9].int shl 16 or header[10].int shl 8 or
+      header[11].int
+  except IOError, OSError:
+    discard
+
+proc faceIndex(url: CFURLRef, path, postScriptName: string): int =
+  let physicalFaceCount = path.collectionFaceCount()
+  if physicalFaceCount == 1:
+    return 0
+  if physicalFaceCount <= 0:
+    return -1
   result = -1
   let descriptors = CTFontManagerCreateFontDescriptorsFromURL(url)
   if descriptors == nil:
@@ -171,15 +212,54 @@ proc faceIndex(url: CFURLRef, postScriptName: string): int =
   defer:
     CFRelease(descriptors)
 
+  if CFArrayGetCount(descriptors).int != physicalFaceCount:
+    return
   let selectedName = postScriptName.normalizedName()
-  for index in 0 ..< CFArrayGetCount(descriptors).int:
+  for index in 0 ..< physicalFaceCount:
     let descriptor =
       cast[CTFontDescriptorRef](CFArrayGetValueAtIndex(descriptors, index.CFIndex))
     if descriptor != nil and
         descriptor.descriptorPostScriptName().normalizedName() == selectedName:
       return index
 
-proc resolvedTypeface(font: CTFontRef): Option[SystemTypefaceFile] =
+func variationTag(identifier: uint32): string =
+  result = newString(4)
+  for index in 0 ..< result.len:
+    result[index] = char((identifier shr ((result.high - index) * 8)) and 0xff'u32)
+
+proc variations(font: CTFontRef): Option[seq[FontVariation]] =
+  let values = CTFontCopyVariation(font)
+  if values == nil:
+    return some(newSeq[FontVariation]())
+  defer:
+    CFRelease(values)
+  let count = CFDictionaryGetCount(values).int
+  if count <= 0:
+    return some(newSeq[FontVariation]())
+  var
+    keys = newSeq[pointer](count)
+    coordinates = newSeq[pointer](count)
+    parsed: seq[FontVariation]
+  CFDictionaryGetKeysAndValues(
+    values,
+    cast[ptr UncheckedArray[pointer]](addr keys[0]),
+    cast[ptr UncheckedArray[pointer]](addr coordinates[0]),
+  )
+  for index in 0 ..< count:
+    var
+      identifier: int64
+      coordinate: cdouble
+    if CFNumberGetValue(
+      cast[CFNumberRef](keys[index]), kCFNumberSInt64Type, addr identifier
+    ) == 0'u8 or
+        CFNumberGetValue(
+          cast[CFNumberRef](coordinates[index]), kCFNumberFloat64Type, addr coordinate
+        ) == 0'u8:
+      return none(seq[FontVariation])
+    parsed.add fontVariation(variationTag(cast[uint32](identifier)), coordinate.float32)
+  result = some(move parsed)
+
+proc resolvedTypeface(font: CTFontRef): Option[SystemTypeface] =
   let
     postScript = CTFontCopyPostScriptName(font)
     url = cast[CFURLRef](CTFontCopyAttribute(font, kCTFontURLAttribute))
@@ -193,9 +273,13 @@ proc resolvedTypeface(font: CTFontRef): Option[SystemTypefaceFile] =
 
   let
     path = url.readableFilePath()
-    index = url.faceIndex(postScript.nimString())
-  if path.len > 0 and index >= 0:
-    result = some(SystemTypefaceFile(path: path, faceIndex: index))
+    index = url.faceIndex(path, postScript.nimString())
+    variationCoordinates = font.variations()
+  if path.len > 0 and index >= 0 and variationCoordinates.isSome:
+    try:
+      result = some(initSystemTypeface(path, index, variationCoordinates.get()))
+    except ValueError:
+      discard
 
 proc typefaceInfo(font: CTFontRef): Option[SystemTypefaceInfo] =
   let file = font.resolvedTypeface()
@@ -218,7 +302,7 @@ proc typefaceInfo(font: CTFontRef): Option[SystemTypefaceInfo] =
       CFRelease(postScriptName)
   result = some(
     SystemTypefaceInfo(
-      file: file.get(),
+      typeface: file.get(),
       family: family.nimString(),
       subfamily: subfamily.nimString(),
       fullName: fullName.nimString(),
@@ -255,7 +339,7 @@ iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
       if info.isSome:
         yield info.get()
 
-proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+proc findNativeSystemTypeface*(names: openArray[string]): SystemFontProviderResult =
   ## Finds the first exact installed face requested in `names` using Core Text.
   ## A bare family name resolves only to its regular face.
   let availableNames = CTFontManagerCopyAvailablePostScriptNames()
@@ -263,7 +347,7 @@ proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProvider
     return unavailableSystemFontProvider()
   CFRelease(availableNames)
 
-  result = systemFontProviderMatch(none(SystemTypefaceFile))
+  result = systemFontProviderMatch(none(SystemTypeface))
   for name in names:
     if name.normalizedName().len == 0:
       continue

--- a/src/figdraw/extras/systemfonts_native.nim
+++ b/src/figdraw/extras/systemfonts_native.nim
@@ -13,3 +13,11 @@ proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProvider
     platformSystemFonts.findNativeSystemTypefaceFile(names)
   else:
     unavailableSystemFontProvider()
+
+iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
+  ## Enumerates local faces from the host platform font service.
+  when declared(platformSystemFonts):
+    for info in platformSystemFonts.nativeSystemTypefaces(available):
+      yield info
+  else:
+    available = false

--- a/src/figdraw/extras/systemfonts_native.nim
+++ b/src/figdraw/extras/systemfonts_native.nim
@@ -7,10 +7,10 @@ elif defined(macosx):
 elif defined(linux) or defined(freebsd):
   import ./systemfonts_fontconfig as platformSystemFonts
 
-proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+proc findNativeSystemTypeface*(names: openArray[string]): SystemFontProviderResult =
   ## Dispatches installed-font matching to the host platform font service.
   when declared(platformSystemFonts):
-    platformSystemFonts.findNativeSystemTypefaceFile(names)
+    platformSystemFonts.findNativeSystemTypeface(names)
   else:
     unavailableSystemFontProvider()
 

--- a/src/figdraw/extras/systemfonts_native.nim
+++ b/src/figdraw/extras/systemfonts_native.nim
@@ -1,0 +1,15 @@
+import ./systemfonttypes
+
+when defined(windows):
+  import ./systemfonts_windows as platformSystemFonts
+elif defined(macosx):
+  import ./systemfonts_macos as platformSystemFonts
+elif defined(linux) or defined(freebsd):
+  import ./systemfonts_fontconfig as platformSystemFonts
+
+proc findNativeSystemTypefaceFile*(names: openArray[string]): SystemFontProviderResult =
+  ## Dispatches installed-font matching to the host platform font service.
+  when declared(platformSystemFonts):
+    platformSystemFonts.findNativeSystemTypefaceFile(names)
+  else:
+    unavailableSystemFontProvider()

--- a/src/figdraw/extras/systemfonts_windows.nim
+++ b/src/figdraw/extras/systemfonts_windows.nim
@@ -1,7 +1,7 @@
 import ./systemfonttypes
 
 when defined(windows):
-  import std/[dynlib, options, os, unicode]
+  import std/[dynlib, options, os, sets, strutils, unicode]
 
   type
     HResult = int32
@@ -499,6 +499,7 @@ when defined(windows):
 
   iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
     ## Enumerates locally readable, nonsimulated DirectWrite faces.
+    var seen = initHashSet[(string, int)]()
     block provider:
       let dwriteLibrary = loadLib("dwrite.dll")
       if dwriteLibrary == nil:
@@ -542,7 +543,11 @@ when defined(windows):
       for familyIndex in 0'u32 ..<
           collection.lpVtbl.getFontFamilyCount(cast[pointer](collection)):
         for info in collection.familyTypefaces(familyIndex):
-          yield info
+          let identity =
+            (info.file.path.toLowerAscii().replace('\\', '/'), info.file.faceIndex)
+          if identity notin seen:
+            seen.incl(identity)
+            yield info
 
   proc regularFamilyTypeface(
       collection: ptr IDWriteFontCollection, familyIndex: UInt32

--- a/src/figdraw/extras/systemfonts_windows.nim
+++ b/src/figdraw/extras/systemfonts_windows.nim
@@ -1,0 +1,545 @@
+import ./systemfonttypes
+
+when defined(windows):
+  import std/[dynlib, options, os, unicode]
+
+  type
+    HResult = int32
+    ULong = uint32
+    UInt32 = uint32
+    WinBool = int32
+    WideChar = uint16
+    Guid {.bycopy.} = object
+      data1: uint32
+      data2: uint16
+      data3: uint16
+      data4: array[8, uint8]
+
+    IDWriteFactory = object
+      lpVtbl: ptr IDWriteFactoryVtbl
+
+    IDWriteFontCollection = object
+      lpVtbl: ptr IDWriteFontCollectionVtbl
+
+    IDWriteFontFamily = object
+      lpVtbl: ptr IDWriteFontFamilyVtbl
+
+    IDWriteFont = object
+      lpVtbl: ptr IDWriteFontVtbl
+
+    IDWriteLocalizedStrings = object
+      lpVtbl: ptr IDWriteLocalizedStringsVtbl
+
+    IDWriteFontFace = object
+      lpVtbl: ptr IDWriteFontFaceVtbl
+
+    IDWriteFontFile = object
+      lpVtbl: ptr IDWriteFontFileVtbl
+
+    IDWriteFontFileLoader = object
+      lpVtbl: ptr IDWriteFontFileLoaderVtbl
+
+    IDWriteLocalFontFileLoader = object
+      lpVtbl: ptr IDWriteLocalFontFileLoaderVtbl
+
+    QueryInterfaceProc =
+      proc(self: pointer, iid: ptr Guid, value: ptr pointer): HResult {.stdcall.}
+    AddRefProc = proc(self: pointer): ULong {.stdcall.}
+    ReleaseProc = proc(self: pointer): ULong {.stdcall.}
+    DWriteCreateFactoryProc =
+      proc(factoryType: cint, iid: ptr Guid, factory: ptr pointer): HResult {.stdcall.}
+
+    IDWriteFactoryVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getSystemFontCollection: proc(
+        self: pointer,
+        collection: ptr ptr IDWriteFontCollection,
+        checkForUpdates: WinBool,
+      ): HResult {.stdcall.}
+
+    IDWriteFontCollectionVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getFontFamilyCount: proc(self: pointer): UInt32 {.stdcall.}
+      getFontFamily: proc(
+        self: pointer, index: UInt32, family: ptr ptr IDWriteFontFamily
+      ): HResult {.stdcall.}
+      findFamilyName: proc(
+        self: pointer, familyName: ptr WideChar, index: ptr UInt32, exists: ptr WinBool
+      ): HResult {.stdcall.}
+      getFontFromFontFace: pointer
+
+    IDWriteFontFamilyVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getFontCollection: pointer
+      getFontCount: proc(self: pointer): UInt32 {.stdcall.}
+      getFont: proc(self: pointer, index: UInt32, font: ptr ptr IDWriteFont): HResult {.
+        stdcall
+      .}
+      getFamilyNames:
+        proc(self: pointer, names: ptr ptr IDWriteLocalizedStrings): HResult {.stdcall.}
+      getFirstMatchingFont: pointer
+      getMatchingFonts: pointer
+
+    IDWriteFontVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getFontFamily: pointer
+      getWeight: proc(self: pointer): cint {.stdcall.}
+      getStretch: proc(self: pointer): cint {.stdcall.}
+      getStyle: proc(self: pointer): cint {.stdcall.}
+      isSymbolFont: pointer
+      getFaceNames:
+        proc(self: pointer, names: ptr ptr IDWriteLocalizedStrings): HResult {.stdcall.}
+      getInformationalStrings: proc(
+        self: pointer,
+        stringId: cint,
+        strings: ptr ptr IDWriteLocalizedStrings,
+        exists: ptr WinBool,
+      ): HResult {.stdcall.}
+      getSimulations: proc(self: pointer): cint {.stdcall.}
+      getMetrics: pointer
+      hasCharacter: pointer
+      createFontFace:
+        proc(self: pointer, fontFace: ptr ptr IDWriteFontFace): HResult {.stdcall.}
+
+    IDWriteLocalizedStringsVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getCount: proc(self: pointer): UInt32 {.stdcall.}
+      findLocaleName: pointer
+      getLocaleNameLength: pointer
+      getLocaleName: pointer
+      getStringLength:
+        proc(self: pointer, index: UInt32, length: ptr UInt32): HResult {.stdcall.}
+      getString: proc(
+        self: pointer, index: UInt32, value: ptr WideChar, size: UInt32
+      ): HResult {.stdcall.}
+
+    IDWriteFontFaceVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getType: pointer
+      getFiles: proc(
+        self: pointer, numberOfFiles: ptr UInt32, fontFiles: ptr ptr IDWriteFontFile
+      ): HResult {.stdcall.}
+      getIndex: proc(self: pointer): UInt32 {.stdcall.}
+
+    IDWriteFontFileVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      getReferenceKey:
+        proc(self: pointer, key: ptr pointer, keySize: ptr UInt32): HResult {.stdcall.}
+      getLoader:
+        proc(self: pointer, loader: ptr ptr IDWriteFontFileLoader): HResult {.stdcall.}
+      analyze: pointer
+
+    IDWriteFontFileLoaderVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      createStreamFromKey: pointer
+
+    IDWriteLocalFontFileLoaderVtbl = object
+      queryInterface: QueryInterfaceProc
+      addRef: AddRefProc
+      release: ReleaseProc
+      createStreamFromKey: pointer
+      getFilePathLengthFromKey: proc(
+        self: pointer, key: pointer, keySize: UInt32, length: ptr UInt32
+      ): HResult {.stdcall.}
+      getFilePathFromKey: proc(
+        self: pointer, key: pointer, keySize: UInt32, path: ptr WideChar, size: UInt32
+      ): HResult {.stdcall.}
+      getLastWriteTimeFromKey: pointer
+
+  const
+    dwriteFactoryTypeShared = 0.cint
+    dwriteFontWeightSemiLight = 350.cint
+    dwriteFontWeightRegular = 400.cint
+    dwriteFontStretchNormal = 5.cint
+    dwriteFontStyleNormal = 0.cint
+    dwriteInformationalStringWin32FamilyNames = 11.cint
+    dwriteInformationalStringTypographicFamilyNames = 13.cint
+    dwriteInformationalStringFullName = 16.cint
+    dwriteInformationalStringPostscriptName = 17.cint
+
+    iidIDWriteFactory = Guid(
+      data1: 0xB859EE5A'u32,
+      data2: 0xD838'u16,
+      data3: 0x4B5B'u16,
+      data4: [0xA2'u8, 0xE8'u8, 0x1A'u8, 0xDC'u8, 0x7D'u8, 0x93'u8, 0xDB'u8, 0x48'u8],
+    )
+    iidIDWriteLocalFontFileLoader = Guid(
+      data1: 0xB2D9F3EC'u32,
+      data2: 0xC9FE'u16,
+      data3: 0x4A11'u16,
+      data4: [0xA2'u8, 0xEC'u8, 0xD8'u8, 0x62'u8, 0x08'u8, 0xF7'u8, 0xC0'u8, 0xA2'u8],
+    )
+
+  template succeeded(value: HResult): bool =
+    value >= 0
+
+  template release(value: untyped) =
+    if value != nil:
+      discard value.lpVtbl.release(cast[pointer](value))
+      value = nil
+
+  proc utf16(value: string): seq[WideChar] =
+    for rune in value.runes:
+      let codepoint = rune.int
+      if codepoint <= 0xFFFF:
+        result.add(WideChar(codepoint))
+      else:
+        let offset = codepoint - 0x10000
+        result.add(WideChar(0xD800 + (offset shr 10)))
+        result.add(WideChar(0xDC00 + (offset and 0x3FF)))
+    result.add(0)
+
+  proc utf8(value: openArray[WideChar]): string =
+    var index = 0
+    while index < value.len and value[index] != 0:
+      var codepoint = value[index].int
+      inc index
+      if codepoint in 0xD800 .. 0xDBFF and index < value.len:
+        let trail = value[index].int
+        if trail in 0xDC00 .. 0xDFFF:
+          codepoint = 0x10000 + ((codepoint - 0xD800) shl 10) + trail - 0xDC00
+          inc index
+      result.add($Rune(codepoint))
+
+  proc normalizedName(value: string): string =
+    for rune in value.runes:
+      result.add($rune.toLower)
+
+  proc containsName(strings: ptr IDWriteLocalizedStrings, requested: string): bool =
+    if strings == nil:
+      return false
+    let requested = requested.normalizedName()
+    for index in 0'u32 ..< strings.lpVtbl.getCount(cast[pointer](strings)):
+      var length: UInt32
+      if not succeeded(
+        strings.lpVtbl.getStringLength(cast[pointer](strings), index, addr length)
+      ):
+        continue
+      var buffer = newSeq[WideChar](length.int + 1)
+      if succeeded(
+        strings.lpVtbl.getString(
+          cast[pointer](strings), index, addr buffer[0], length + 1
+        )
+      ) and buffer.utf8().normalizedName() == requested:
+        return true
+
+  proc fontHasInformationalName(
+      font: ptr IDWriteFont, requested: string, stringIds: openArray[cint]
+  ): bool =
+    for stringId in stringIds:
+      var
+        strings: ptr IDWriteLocalizedStrings
+        exists: WinBool
+      if succeeded(
+        font.lpVtbl.getInformationalStrings(
+          cast[pointer](font), stringId, addr strings, addr exists
+        )
+      ) and exists != 0:
+        result = strings.containsName(requested)
+      release(strings)
+      if result:
+        return
+
+  proc fontHasFaceName(font: ptr IDWriteFont, requested: string): bool =
+    var names: ptr IDWriteLocalizedStrings
+    if succeeded(font.lpVtbl.getFaceNames(cast[pointer](font), addr names)):
+      result = names.containsName(requested)
+    release(names)
+
+  proc isRegularFont(font: ptr IDWriteFont): bool =
+    let weight = font.lpVtbl.getWeight(cast[pointer](font))
+    font.lpVtbl.getStretch(cast[pointer](font)) == dwriteFontStretchNormal and
+      font.lpVtbl.getStyle(cast[pointer](font)) == dwriteFontStyleNormal and
+      font.lpVtbl.getSimulations(cast[pointer](font)) == 0 and (
+      weight == dwriteFontWeightRegular or
+      (weight == dwriteFontWeightSemiLight and font.fontHasFaceName("Book"))
+    )
+
+  proc containsFamilyFaceName(
+      familyNames, faceNames: ptr IDWriteLocalizedStrings, requested: string
+  ): bool =
+    if familyNames == nil or faceNames == nil:
+      return false
+    let requested = requested.normalizedName()
+    for familyIndex in 0'u32 ..< familyNames.lpVtbl.getCount(cast[pointer](familyNames)):
+      var familyLength: UInt32
+      if not succeeded(
+        familyNames.lpVtbl.getStringLength(
+          cast[pointer](familyNames), familyIndex, addr familyLength
+        )
+      ):
+        continue
+      var familyBuffer = newSeq[WideChar](familyLength.int + 1)
+      if not succeeded(
+        familyNames.lpVtbl.getString(
+          cast[pointer](familyNames),
+          familyIndex,
+          addr familyBuffer[0],
+          familyLength + 1,
+        )
+      ):
+        continue
+      let familyName = familyBuffer.utf8()
+      for faceIndex in 0'u32 ..< faceNames.lpVtbl.getCount(cast[pointer](faceNames)):
+        var faceLength: UInt32
+        if not succeeded(
+          faceNames.lpVtbl.getStringLength(
+            cast[pointer](faceNames), faceIndex, addr faceLength
+          )
+        ):
+          continue
+        var faceBuffer = newSeq[WideChar](faceLength.int + 1)
+        if succeeded(
+          faceNames.lpVtbl.getString(
+            cast[pointer](faceNames), faceIndex, addr faceBuffer[0], faceLength + 1
+          )
+        ) and (familyName & " " & faceBuffer.utf8()).normalizedName() == requested:
+          return true
+
+  proc localTypefaceFile(font: ptr IDWriteFont): Option[SystemTypefaceFile] =
+    var face: ptr IDWriteFontFace
+    if not succeeded(font.lpVtbl.createFontFace(cast[pointer](font), addr face)) or
+        face == nil:
+      return
+    defer:
+      release(face)
+
+    var fileCount: UInt32
+    if not succeeded(face.lpVtbl.getFiles(cast[pointer](face), addr fileCount, nil)) or
+        fileCount != 1:
+      return
+
+    var fontFile: ptr IDWriteFontFile
+    if not succeeded(
+      face.lpVtbl.getFiles(cast[pointer](face), addr fileCount, addr fontFile)
+    ) or fontFile == nil or fileCount != 1:
+      release(fontFile)
+      return
+    defer:
+      release(fontFile)
+
+    var
+      key: pointer
+      keySize: UInt32
+      loader: ptr IDWriteFontFileLoader
+    if not succeeded(
+      fontFile.lpVtbl.getReferenceKey(cast[pointer](fontFile), addr key, addr keySize)
+    ) or key == nil:
+      return
+    if not succeeded(fontFile.lpVtbl.getLoader(cast[pointer](fontFile), addr loader)) or
+        loader == nil:
+      release(loader)
+      return
+    defer:
+      release(loader)
+
+    var localLoader: ptr IDWriteLocalFontFileLoader
+    if not succeeded(
+      loader.lpVtbl.queryInterface(
+        cast[pointer](loader),
+        unsafeAddr iidIDWriteLocalFontFileLoader,
+        cast[ptr pointer](addr localLoader),
+      )
+    ) or localLoader == nil:
+      release(localLoader)
+      return
+    defer:
+      release(localLoader)
+
+    var pathLength: UInt32
+    if not succeeded(
+      localLoader.lpVtbl.getFilePathLengthFromKey(
+        cast[pointer](localLoader), key, keySize, addr pathLength
+      )
+    ):
+      return
+    var path = newSeq[WideChar](pathLength.int + 1)
+    if not succeeded(
+      localLoader.lpVtbl.getFilePathFromKey(
+        cast[pointer](localLoader), key, keySize, addr path[0], pathLength + 1
+      )
+    ):
+      return
+
+    let decodedPath = path.utf8()
+    if decodedPath.len > 0 and decodedPath.isAbsolute() and decodedPath.fileExists():
+      result = some(
+        SystemTypefaceFile(
+          path: decodedPath, faceIndex: face.lpVtbl.getIndex(cast[pointer](face)).int
+        )
+      )
+
+  proc regularFamilyTypeface(
+      collection: ptr IDWriteFontCollection, familyIndex: UInt32
+  ): Option[SystemTypefaceFile] =
+    var family: ptr IDWriteFontFamily
+    if not succeeded(
+      collection.lpVtbl.getFontFamily(
+        cast[pointer](collection), familyIndex, addr family
+      )
+    ) or family == nil:
+      release(family)
+      return
+    defer:
+      release(family)
+
+    # Avoid GetFirstMatchingFont: it deliberately returns a closest style when
+    # the requested regular face is absent.
+    for desiredWeight in [dwriteFontWeightRegular, dwriteFontWeightSemiLight]:
+      for index in 0'u32 ..< family.lpVtbl.getFontCount(cast[pointer](family)):
+        var font: ptr IDWriteFont
+        if not succeeded(family.lpVtbl.getFont(cast[pointer](family), index, addr font)) or
+            font == nil:
+          release(font)
+          continue
+        if font.isRegularFont() and
+            font.lpVtbl.getWeight(cast[pointer](font)) == desiredWeight:
+          result = font.localTypefaceFile()
+        release(font)
+        if result.isSome:
+          return
+
+  proc explicitTypeface(
+      collection: ptr IDWriteFontCollection, requested: string
+  ): Option[SystemTypefaceFile] =
+    var bookFallback: Option[SystemTypefaceFile]
+    for familyIndex in 0'u32 ..<
+        collection.lpVtbl.getFontFamilyCount(cast[pointer](collection)):
+      var family: ptr IDWriteFontFamily
+      if not succeeded(
+        collection.lpVtbl.getFontFamily(
+          cast[pointer](collection), familyIndex, addr family
+        )
+      ) or family == nil:
+        release(family)
+        continue
+      var familyNames: ptr IDWriteLocalizedStrings
+      if not succeeded(
+        family.lpVtbl.getFamilyNames(cast[pointer](family), addr familyNames)
+      ):
+        release(familyNames)
+      for fontIndex in 0'u32 ..< family.lpVtbl.getFontCount(cast[pointer](family)):
+        var font: ptr IDWriteFont
+        if not succeeded(
+          family.lpVtbl.getFont(cast[pointer](family), fontIndex, addr font)
+        ) or font == nil:
+          release(font)
+          continue
+        if font.lpVtbl.getSimulations(cast[pointer](font)) != 0:
+          release(font)
+          continue
+        var faceNames: ptr IDWriteLocalizedStrings
+        discard font.lpVtbl.getFaceNames(cast[pointer](font), addr faceNames)
+        let explicitNameMatches =
+          font.fontHasInformationalName(
+            requested,
+            [dwriteInformationalStringFullName, dwriteInformationalStringPostscriptName],
+          ) or containsFamilyFaceName(familyNames, faceNames, requested)
+        let familyNameMatches =
+          font.isRegularFont() and
+          font.fontHasInformationalName(
+            requested,
+            [
+              dwriteInformationalStringWin32FamilyNames,
+              dwriteInformationalStringTypographicFamilyNames,
+            ],
+          )
+        release(faceNames)
+        if explicitNameMatches:
+          result = font.localTypefaceFile()
+        elif familyNameMatches:
+          let candidate = font.localTypefaceFile()
+          if font.lpVtbl.getWeight(cast[pointer](font)) == dwriteFontWeightRegular:
+            result = candidate
+          elif bookFallback.isNone:
+            bookFallback = candidate
+        release(font)
+        if result.isSome:
+          break
+      release(familyNames)
+      release(family)
+      if result.isSome:
+        return
+    result = bookFallback
+
+  proc findNativeSystemTypefaceFile*(
+      names: openArray[string]
+  ): SystemFontProviderResult =
+    ## Resolves an installed DirectWrite face to its local file and face index.
+    let dwriteLibrary = loadLib("dwrite.dll")
+    if dwriteLibrary == nil:
+      return unavailableSystemFontProvider()
+    defer:
+      unloadLib(dwriteLibrary)
+    let dWriteCreateFactory =
+      cast[DWriteCreateFactoryProc](dwriteLibrary.symAddr("DWriteCreateFactory"))
+    if dWriteCreateFactory == nil:
+      return unavailableSystemFontProvider()
+
+    var factory: ptr IDWriteFactory
+    if not succeeded(
+      dWriteCreateFactory(
+        dwriteFactoryTypeShared,
+        unsafeAddr iidIDWriteFactory,
+        cast[ptr pointer](addr factory),
+      )
+    ) or factory == nil:
+      release(factory)
+      return unavailableSystemFontProvider()
+    defer:
+      release(factory)
+
+    var collection: ptr IDWriteFontCollection
+    if not succeeded(
+      factory.lpVtbl.getSystemFontCollection(cast[pointer](factory), addr collection, 0)
+    ) or collection == nil:
+      release(collection)
+      return unavailableSystemFontProvider()
+    defer:
+      release(collection)
+
+    for requested in names:
+      if requested.len == 0:
+        continue
+      var
+        familyIndex: UInt32
+        exists: WinBool
+        wideName = requested.utf16()
+      if succeeded(
+        collection.lpVtbl.findFamilyName(
+          cast[pointer](collection), addr wideName[0], addr familyIndex, addr exists
+        )
+      ) and exists != 0:
+        let match = collection.regularFamilyTypeface(familyIndex)
+        if match.isSome:
+          return systemFontProviderMatch(match)
+
+      let match = collection.explicitTypeface(requested)
+      if match.isSome:
+        return systemFontProviderMatch(match)
+
+    systemFontProviderMatch(none(SystemTypefaceFile))
+
+else:
+  proc findNativeSystemTypefaceFile*(
+      names: openArray[string]
+  ): SystemFontProviderResult =
+    ## The DirectWrite system font provider is unavailable off Windows.
+    discard names
+    unavailableSystemFontProvider()

--- a/src/figdraw/extras/systemfonts_windows.nim
+++ b/src/figdraw/extras/systemfonts_windows.nim
@@ -340,7 +340,7 @@ when defined(windows):
         ) and (familyName & " " & faceBuffer.utf8()).normalizedName() == requested:
           return true
 
-  proc localTypefaceFile(font: ptr IDWriteFont): Option[SystemTypefaceFile] =
+  proc localTypeface(font: ptr IDWriteFont): Option[SystemTypeface] =
     var face: ptr IDWriteFontFace
     if not succeeded(font.lpVtbl.createFontFace(cast[pointer](font), addr face)) or
         face == nil:
@@ -417,9 +417,7 @@ when defined(windows):
     except IOError, OSError:
       return
     result = some(
-      SystemTypefaceFile(
-        path: decodedPath, faceIndex: face.lpVtbl.getIndex(cast[pointer](face)).int
-      )
+      initSystemTypeface(decodedPath, face.lpVtbl.getIndex(cast[pointer](face)).int)
     )
 
   proc typefaceInfo(
@@ -427,8 +425,8 @@ when defined(windows):
   ): Option[SystemTypefaceInfo] =
     if font.lpVtbl.getSimulations(cast[pointer](font)) != 0:
       return
-    let file = font.localTypefaceFile()
-    if file.isNone:
+    let typeface = font.localTypeface()
+    if typeface.isNone:
       return
 
     var faceNames: ptr IDWriteLocalizedStrings
@@ -446,7 +444,7 @@ when defined(windows):
         font.informationalName(dwriteInformationalStringWin32SubfamilyNames)
     result = some(
       SystemTypefaceInfo(
-        file: file.get(),
+        typeface: typeface.get(),
         family:
           if typographicFamily.len > 0:
             typographicFamily
@@ -543,15 +541,17 @@ when defined(windows):
       for familyIndex in 0'u32 ..<
           collection.lpVtbl.getFontFamilyCount(cast[pointer](collection)):
         for info in collection.familyTypefaces(familyIndex):
-          let identity =
-            (info.file.path.toLowerAscii().replace('\\', '/'), info.file.faceIndex)
+          let identity = (
+            info.typeface.file.path.toLowerAscii().replace('\\', '/'),
+            info.typeface.file.faceIndex,
+          )
           if identity notin seen:
             seen.incl(identity)
             yield info
 
   proc regularFamilyTypeface(
       collection: ptr IDWriteFontCollection, familyIndex: UInt32
-  ): Option[SystemTypefaceFile] =
+  ): Option[SystemTypeface] =
     var family: ptr IDWriteFontFamily
     if not succeeded(
       collection.lpVtbl.getFontFamily(
@@ -574,15 +574,15 @@ when defined(windows):
           continue
         if font.isRegularFont() and
             font.lpVtbl.getWeight(cast[pointer](font)) == desiredWeight:
-          result = font.localTypefaceFile()
+          result = font.localTypeface()
         release(font)
         if result.isSome:
           return
 
   proc explicitTypeface(
       collection: ptr IDWriteFontCollection, requested: string
-  ): Option[SystemTypefaceFile] =
-    var bookFallback: Option[SystemTypefaceFile]
+  ): Option[SystemTypeface] =
+    var bookFallback: Option[SystemTypeface]
     for familyIndex in 0'u32 ..<
         collection.lpVtbl.getFontFamilyCount(cast[pointer](collection)):
       var family: ptr IDWriteFontFamily
@@ -626,9 +626,9 @@ when defined(windows):
           )
         release(faceNames)
         if explicitNameMatches:
-          result = font.localTypefaceFile()
+          result = font.localTypeface()
         elif familyNameMatches:
-          let candidate = font.localTypefaceFile()
+          let candidate = font.localTypeface()
           if font.lpVtbl.getWeight(cast[pointer](font)) == dwriteFontWeightRegular:
             result = candidate
           elif bookFallback.isNone:
@@ -642,9 +642,7 @@ when defined(windows):
         return
     result = bookFallback
 
-  proc findNativeSystemTypefaceFile*(
-      names: openArray[string]
-  ): SystemFontProviderResult =
+  proc findNativeSystemTypeface*(names: openArray[string]): SystemFontProviderResult =
     ## Resolves an installed DirectWrite face to its local file and face index.
     let dwriteLibrary = loadLib("dwrite.dll")
     if dwriteLibrary == nil:
@@ -698,16 +696,14 @@ when defined(windows):
       if match.isSome:
         return systemFontProviderMatch(match)
 
-    systemFontProviderMatch(none(SystemTypefaceFile))
+    systemFontProviderMatch(none(SystemTypeface))
 
 else:
   iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
     ## DirectWrite enumeration is unavailable off Windows.
     available = false
 
-  proc findNativeSystemTypefaceFile*(
-      names: openArray[string]
-  ): SystemFontProviderResult =
+  proc findNativeSystemTypeface*(names: openArray[string]): SystemFontProviderResult =
     ## The DirectWrite system font provider is unavailable off Windows.
     discard names
     unavailableSystemFontProvider()

--- a/src/figdraw/extras/systemfonts_windows.nim
+++ b/src/figdraw/extras/systemfonts_windows.nim
@@ -169,7 +169,9 @@ when defined(windows):
     dwriteFontStretchNormal = 5.cint
     dwriteFontStyleNormal = 0.cint
     dwriteInformationalStringWin32FamilyNames = 11.cint
+    dwriteInformationalStringWin32SubfamilyNames = 12.cint
     dwriteInformationalStringTypographicFamilyNames = 13.cint
+    dwriteInformationalStringTypographicSubfamilyNames = 14.cint
     dwriteInformationalStringFullName = 16.cint
     dwriteInformationalStringPostscriptName = 17.cint
 
@@ -238,6 +240,32 @@ when defined(windows):
         )
       ) and buffer.utf8().normalizedName() == requested:
         return true
+
+  proc firstString(strings: ptr IDWriteLocalizedStrings): string =
+    if strings == nil or strings.lpVtbl.getCount(cast[pointer](strings)) == 0:
+      return
+    var length: UInt32
+    if not succeeded(
+      strings.lpVtbl.getStringLength(cast[pointer](strings), 0, addr length)
+    ):
+      return
+    var buffer = newSeq[WideChar](length.int + 1)
+    if succeeded(
+      strings.lpVtbl.getString(cast[pointer](strings), 0, addr buffer[0], length + 1)
+    ):
+      result = buffer.utf8()
+
+  proc informationalName(font: ptr IDWriteFont, stringId: cint): string =
+    var
+      strings: ptr IDWriteLocalizedStrings
+      exists: WinBool
+    if succeeded(
+      font.lpVtbl.getInformationalStrings(
+        cast[pointer](font), stringId, addr strings, addr exists
+      )
+    ) and exists != 0:
+      result = strings.firstString()
+    release(strings)
 
   proc fontHasInformationalName(
       font: ptr IDWriteFont, requested: string, stringIds: openArray[cint]
@@ -378,12 +406,143 @@ when defined(windows):
       return
 
     let decodedPath = path.utf8()
-    if decodedPath.len > 0 and decodedPath.isAbsolute() and decodedPath.fileExists():
-      result = some(
-        SystemTypefaceFile(
-          path: decodedPath, faceIndex: face.lpVtbl.getIndex(cast[pointer](face)).int
-        )
+    if decodedPath.len == 0 or not decodedPath.isAbsolute() or
+        not decodedPath.fileExists():
+      return
+    try:
+      var file: File
+      if not open(file, decodedPath, fmRead):
+        return
+      close(file)
+    except IOError, OSError:
+      return
+    result = some(
+      SystemTypefaceFile(
+        path: decodedPath, faceIndex: face.lpVtbl.getIndex(cast[pointer](face)).int
       )
+    )
+
+  proc typefaceInfo(
+      font: ptr IDWriteFont, fallbackFamily: string
+  ): Option[SystemTypefaceInfo] =
+    if font.lpVtbl.getSimulations(cast[pointer](font)) != 0:
+      return
+    let file = font.localTypefaceFile()
+    if file.isNone:
+      return
+
+    var faceNames: ptr IDWriteLocalizedStrings
+    discard font.lpVtbl.getFaceNames(cast[pointer](font), addr faceNames)
+    let fallbackSubfamily = faceNames.firstString()
+    release(faceNames)
+
+    let
+      typographicFamily =
+        font.informationalName(dwriteInformationalStringTypographicFamilyNames)
+      win32Family = font.informationalName(dwriteInformationalStringWin32FamilyNames)
+      typographicSubfamily =
+        font.informationalName(dwriteInformationalStringTypographicSubfamilyNames)
+      win32Subfamily =
+        font.informationalName(dwriteInformationalStringWin32SubfamilyNames)
+    result = some(
+      SystemTypefaceInfo(
+        file: file.get(),
+        family:
+          if typographicFamily.len > 0:
+            typographicFamily
+          elif win32Family.len > 0:
+            win32Family
+          else:
+            fallbackFamily,
+        subfamily:
+          if typographicSubfamily.len > 0:
+            typographicSubfamily
+          elif win32Subfamily.len > 0:
+            win32Subfamily
+          else:
+            fallbackSubfamily,
+        fullName: font.informationalName(dwriteInformationalStringFullName),
+        postScriptName: font.informationalName(dwriteInformationalStringPostscriptName),
+      )
+    )
+
+  proc familyTypefaces(
+      collection: ptr IDWriteFontCollection, familyIndex: UInt32
+  ): seq[SystemTypefaceInfo] =
+    var family: ptr IDWriteFontFamily
+    if not succeeded(
+      collection.lpVtbl.getFontFamily(
+        cast[pointer](collection), familyIndex, addr family
+      )
+    ) or family == nil:
+      release(family)
+      return
+    defer:
+      release(family)
+
+    var familyNames: ptr IDWriteLocalizedStrings
+    discard family.lpVtbl.getFamilyNames(cast[pointer](family), addr familyNames)
+    let fallbackFamily = familyNames.firstString()
+    release(familyNames)
+
+    for fontIndex in 0'u32 ..< family.lpVtbl.getFontCount(cast[pointer](family)):
+      var font: ptr IDWriteFont
+      if not succeeded(
+        family.lpVtbl.getFont(cast[pointer](family), fontIndex, addr font)
+      ) or font == nil:
+        release(font)
+        continue
+      let info = font.typefaceInfo(fallbackFamily)
+      release(font)
+      if info.isSome:
+        result.add info.get()
+
+  iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
+    ## Enumerates locally readable, nonsimulated DirectWrite faces.
+    block provider:
+      let dwriteLibrary = loadLib("dwrite.dll")
+      if dwriteLibrary == nil:
+        available = false
+        break provider
+      defer:
+        unloadLib(dwriteLibrary)
+      let dWriteCreateFactory =
+        cast[DWriteCreateFactoryProc](dwriteLibrary.symAddr("DWriteCreateFactory"))
+      if dWriteCreateFactory == nil:
+        available = false
+        break provider
+
+      var factory: ptr IDWriteFactory
+      if not succeeded(
+        dWriteCreateFactory(
+          dwriteFactoryTypeShared,
+          unsafeAddr iidIDWriteFactory,
+          cast[ptr pointer](addr factory),
+        )
+      ) or factory == nil:
+        release(factory)
+        available = false
+        break provider
+      defer:
+        release(factory)
+
+      var collection: ptr IDWriteFontCollection
+      if not succeeded(
+        factory.lpVtbl.getSystemFontCollection(
+          cast[pointer](factory), addr collection, 0
+        )
+      ) or collection == nil:
+        release(collection)
+        available = false
+        break provider
+      defer:
+        release(collection)
+      available = true
+
+      for familyIndex in 0'u32 ..<
+          collection.lpVtbl.getFontFamilyCount(cast[pointer](collection)):
+        for info in collection.familyTypefaces(familyIndex):
+          yield info
 
   proc regularFamilyTypeface(
       collection: ptr IDWriteFontCollection, familyIndex: UInt32
@@ -537,6 +696,10 @@ when defined(windows):
     systemFontProviderMatch(none(SystemTypefaceFile))
 
 else:
+  iterator nativeSystemTypefaces*(available: var bool): SystemTypefaceInfo =
+    ## DirectWrite enumeration is unavailable off Windows.
+    available = false
+
   proc findNativeSystemTypefaceFile*(
       names: openArray[string]
   ): SystemFontProviderResult =

--- a/src/figdraw/extras/systemfonttypes.nim
+++ b/src/figdraw/extras/systemfonttypes.nim
@@ -1,0 +1,23 @@
+import std/options
+
+type
+  SystemTypefaceFile* = object
+    ## An installed font file and the selected face within it.
+    path*: string
+    faceIndex*: int ## Zero-based face index, including for standalone fonts.
+
+  SystemFontProviderResult* = object
+    ## Result from a platform font provider.
+    ##
+    ## `available` distinguishes an unavailable provider from a valid lookup
+    ## that found no matching installed face.
+    available*: bool
+    match*: Option[SystemTypefaceFile]
+
+func unavailableSystemFontProvider*(): SystemFontProviderResult {.inline.} =
+  SystemFontProviderResult()
+
+func systemFontProviderMatch*(
+    match: Option[SystemTypefaceFile]
+): SystemFontProviderResult {.inline.} =
+  SystemFontProviderResult(available: true, match: match)

--- a/src/figdraw/extras/systemfonttypes.nim
+++ b/src/figdraw/extras/systemfonttypes.nim
@@ -6,6 +6,24 @@ type
     path*: string
     faceIndex*: int ## Zero-based face index, including for standalone fonts.
 
+  SystemTypefaceInfo* = object
+    ## Names and local file identity reported by a platform font provider.
+    ##
+    ## Names are provider-selected display metadata and may differ from the
+    ## OpenType names parsed from `file`. Empty names are permitted.
+    file*: SystemTypefaceFile
+    family*: string
+    subfamily*: string
+    fullName*: string
+    postScriptName*: string
+
+  SystemTypefaceQuery* = object
+    ## Exact filters for installed typeface enumeration.
+    ##
+    ## Empty fields are wildcards. Populated fields are combined with AND.
+    family*: string
+    subfamily*: string
+
   SystemFontProviderResult* = object
     ## Result from a platform font provider.
     ##

--- a/src/figdraw/extras/systemfonttypes.nim
+++ b/src/figdraw/extras/systemfonttypes.nim
@@ -1,17 +1,27 @@
-import std/options
+import std/[algorithm, hashes, math, options]
+
+from ../common/fonttypes import FontVariation
 
 type
   SystemTypefaceFile* = object
-    ## An installed font file and the selected face within it.
+    ## A locally readable font file and the selected physical face within it.
     path*: string
     faceIndex*: int ## Zero-based face index, including for standalone fonts.
 
+  SystemTypeface* = object
+    ## An exact installed typeface selection.
+    ##
+    ## `file` identifies the physical OpenType face. `variations` distinguishes
+    ## named instances that share a variable-font face.
+    file*: SystemTypefaceFile
+    variations*: seq[FontVariation]
+
   SystemTypefaceInfo* = object
-    ## Names and local file identity reported by a platform font provider.
+    ## Names and exact identity reported by a platform font provider.
     ##
     ## Names are provider-selected display metadata and may differ from the
-    ## OpenType names parsed from `file`. Empty names are permitted.
-    file*: SystemTypefaceFile
+    ## OpenType names parsed from `typeface`. Empty names are permitted.
+    typeface*: SystemTypeface
     family*: string
     subfamily*: string
     fullName*: string
@@ -30,12 +40,55 @@ type
     ## `available` distinguishes an unavailable provider from a valid lookup
     ## that found no matching installed face.
     available*: bool
-    match*: Option[SystemTypefaceFile]
+    match*: Option[SystemTypeface]
+
+func initSystemTypefaceFile*(path: string, faceIndex: Natural = 0): SystemTypefaceFile =
+  ## Creates a physical system-typeface file identity.
+  SystemTypefaceFile(path: path, faceIndex: faceIndex)
+
+func canonicalVariations(
+    variations: openArray[FontVariation] = []
+): seq[FontVariation] =
+  result = @variations
+  result.sort(
+    proc(left, right: FontVariation): int =
+      cmp(left.tag, right.tag)
+  )
+  for index, variation in result:
+    if variation.tag.len != 4:
+      raise newException(ValueError, "font variation tags must contain four bytes")
+    for ch in variation.tag:
+      if ch notin {'\x20' .. '\x7e'}:
+        raise newException(ValueError, "font variation tags must be printable ASCII")
+    if variation.value.classify in {fcNan, fcInf, fcNegInf}:
+      raise newException(ValueError, "font variation values must be finite")
+    if index > 0 and variation.tag == result[index - 1].tag:
+      raise newException(ValueError, "font variation tags must be unique")
+
+func initSystemTypeface*(
+    file: SystemTypefaceFile, variations: openArray[FontVariation] = []
+): SystemTypeface =
+  ## Creates an exact system-typeface identity with canonical axis ordering.
+  if file.faceIndex < 0:
+    raise newException(ValueError, "system typeface face index must not be negative")
+  SystemTypeface(file: file, variations: canonicalVariations(variations))
+
+func initSystemTypeface*(
+    path: string, faceIndex: Natural = 0, variations: openArray[FontVariation] = []
+): SystemTypeface =
+  ## Creates an exact system-typeface identity from a path and physical face index.
+  initSystemTypeface(initSystemTypefaceFile(path, faceIndex), variations)
+
+proc hash*(file: SystemTypefaceFile): Hash =
+  hash((file.path, file.faceIndex))
+
+proc hash*(typeface: SystemTypeface): Hash =
+  hash((typeface.file, typeface.variations))
 
 func unavailableSystemFontProvider*(): SystemFontProviderResult {.inline.} =
   SystemFontProviderResult()
 
 func systemFontProviderMatch*(
-    match: Option[SystemTypefaceFile]
+    match: Option[SystemTypeface]
 ): SystemFontProviderResult {.inline.} =
   SystemFontProviderResult(available: true, match: match)

--- a/tests/tdynlib_api.nim
+++ b/tests/tdynlib_api.nim
@@ -6,6 +6,11 @@ when defined(useNativeDynlib):
   proc loadExactTypefaceForCompileCheck(file: SystemTypefaceFile): TypefaceId {.used.} =
     loadTypeface(file)
 
+  proc exactFontForCompileCheck(
+      typeface: SystemTypeface, size: float32
+  ): FigFont {.used.} =
+    typeface.fontWithSize(size)
+
 suite "native dynlib API":
   when defined(useNativeDynlib):
     test "supports elliptical corners and drawable ellipses":

--- a/tests/tdynlib_api.nim
+++ b/tests/tdynlib_api.nim
@@ -3,6 +3,9 @@ import std/unittest
 when defined(useNativeDynlib):
   import figdraw/dynlib
 
+  proc loadExactTypefaceForCompileCheck(file: SystemTypefaceFile): TypefaceId {.used.} =
+    loadTypeface(file)
+
 suite "native dynlib API":
   when defined(useNativeDynlib):
     test "supports elliptical corners and drawable ellipses":

--- a/tests/tfontmetadata.nim
+++ b/tests/tfontmetadata.nim
@@ -1,5 +1,6 @@
-import std/[os, tempfiles, unicode, unittest]
+import std/[options, os, tempfiles, unicode, unittest]
 
+import figdraw/common/typefaceinfos
 import figdraw/extras/systemfonts
 
 type NameEntry = tuple[id: int, text: string]
@@ -101,14 +102,15 @@ suite "installed font metadata resolution":
   test "family metadata overrides an unrelated filename":
     let path = fixtureDir / "MisleadingName-Bold.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path == path
-    check findSystemTypefaceFile(["MisleadingName"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["MisleadingName"], [path]).isNone
 
   test "related families cannot consume a regular family as a prefix":
     let path = fixtureDir / "regular.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
     for name in ["Fixture Sans CJK", "Fixture Sans Mono", "Fixture Sans Unknown"]:
-      check findSystemTypefaceFile([name], [path]).path.len == 0
+      check findSystemTypefaceFile([name], [path]).isNone
 
   test "unstyled family skips bold italic and oblique faces for the next fallback":
     let
@@ -129,7 +131,7 @@ suite "installed font metadata resolution":
     writeFile(fallback, fontMetadata("Other Sans"))
     check findSystemTypefaceFile(
       ["Fixture Sans", "Other Sans"], [bold, italic, oblique, fallback]
-    ).path == fallback
+    ) == some(SystemTypefaceFile(path: fallback, faceIndex: 0))
 
   test "missing bold and italic styles preserve explicit fallback order":
     let
@@ -138,8 +140,8 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(fallback, fontMetadata("Other Sans"))
     for name in ["Fixture Sans Bold", "Fixture Sans Italic"]:
-      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]).path ==
-        fallback
+      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]) ==
+        some(SystemTypefaceFile(path: fallback, faceIndex: 0))
 
   test "explicit styles use the matching face even with opaque filenames":
     let
@@ -149,10 +151,10 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(bold, fontMetadata("Fixture Sans", "Bold", 700, 32))
     writeFile(italic, fontMetadata("Fixture Sans", "Italic", 400, 1))
-    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]).path ==
-      bold
-    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]).path ==
-      italic
+    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]) ==
+      some(SystemTypefaceFile(path: bold, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]) ==
+      some(SystemTypefaceFile(path: italic, faceIndex: 0))
 
   test "typographic family and subfamily retain semibold style":
     let path = fixtureDir / "font.ttf"
@@ -167,8 +169,9 @@ suite "installed font metadata resolution":
         typographicStyle = "SemiBold",
       ),
     )
-    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]).path == path
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
 
   test "style words are matched exactly and combined styles require both traits":
     let path = fixtureDir / "bold.ttf"
@@ -176,20 +179,22 @@ suite "installed font metadata resolution":
     for name in [
       "Fixture Sans SemiBold", "Fixture Sans NotBold", "Fixture Sans Bold Italic"
     ]:
-      check findSystemTypefaceFile([name], [path]).path.len == 0
+      check findSystemTypefaceFile([name], [path]).isNone
 
   test "regional collection family names remain distinct":
     let path = fixtureDir / "regional.ttf"
     writeFile(path, fontMetadata("Fixture Sans CJK JP"))
-    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]).path == path
-    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).path.len == 0
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).isNone
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
 
   test "Unicode family names remain distinct":
     let path = fixtureDir / "unicode.ttf"
     writeFile(path, fontMetadata("明朝"))
-    check findSystemTypefaceFile(["明朝"], [path]).path == path
-    check findSystemTypefaceFile(["黑体"], [path]).path.len == 0
+    check findSystemTypefaceFile(["明朝"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["黑体"], [path]).isNone
 
   test "matches in one directory do not depend on enumeration order":
     let
@@ -197,19 +202,22 @@ suite "installed font metadata resolution":
       second = fixtureDir / "z.ttf"
     writeFile(first, fontMetadata("Fixture Sans"))
     writeFile(second, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(["Fixture Sans"], [first, second]).path == first
-    check findSystemTypefaceFile(["Fixture Sans"], [second, first]).path == first
+    let expected = some(SystemTypefaceFile(path: first, faceIndex: 0))
+    check findSystemTypefaceFile(["Fixture Sans"], [first, second]) == expected
+    check findSystemTypefaceFile(["Fixture Sans"], [second, first]) == expected
 
   test "metadata is cached until explicit refresh":
     let path = fixtureDir / "font.ttf"
     writeFile(path, fontMetadata("First Family"))
-    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    check findSystemTypefaceFile(["First Family"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
     writeFile(path, fontMetadata("Second Family"))
-    check findSystemTypefaceFile(["First Family"], [path]).path == path
-    check findSystemTypefaceFile(["Second Family"], [path]).path.len == 0
+    check findSystemTypefaceFile(["First Family"], [path]).isSome
+    check findSystemTypefaceFile(["Second Family"], [path]).isNone
     refreshSystemFontMetadata()
-    check findSystemTypefaceFile(["Second Family"], [path]).path == path
-    check findSystemTypefaceFile(["First Family"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Second Family"], [path]) ==
+      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypefaceFile(["First Family"], [path]).isNone
 
   test "caller directory precedence wins over alphabetical file order":
     let
@@ -223,9 +231,19 @@ suite "installed font metadata resolution":
     writeFile(systemFont, fontMetadata("Fixture Sans"))
     check findSystemTypefaceFile(
       ["Fixture Sans"], [userFont, systemFont], preserveInputOrder = true
-    ).path == userFont
+    ) == some(SystemTypefaceFile(path: userFont, faceIndex: 0))
 
   test "malformed metadata cannot fall back to the filename":
     let path = fixtureDir / "FixtureSans-Regular.ttf"
     writeFile(path, "invalid font data")
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
+
+  test "lightweight name metadata has a distinct result type":
+    let info = readTypefaceNameInfo(fontMetadata("Fixture Sans"))
+    check info.family == "Fixture Sans"
+    check info.faceIndex == 0
+    check info.regular
+
+  test "lightweight name metadata rejects a standalone nonzero face":
+    expect ValueError:
+      discard readTypefaceNameInfo(fontMetadata("Fixture Sans"), faceIndex = 1)

--- a/tests/tfontmetadata.nim
+++ b/tests/tfontmetadata.nim
@@ -102,15 +102,14 @@ suite "installed font metadata resolution":
   test "family metadata overrides an unrelated filename":
     let path = fixtureDir / "MisleadingName-Bold.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(["Fixture Sans"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
-    check findSystemTypefaceFile(["MisleadingName"], [path]).isNone
+    check findSystemTypeface(["Fixture Sans"], [path]) == some(initSystemTypeface(path))
+    check findSystemTypeface(["MisleadingName"], [path]).isNone
 
   test "related families cannot consume a regular family as a prefix":
     let path = fixtureDir / "regular.ttf"
     writeFile(path, fontMetadata("Fixture Sans"))
     for name in ["Fixture Sans CJK", "Fixture Sans Mono", "Fixture Sans Unknown"]:
-      check findSystemTypefaceFile([name], [path]).isNone
+      check findSystemTypeface([name], [path]).isNone
 
   test "unstyled family skips bold italic and oblique faces for the next fallback":
     let
@@ -129,9 +128,9 @@ suite "installed font metadata resolution":
       fontMetadata("Fixture Sans", "Oblique", 400, 512, fullName = "Fixture Sans"),
     )
     writeFile(fallback, fontMetadata("Other Sans"))
-    check findSystemTypefaceFile(
+    check findSystemTypeface(
       ["Fixture Sans", "Other Sans"], [bold, italic, oblique, fallback]
-    ) == some(SystemTypefaceFile(path: fallback, faceIndex: 0))
+    ) == some(initSystemTypeface(fallback))
 
   test "missing bold and italic styles preserve explicit fallback order":
     let
@@ -140,8 +139,8 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(fallback, fontMetadata("Other Sans"))
     for name in ["Fixture Sans Bold", "Fixture Sans Italic"]:
-      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]) ==
-        some(SystemTypefaceFile(path: fallback, faceIndex: 0))
+      check findSystemTypeface([name, "Other Sans"], [regular, fallback]) ==
+        some(initSystemTypeface(fallback))
 
   test "explicit styles use the matching face even with opaque filenames":
     let
@@ -151,10 +150,10 @@ suite "installed font metadata resolution":
     writeFile(regular, fontMetadata("Fixture Sans"))
     writeFile(bold, fontMetadata("Fixture Sans", "Bold", 700, 32))
     writeFile(italic, fontMetadata("Fixture Sans", "Italic", 400, 1))
-    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]) ==
-      some(SystemTypefaceFile(path: bold, faceIndex: 0))
-    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]) ==
-      some(SystemTypefaceFile(path: italic, faceIndex: 0))
+    check findSystemTypeface(["Fixture Sans Bold"], [regular, italic, bold]) ==
+      some(initSystemTypeface(bold))
+    check findSystemTypeface(["Fixture Sans Italic"], [regular, bold, italic]) ==
+      some(initSystemTypeface(italic))
 
   test "typographic family and subfamily retain semibold style":
     let path = fixtureDir / "font.ttf"
@@ -169,9 +168,9 @@ suite "installed font metadata resolution":
         typographicStyle = "SemiBold",
       ),
     )
-    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
+    check findSystemTypeface(["Fixture Sans SemiBold"], [path]) ==
+      some(initSystemTypeface(path))
+    check findSystemTypeface(["Fixture Sans"], [path]).isNone
 
   test "style words are matched exactly and combined styles require both traits":
     let path = fixtureDir / "bold.ttf"
@@ -179,22 +178,21 @@ suite "installed font metadata resolution":
     for name in [
       "Fixture Sans SemiBold", "Fixture Sans NotBold", "Fixture Sans Bold Italic"
     ]:
-      check findSystemTypefaceFile([name], [path]).isNone
+      check findSystemTypeface([name], [path]).isNone
 
   test "regional collection family names remain distinct":
     let path = fixtureDir / "regional.ttf"
     writeFile(path, fontMetadata("Fixture Sans CJK JP"))
-    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
-    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).isNone
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
+    check findSystemTypeface(["Fixture Sans CJK JP"], [path]) ==
+      some(initSystemTypeface(path))
+    check findSystemTypeface(["Fixture Sans CJK SC"], [path]).isNone
+    check findSystemTypeface(["Fixture Sans"], [path]).isNone
 
   test "Unicode family names remain distinct":
     let path = fixtureDir / "unicode.ttf"
     writeFile(path, fontMetadata("明朝"))
-    check findSystemTypefaceFile(["明朝"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
-    check findSystemTypefaceFile(["黑体"], [path]).isNone
+    check findSystemTypeface(["明朝"], [path]) == some(initSystemTypeface(path))
+    check findSystemTypeface(["黑体"], [path]).isNone
 
   test "matches in one directory do not depend on enumeration order":
     let
@@ -202,22 +200,22 @@ suite "installed font metadata resolution":
       second = fixtureDir / "z.ttf"
     writeFile(first, fontMetadata("Fixture Sans"))
     writeFile(second, fontMetadata("Fixture Sans"))
-    let expected = some(SystemTypefaceFile(path: first, faceIndex: 0))
-    check findSystemTypefaceFile(["Fixture Sans"], [first, second]) == expected
-    check findSystemTypefaceFile(["Fixture Sans"], [second, first]) == expected
+    let expected = some(initSystemTypeface(first))
+    check findSystemTypeface(["Fixture Sans"], [first, second]) == expected
+    check findSystemTypeface(["Fixture Sans"], [second, first]) == expected
 
   test "metadata is cached until explicit refresh":
     let path = fixtureDir / "font.ttf"
     writeFile(path, fontMetadata("First Family"))
-    check findSystemTypefaceFile(["First Family"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
+    check findSystemTypeface(["First Family"], [path]) == some(initSystemTypeface(path))
     writeFile(path, fontMetadata("Second Family"))
-    check findSystemTypefaceFile(["First Family"], [path]).isSome
-    check findSystemTypefaceFile(["Second Family"], [path]).isNone
+    check findSystemTypeface(["First Family"], [path]).isSome
+    check findSystemTypeface(["Second Family"], [path]).isNone
     refreshSystemFontMetadata()
-    check findSystemTypefaceFile(["Second Family"], [path]) ==
-      some(SystemTypefaceFile(path: path, faceIndex: 0))
-    check findSystemTypefaceFile(["First Family"], [path]).isNone
+    check findSystemTypeface(["Second Family"], [path]) == some(
+      initSystemTypeface(path)
+    )
+    check findSystemTypeface(["First Family"], [path]).isNone
 
   test "caller directory precedence wins over alphabetical file order":
     let
@@ -229,14 +227,14 @@ suite "installed font metadata resolution":
     createDir(systemDir)
     writeFile(userFont, fontMetadata("Fixture Sans"))
     writeFile(systemFont, fontMetadata("Fixture Sans"))
-    check findSystemTypefaceFile(
+    check findSystemTypeface(
       ["Fixture Sans"], [userFont, systemFont], preserveInputOrder = true
-    ) == some(SystemTypefaceFile(path: userFont, faceIndex: 0))
+    ) == some(initSystemTypeface(userFont))
 
   test "malformed metadata cannot fall back to the filename":
     let path = fixtureDir / "FixtureSans-Regular.ttf"
     writeFile(path, "invalid font data")
-    check findSystemTypefaceFile(["Fixture Sans"], [path]).isNone
+    check findSystemTypeface(["Fixture Sans"], [path]).isNone
 
   test "lightweight name metadata has a distinct result type":
     let info = readTypefaceNameInfo(fontMetadata("Fixture Sans"))

--- a/tests/tfontmetadata.nim
+++ b/tests/tfontmetadata.nim
@@ -1,0 +1,231 @@
+import std/[os, tempfiles, unicode, unittest]
+
+import figdraw/extras/systemfonts
+
+type NameEntry = tuple[id: int, text: string]
+
+proc putUint16(data: var string, offset, value: int) =
+  data[offset] = char((value shr 8) and 255)
+  data[offset + 1] = char(value and 255)
+
+proc putUint32(data: var string, offset, value: int) =
+  data.putUint16(offset, value shr 16)
+  data.putUint16(offset + 2, value and 65535)
+
+proc utf16(text: string): string =
+  for rune in text.runes:
+    let codepoint = rune.int
+    if codepoint <= 65535:
+      result.add char(codepoint shr 8)
+      result.add char(codepoint and 255)
+    else:
+      let
+        highSurrogate = 0xd800 + ((codepoint - 0x10000) shr 10)
+        lowSurrogate = 0xdc00 + ((codepoint - 0x10000) and 1023)
+      result.add char(highSurrogate shr 8)
+      result.add char(highSurrogate and 255)
+      result.add char(lowSurrogate shr 8)
+      result.add char(lowSurrogate and 255)
+
+proc fontMetadata(
+    family: string,
+    style = "Regular",
+    weight = 400,
+    selection = 64,
+    fullName = "",
+    typographicFamily = "",
+    typographicStyle = "",
+    monospace = false,
+): string =
+  ## Minimal SFNT metadata fixture; deliberately contains no glyph outlines.
+  var names: seq[NameEntry] = @[(1, family), (2, style)]
+  names.add(
+    (
+      4,
+      if fullName.len > 0:
+        fullName
+      else:
+        family & " " & style,
+    )
+  )
+  if typographicFamily.len > 0:
+    names.add((16, typographicFamily))
+  if typographicStyle.len > 0:
+    names.add((17, typographicStyle))
+
+  var nameTable = newString(6 + names.len * 12)
+  nameTable.putUint16(2, names.len)
+  nameTable.putUint16(4, nameTable.len)
+  var strings: string
+  for index, entry in names:
+    let
+      encoded = utf16(entry.text)
+      offset = 6 + index * 12
+    nameTable.putUint16(offset, 3)
+    nameTable.putUint16(offset + 2, 1)
+    nameTable.putUint16(offset + 4, 0x0409)
+    nameTable.putUint16(offset + 6, entry.id)
+    nameTable.putUint16(offset + 8, encoded.len)
+    nameTable.putUint16(offset + 10, strings.len)
+    strings.add encoded
+  nameTable.add strings
+
+  var
+    styleTable = newString(86)
+    postTable = newString(16)
+  styleTable.putUint16(4, weight)
+  styleTable.putUint16(6, 5)
+  styleTable.putUint16(62, selection)
+  postTable.putUint32(12, ord(monospace))
+  let tables = [("name", nameTable), ("OS/2", styleTable), ("post", postTable)]
+  result = newString(12 + tables.len * 16)
+  result.putUint32(0, 0x00010000)
+  result.putUint16(4, tables.len)
+  for index, table in tables:
+    let offset = 12 + index * 16
+    for tagIndex in 0 .. 3:
+      result[offset + tagIndex] = table[0][tagIndex]
+    result.putUint32(offset + 8, result.len)
+    result.putUint32(offset + 12, table[1].len)
+    result.add table[1]
+
+suite "installed font metadata resolution":
+  setup:
+    let fixtureDir = createTempDir("figdraw-font-metadata-", "")
+    refreshSystemFontMetadata()
+
+  teardown:
+    refreshSystemFontMetadata()
+    removeDir(fixtureDir)
+
+  test "family metadata overrides an unrelated filename":
+    let path = fixtureDir / "MisleadingName-Bold.ttf"
+    writeFile(path, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path == path
+    check findSystemTypefaceFile(["MisleadingName"], [path]).path.len == 0
+
+  test "related families cannot consume a regular family as a prefix":
+    let path = fixtureDir / "regular.ttf"
+    writeFile(path, fontMetadata("Fixture Sans"))
+    for name in ["Fixture Sans CJK", "Fixture Sans Mono", "Fixture Sans Unknown"]:
+      check findSystemTypefaceFile([name], [path]).path.len == 0
+
+  test "unstyled family skips bold italic and oblique faces for the next fallback":
+    let
+      bold = fixtureDir / "bold.ttf"
+      italic = fixtureDir / "italic.ttf"
+      oblique = fixtureDir / "oblique.ttf"
+      fallback = fixtureDir / "fallback.ttf"
+    writeFile(
+      bold, fontMetadata("Fixture Sans", "Bold", 700, 32, fullName = "Fixture Sans")
+    )
+    writeFile(
+      italic, fontMetadata("Fixture Sans", "Italic", 400, 1, fullName = "Fixture Sans")
+    )
+    writeFile(
+      oblique,
+      fontMetadata("Fixture Sans", "Oblique", 400, 512, fullName = "Fixture Sans"),
+    )
+    writeFile(fallback, fontMetadata("Other Sans"))
+    check findSystemTypefaceFile(
+      ["Fixture Sans", "Other Sans"], [bold, italic, oblique, fallback]
+    ).path == fallback
+
+  test "missing bold and italic styles preserve explicit fallback order":
+    let
+      regular = fixtureDir / "regular.ttf"
+      fallback = fixtureDir / "fallback.ttf"
+    writeFile(regular, fontMetadata("Fixture Sans"))
+    writeFile(fallback, fontMetadata("Other Sans"))
+    for name in ["Fixture Sans Bold", "Fixture Sans Italic"]:
+      check findSystemTypefaceFile([name, "Other Sans"], [regular, fallback]).path ==
+        fallback
+
+  test "explicit styles use the matching face even with opaque filenames":
+    let
+      regular = fixtureDir / "font-a.ttf"
+      bold = fixtureDir / "font-b.ttf"
+      italic = fixtureDir / "font-c.ttf"
+    writeFile(regular, fontMetadata("Fixture Sans"))
+    writeFile(bold, fontMetadata("Fixture Sans", "Bold", 700, 32))
+    writeFile(italic, fontMetadata("Fixture Sans", "Italic", 400, 1))
+    check findSystemTypefaceFile(["Fixture Sans Bold"], [regular, italic, bold]).path ==
+      bold
+    check findSystemTypefaceFile(["Fixture Sans Italic"], [regular, bold, italic]).path ==
+      italic
+
+  test "typographic family and subfamily retain semibold style":
+    let path = fixtureDir / "font.ttf"
+    writeFile(
+      path,
+      fontMetadata(
+        "Fixture Sans SemiBold",
+        "Regular",
+        600,
+        64,
+        typographicFamily = "Fixture Sans",
+        typographicStyle = "SemiBold",
+      ),
+    )
+    check findSystemTypefaceFile(["Fixture Sans SemiBold"], [path]).path == path
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+
+  test "style words are matched exactly and combined styles require both traits":
+    let path = fixtureDir / "bold.ttf"
+    writeFile(path, fontMetadata("Fixture Sans", "Bold", 700, 32))
+    for name in [
+      "Fixture Sans SemiBold", "Fixture Sans NotBold", "Fixture Sans Bold Italic"
+    ]:
+      check findSystemTypefaceFile([name], [path]).path.len == 0
+
+  test "regional collection family names remain distinct":
+    let path = fixtureDir / "regional.ttf"
+    writeFile(path, fontMetadata("Fixture Sans CJK JP"))
+    check findSystemTypefaceFile(["Fixture Sans CJK JP"], [path]).path == path
+    check findSystemTypefaceFile(["Fixture Sans CJK SC"], [path]).path.len == 0
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0
+
+  test "Unicode family names remain distinct":
+    let path = fixtureDir / "unicode.ttf"
+    writeFile(path, fontMetadata("明朝"))
+    check findSystemTypefaceFile(["明朝"], [path]).path == path
+    check findSystemTypefaceFile(["黑体"], [path]).path.len == 0
+
+  test "matches in one directory do not depend on enumeration order":
+    let
+      first = fixtureDir / "a.ttf"
+      second = fixtureDir / "z.ttf"
+    writeFile(first, fontMetadata("Fixture Sans"))
+    writeFile(second, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(["Fixture Sans"], [first, second]).path == first
+    check findSystemTypefaceFile(["Fixture Sans"], [second, first]).path == first
+
+  test "metadata is cached until explicit refresh":
+    let path = fixtureDir / "font.ttf"
+    writeFile(path, fontMetadata("First Family"))
+    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    writeFile(path, fontMetadata("Second Family"))
+    check findSystemTypefaceFile(["First Family"], [path]).path == path
+    check findSystemTypefaceFile(["Second Family"], [path]).path.len == 0
+    refreshSystemFontMetadata()
+    check findSystemTypefaceFile(["Second Family"], [path]).path == path
+    check findSystemTypefaceFile(["First Family"], [path]).path.len == 0
+
+  test "caller directory precedence wins over alphabetical file order":
+    let
+      userDir = fixtureDir / "user"
+      systemDir = fixtureDir / "system"
+      userFont = userDir / "z.ttf"
+      systemFont = systemDir / "a.ttf"
+    createDir(userDir)
+    createDir(systemDir)
+    writeFile(userFont, fontMetadata("Fixture Sans"))
+    writeFile(systemFont, fontMetadata("Fixture Sans"))
+    check findSystemTypefaceFile(
+      ["Fixture Sans"], [userFont, systemFont], preserveInputOrder = true
+    ).path == userFont
+
+  test "malformed metadata cannot fall back to the filename":
+    let path = fixtureDir / "FixtureSans-Regular.ttf"
+    writeFile(path, "invalid font data")
+    check findSystemTypefaceFile(["Fixture Sans"], [path]).path.len == 0

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -264,9 +264,9 @@ suite "fontutils":
     writeFile(collectionPath, collectionData)
     refreshSystemFontMetadata()
 
-    let systemTypeface = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    let systemTypeface = findSystemTypeface(["PT Sans"], [collectionPath])
     require systemTypeface.isSome
-    let resolvedTypefaceId = loadTypeface(systemTypeface.get())
+    let resolvedTypefaceId = loadTypeface(systemTypeface.get().file)
     let resolvedInfo = getTypefaceInfo(resolvedTypefaceId)
     check getTypefaceSource(resolvedTypefaceId).faceIndex == 1
     check resolvedInfo.family == "PT Sans"
@@ -287,6 +287,18 @@ suite "fontutils":
       require image != nil
       check image.opaqueBounds().w > 0
       check image.opaqueBounds().h > 0
+
+  test "exact system typeface applies variable coordinates to its font":
+    let
+      path = getCurrentDir() / "examples/fonts/NotoNaskhArabic-wght.ttf"
+      typeface =
+        initSystemTypeface(path, variations = [fontVariation("wght", 650.0'f32)])
+      font = typeface.fontWithSize(18.0'f32)
+      source = getTypefaceSource(font.typefaceId)
+    check source.name == path
+    check source.faceIndex == 0
+    check font.size == 18.0'f32
+    check font.variations == typeface.variations
 
   test "unknown typeface metadata lookup raises ValueError":
     expect ValueError:

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -249,45 +249,12 @@ suite "fontutils":
     check not info.bold
     check not info.italic
 
-  test "named system-family lookup selects metadata face in a renamed collection":
+  test "system typeface result loads the selected collection face":
     let
-      tempDir = createTempDir("figdraw-named-system-font-test-", "")
+      tempDir = createTempDir("figdraw-system-font-test-", "")
       sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
-    var fontDir: string
-    when defined(windows):
-      let
-        oldLocalAppData = getEnv("LOCALAPPDATA", "")
-        hadLocalAppData = existsEnv("LOCALAPPDATA")
-      fontDir = tempDir / "Microsoft" / "Windows" / "Fonts"
-    elif defined(macosx):
-      let
-        oldHome = getEnv("HOME", "")
-        hadHome = existsEnv("HOME")
-      fontDir = tempDir / "Library" / "Fonts"
-    else:
-      let
-        oldXdgDataHome = getEnv("XDG_DATA_HOME", "")
-        hadXdgDataHome = existsEnv("XDG_DATA_HOME")
-      fontDir = tempDir / "fonts"
-    let collectionPath = fontDir / "unrelated-name.otc"
-    if not dirExists(fontDir):
-      createDir(fontDir)
+      collectionPath = tempDir / "unrelated-name.otc"
     defer:
-      when defined(windows):
-        if hadLocalAppData:
-          putEnv("LOCALAPPDATA", oldLocalAppData)
-        else:
-          delEnv("LOCALAPPDATA")
-      elif defined(macosx):
-        if hadHome:
-          putEnv("HOME", oldHome)
-        else:
-          delEnv("HOME")
-      else:
-        if hadXdgDataHome:
-          putEnv("XDG_DATA_HOME", oldXdgDataHome)
-        else:
-          delEnv("XDG_DATA_HOME")
       refreshSystemFontMetadata()
       if dirExists(tempDir):
         removeDir(tempDir)
@@ -295,12 +262,6 @@ suite "fontutils":
     var collectionData = readFile(sourcePath)
     collectionData.swapTtcFaceOffsets(0, 1)
     writeFile(collectionPath, collectionData)
-    when defined(windows):
-      putEnv("LOCALAPPDATA", tempDir)
-    elif defined(macosx):
-      putEnv("HOME", tempDir)
-    else:
-      putEnv("XDG_DATA_HOME", tempDir)
     refreshSystemFontMetadata()
 
     let systemTypeface = findSystemTypefaceFile(["PT Sans"], [collectionPath])
@@ -311,24 +272,16 @@ suite "fontutils":
     check resolvedInfo.family == "PT Sans"
     check resolvedInfo.regular
 
-    let typefaceId = loadTypeface("PT Sans")
-    let info = getTypefaceInfo(typefaceId)
-    check typefaceId == resolvedTypefaceId
-    check getTypefaceSource(typefaceId).name == collectionPath
-    check getTypefaceSource(typefaceId).faceIndex == 1
-    check info.family == "PT Sans"
-    check info.regular
-
     let arrangement = typeset(
       rect(0, 0, 120, 50),
-      FigFont(typefaceId: typefaceId, size: 24.0'f32),
+      FigFont(typefaceId: resolvedTypefaceId, size: 24.0'f32),
       "A",
       minContent = false,
       wrap = false,
     )
     require arrangement.arrangedGlyphs.len == 1
     for glyph in arrangement.glyphs():
-      check getFigFont(glyph.fontId).typefaceId == typefaceId
+      check getFigFont(glyph.fontId).typefaceId == resolvedTypefaceId
       check glyph.glyphId != FontGlyphId(0)
       let image = glyph.generateGlyph(force = true, upload = false)
       require image != nil

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,4 +1,4 @@
-import std/[hashes, os, tables, unicode, unittest]
+import std/[hashes, os, tables, tempfiles, unicode, unittest]
 
 import pkg/pixie
 import pkg/pixie/fonts
@@ -245,8 +245,86 @@ suite "fontutils":
     check getTypefaceSource(typefaceId).faceIndex == 1
     check info.family == "PT Sans"
     check info.regular
+
     check not info.bold
     check not info.italic
+
+  test "named system-family lookup selects metadata face in a renamed collection":
+    let
+      tempDir = createTempDir("figdraw-named-system-font-test-", "")
+      sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
+    var fontDir: string
+    when defined(windows):
+      let
+        oldLocalAppData = getEnv("LOCALAPPDATA", "")
+        hadLocalAppData = existsEnv("LOCALAPPDATA")
+      fontDir = tempDir / "Microsoft" / "Windows" / "Fonts"
+    elif defined(macosx):
+      let
+        oldHome = getEnv("HOME", "")
+        hadHome = existsEnv("HOME")
+      fontDir = tempDir / "Library" / "Fonts"
+    else:
+      let
+        oldXdgDataHome = getEnv("XDG_DATA_HOME", "")
+        hadXdgDataHome = existsEnv("XDG_DATA_HOME")
+      fontDir = tempDir / "fonts"
+    let collectionPath = fontDir / "unrelated-name.otc"
+    if not dirExists(fontDir):
+      createDir(fontDir)
+    defer:
+      when defined(windows):
+        if hadLocalAppData:
+          putEnv("LOCALAPPDATA", oldLocalAppData)
+        else:
+          delEnv("LOCALAPPDATA")
+      elif defined(macosx):
+        if hadHome:
+          putEnv("HOME", oldHome)
+        else:
+          delEnv("HOME")
+      else:
+        if hadXdgDataHome:
+          putEnv("XDG_DATA_HOME", oldXdgDataHome)
+        else:
+          delEnv("XDG_DATA_HOME")
+      refreshSystemFontMetadata()
+      if dirExists(tempDir):
+        removeDir(tempDir)
+
+    var collectionData = readFile(sourcePath)
+    collectionData.swapTtcFaceOffsets(0, 1)
+    writeFile(collectionPath, collectionData)
+    when defined(windows):
+      putEnv("LOCALAPPDATA", tempDir)
+    elif defined(macosx):
+      putEnv("HOME", tempDir)
+    else:
+      putEnv("XDG_DATA_HOME", tempDir)
+    refreshSystemFontMetadata()
+
+    let typefaceId = loadTypeface("PT Sans")
+    let info = getTypefaceInfo(typefaceId)
+    check getTypefaceSource(typefaceId).name == collectionPath
+    check getTypefaceSource(typefaceId).faceIndex == 1
+    check info.family == "PT Sans"
+    check info.regular
+
+    let arrangement = typeset(
+      rect(0, 0, 120, 50),
+      FigFont(typefaceId: typefaceId, size: 24.0'f32),
+      "A",
+      minContent = false,
+      wrap = false,
+    )
+    require arrangement.arrangedGlyphs.len == 1
+    for glyph in arrangement.glyphs():
+      check getFigFont(glyph.fontId).typefaceId == typefaceId
+      check glyph.glyphId != FontGlyphId(0)
+      let image = glyph.generateGlyph(force = true, upload = false)
+      require image != nil
+      check image.opaqueBounds().w > 0
+      check image.opaqueBounds().h > 0
 
   test "unknown typeface metadata lookup raises ValueError":
     expect ValueError:

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,4 +1,4 @@
-import std/[hashes, os, tables, tempfiles, unicode, unittest]
+import std/[hashes, options, os, tables, tempfiles, unicode, unittest]
 
 import pkg/pixie
 import pkg/pixie/fonts
@@ -303,8 +303,17 @@ suite "fontutils":
       putEnv("XDG_DATA_HOME", tempDir)
     refreshSystemFontMetadata()
 
+    let systemTypeface = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    require systemTypeface.isSome
+    let resolvedTypefaceId = loadTypeface(systemTypeface.get())
+    let resolvedInfo = getTypefaceInfo(resolvedTypefaceId)
+    check getTypefaceSource(resolvedTypefaceId).faceIndex == 1
+    check resolvedInfo.family == "PT Sans"
+    check resolvedInfo.regular
+
     let typefaceId = loadTypeface("PT Sans")
     let info = getTypefaceInfo(typefaceId)
+    check typefaceId == resolvedTypefaceId
     check getTypefaceSource(typefaceId).name == collectionPath
     check getTypefaceSource(typefaceId).faceIndex == 1
     check info.family == "PT Sans"

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -1,17 +1,40 @@
-import std/[options, os, sets, strutils, unittest]
+import std/[math, options, os, sets, strutils, unittest]
 
 import figdraw/common/fonttypes
 
 when defined(useNativeDynlib):
   import figdraw/dynlib
   from figdraw/extras/systemfonts import
-    systemDefaultFontNames, findSystemFontFile, findSystemTypefaceFile,
+    systemDefaultFontNames, findSystemFontFile, findSystemTypeface,
     refreshSystemFontMetadata, fontNameMatchScore, systemTypefaces, SystemTypefaceQuery,
-    sfrMono
+    SystemTypeface, sfrMono
 else:
   import figdraw
 
 suite "system fonts":
+  test "exact typeface identities canonicalize and validate variation axes":
+    let
+      file = initSystemTypefaceFile("/fonts/Variable.ttf", 2)
+      first = initSystemTypeface(
+        file, [fontVariation("wght", 700.0'f32), fontVariation("ital", 1.0'f32)]
+      )
+      second = initSystemTypeface(
+        file, [fontVariation("ital", 1.0'f32), fontVariation("wght", 700.0'f32)]
+      )
+    check first == second
+    check first.file == file
+    check first.variations[0].tag == "ital"
+    check first.variations[1].tag == "wght"
+
+    expect ValueError:
+      discard initSystemTypeface(file, [fontVariation("weight", 700.0'f32)])
+    expect ValueError:
+      discard initSystemTypeface(
+        file, [fontVariation("wght", 600.0'f32), fontVariation("wght", 700.0'f32)]
+      )
+    expect ValueError:
+      discard initSystemTypeface(file, [fontVariation("wght", NaN.float32)])
+
   test "platform default font names are listed by role":
     let
       sans = systemDefaultFontNames()
@@ -43,15 +66,14 @@ suite "system fonts":
 
   test "system typeface iterator returns unique readable face identities":
     var
-      identities = initHashSet[(string, int)]()
+      identities = initHashSet[SystemTypeface]()
       count = 0
     for info in systemTypefaces():
-      let identity = (info.file.path, info.file.faceIndex)
-      check info.file.path.isAbsolute()
-      check info.file.path.fileExists()
-      check info.file.faceIndex >= 0
-      check identity notin identities
-      identities.incl(identity)
+      check info.typeface.file.path.isAbsolute()
+      check info.typeface.file.path.fileExists()
+      check info.typeface.file.faceIndex >= 0
+      check info.typeface notin identities
+      identities.incl(info.typeface)
       inc count
     check count > 0
 
@@ -156,10 +178,10 @@ suite "system fonts":
     writeFile(collectionPath, data)
     refreshSystemFontMetadata()
 
-    let match = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    let match = findSystemTypeface(["PT Sans"], [collectionPath])
     require match.isSome
-    check match.get().path == collectionPath
-    check match.get().faceIndex == 1
+    check match.get().file.path == collectionPath
+    check match.get().file.faceIndex == 1
 
   test "regional family aliases resolve their base collection":
     check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -1,4 +1,4 @@
-import std/[os, strutils, unittest]
+import std/[options, os, strutils, unittest]
 
 import figdraw/common/fonttypes
 
@@ -99,8 +99,9 @@ suite "system fonts":
     refreshSystemFontMetadata()
 
     let match = findSystemTypefaceFile(["PT Sans"], [collectionPath])
-    check match.path == collectionPath
-    check match.faceIndex == 1
+    require match.isSome
+    check match.get().path == collectionPath
+    check match.get().faceIndex == 1
 
   test "regional family aliases resolve their base collection":
     check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -5,7 +5,8 @@ import figdraw/common/fonttypes
 when defined(useNativeDynlib):
   import figdraw/dynlib
   from figdraw/extras/systemfonts import
-    systemDefaultFontNames, findSystemFontFile, sfrMono
+    systemDefaultFontNames, findSystemFontFile, findSystemTypefaceFile,
+    refreshSystemFontMetadata, fontNameMatchScore, sfrMono
 else:
   import figdraw
 
@@ -37,7 +38,7 @@ suite "system fonts":
     let fonts = systemFontFiles()
     check fonts.len > 0
     for font in fonts:
-      check font.splitFile.ext.toLowerAscii() in supportedFontFileExtensions()
+      check font.splitFile.ext.toLowerAscii() in fonttypes.supportedFontFileExtensions()
 
   test "family lookup rejects related and styled font filenames":
     let font = findSystemFontFile(
@@ -76,6 +77,30 @@ suite "system fonts":
   test "collection face scoring excludes bold before a regular face":
     check fontNameMatchScore("PT Sans", "PT Sans Bold") == -1
     check fontNameMatchScore("PT Sans", "PT Sans Regular") == 1
+
+  test "OpenType metadata selects a regular collection face independent of filename":
+    let
+      tempDir = getTempDir() / "figdraw-system-font-metadata-test"
+      sourcePath = getCurrentDir() / "deps/pixie/tests/fonts/PTSans.ttc"
+      collectionPath = tempDir / "unrelated-name.ttc"
+    if not dirExists(tempDir):
+      createDir(tempDir)
+    defer:
+      refreshSystemFontMetadata()
+      if dirExists(tempDir):
+        removeDir(tempDir)
+
+    var data = readFile(sourcePath)
+    swap(data[12], data[16])
+    swap(data[13], data[17])
+    swap(data[14], data[18])
+    swap(data[15], data[19])
+    writeFile(collectionPath, data)
+    refreshSystemFontMetadata()
+
+    let match = findSystemTypefaceFile(["PT Sans"], [collectionPath])
+    check match.path == collectionPath
+    check match.faceIndex == 1
 
   test "regional family aliases resolve their base collection":
     check findSystemFontFile(["PingFang SC"], ["/fonts/PingFang.ttc"]) ==

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -1,4 +1,4 @@
-import std/[options, os, strutils, unittest]
+import std/[options, os, sets, strutils, unittest]
 
 import figdraw/common/fonttypes
 
@@ -6,7 +6,8 @@ when defined(useNativeDynlib):
   import figdraw/dynlib
   from figdraw/extras/systemfonts import
     systemDefaultFontNames, findSystemFontFile, findSystemTypefaceFile,
-    refreshSystemFontMetadata, fontNameMatchScore, sfrMono
+    refreshSystemFontMetadata, fontNameMatchScore, systemTypefaces, SystemTypefaceQuery,
+    sfrMono
 else:
   import figdraw
 
@@ -39,6 +40,46 @@ suite "system fonts":
     check fonts.len > 0
     for font in fonts:
       check font.splitFile.ext.toLowerAscii() in fonttypes.supportedFontFileExtensions()
+
+  test "system typeface iterator returns unique readable face identities":
+    var
+      identities = initHashSet[(string, int)]()
+      count = 0
+    for info in systemTypefaces():
+      let identity = (info.file.path, info.file.faceIndex)
+      check info.file.path.isAbsolute()
+      check info.file.path.fileExists()
+      check info.file.faceIndex >= 0
+      check identity notin identities
+      identities.incl(identity)
+      inc count
+    check count > 0
+
+  test "system typeface queries are strict filters":
+    var family: string
+    for info in systemTypefaces():
+      if info.family.len > 0 and info.subfamily.len > 0:
+        family = info.family
+        break
+    require family.len > 0
+
+    var matchingCount = 0
+    for info in systemTypefaces(SystemTypefaceQuery(family: family.toUpperAscii())):
+      check info.family.toLowerAscii() == family.toLowerAscii()
+      inc matchingCount
+    check matchingCount > 0
+
+    for info in systemTypefaces(
+      SystemTypefaceQuery(family: "FigDraw Missing Font 2D601F0A")
+    ):
+      discard info
+      check false
+
+  test "system typeface iterator does not swallow consumer exceptions":
+    expect ValueError:
+      for info in systemTypefaces():
+        discard info
+        raise newException(ValueError, "consumer exception")
 
   test "family lookup rejects related and styled font filenames":
     let font = findSystemFontFile(

--- a/tests/tsystemfonts.nim
+++ b/tests/tsystemfonts.nim
@@ -56,10 +56,15 @@ suite "system fonts":
     check count > 0
 
   test "system typeface queries are strict filters":
-    var family: string
+    var
+      family: string
+      subfamily: string
     for info in systemTypefaces():
-      if info.family.len > 0 and info.subfamily.len > 0:
+      if info.family.len > 0 and info.subfamily.len > 0 and
+          info.family.allCharsInSet({'\x20' .. '\x7e'}) and
+          info.subfamily.allCharsInSet({'\x20' .. '\x7e'}):
         family = info.family
+        subfamily = info.subfamily
         break
     require family.len > 0
 
@@ -68,6 +73,18 @@ suite "system fonts":
       check info.family.toLowerAscii() == family.toLowerAscii()
       inc matchingCount
     check matchingCount > 0
+
+    var styleMatchingCount = 0
+    for info in systemTypefaces(
+      SystemTypefaceQuery(
+        family: "-" & family.replace(" ", "_") & ".",
+        subfamily: "-" & subfamily.replace(" ", "_") & ".",
+      )
+    ):
+      check info.family.toLowerAscii() == family.toLowerAscii()
+      check info.subfamily.toLowerAscii() == subfamily.toLowerAscii()
+      inc styleMatchingCount
+    check styleMatchingCount > 0
 
     for info in systemTypefaces(
       SystemTypefaceQuery(family: "FigDraw Missing Font 2D601F0A")

--- a/tests/tsystemfonts_fontconfig.nim
+++ b/tests/tsystemfonts_fontconfig.nim
@@ -1,4 +1,4 @@
-import std/[options, os, unittest]
+import std/[options, os, sets, unittest]
 
 when defined(linux) or defined(freebsd):
   from figdraw/common/typefaceinfos import readTypefaceNameInfo
@@ -41,6 +41,19 @@ when defined(linux) or defined(freebsd):
       )
       check result.available
       check result.match.isNone
+
+    test "enumerates unique locally readable faces":
+      var
+        available = false
+        identities = initHashSet[(string, int)]()
+      for info in nativeSystemTypefaces(available):
+        let identity = (info.file.path, info.file.faceIndex)
+        check info.file.path.isAbsolute()
+        check info.file.path.fileExists()
+        check identity notin identities
+        identities.incl(identity)
+      check available
+      check identities.len > 0
 else:
   suite "Fontconfig system-font provider":
     test "is only exercised on Fontconfig platforms":

--- a/tests/tsystemfonts_fontconfig.nim
+++ b/tests/tsystemfonts_fontconfig.nim
@@ -2,22 +2,23 @@ import std/[options, os, sets, unittest]
 
 when defined(linux) or defined(freebsd):
   from figdraw/common/typefaceinfos import readTypefaceNameInfo
+  from figdraw/extras/systemfonttypes import SystemTypeface
   import figdraw/extras/systemfonts_fontconfig
 
   suite "Fontconfig system-font provider":
     test "returns a local regular face with an exact face index":
-      let result = findNativeSystemTypefaceFile(
+      let result = findNativeSystemTypeface(
         ["DejaVu Sans", "Noto Sans", "Liberation Sans", "Ubuntu"]
       )
       check result.available
       require result.match.isSome
       let match = result.match.get()
-      check match.path.isAbsolute()
-      check match.path.fileExists()
-      check match.faceIndex >= 0
+      check match.file.path.isAbsolute()
+      check match.file.path.fileExists()
+      check match.file.faceIndex >= 0
 
     test "respects candidate fallback order":
-      let result = findNativeSystemTypefaceFile(
+      let result = findNativeSystemTypeface(
         [
           "FigDraw Font That Cannot Possibly Be Installed 3A916EC4", "DejaVu Sans",
           "Noto Sans", "Liberation Sans", "Ubuntu",
@@ -27,16 +28,18 @@ when defined(linux) or defined(freebsd):
       check result.match.isSome
 
     test "returns the requested explicit style":
-      let result = findNativeSystemTypefaceFile(
+      let result = findNativeSystemTypeface(
         ["DejaVu Sans Bold", "Noto Sans Bold", "Liberation Sans Bold"]
       )
       check result.available
       require result.match.isSome
       let match = result.match.get()
-      check readTypefaceNameInfo(readFile(match.path), Natural(match.faceIndex)).bold
+      check readTypefaceNameInfo(
+        readFile(match.file.path), Natural(match.file.faceIndex)
+      ).bold
 
     test "rejects Fontconfig's closest match":
-      let result = findNativeSystemTypefaceFile(
+      let result = findNativeSystemTypeface(
         ["FigDraw Font That Cannot Possibly Be Installed 9E548A3C"]
       )
       check result.available
@@ -45,13 +48,12 @@ when defined(linux) or defined(freebsd):
     test "enumerates unique locally readable faces":
       var
         available = false
-        identities = initHashSet[(string, int)]()
+        identities = initHashSet[SystemTypeface]()
       for info in nativeSystemTypefaces(available):
-        let identity = (info.file.path, info.file.faceIndex)
-        check info.file.path.isAbsolute()
-        check info.file.path.fileExists()
-        check identity notin identities
-        identities.incl(identity)
+        check info.typeface.file.path.isAbsolute()
+        check info.typeface.file.path.fileExists()
+        check info.typeface notin identities
+        identities.incl(info.typeface)
       check available
       check identities.len > 0
 else:

--- a/tests/tsystemfonts_fontconfig.nim
+++ b/tests/tsystemfonts_fontconfig.nim
@@ -1,0 +1,47 @@
+import std/[options, os, unittest]
+
+when defined(linux) or defined(freebsd):
+  from figdraw/common/typefaceinfos import readTypefaceNameInfo
+  import figdraw/extras/systemfonts_fontconfig
+
+  suite "Fontconfig system-font provider":
+    test "returns a local regular face with an exact face index":
+      let result = findNativeSystemTypefaceFile(
+        ["DejaVu Sans", "Noto Sans", "Liberation Sans", "Ubuntu"]
+      )
+      check result.available
+      require result.match.isSome
+      let match = result.match.get()
+      check match.path.isAbsolute()
+      check match.path.fileExists()
+      check match.faceIndex >= 0
+
+    test "respects candidate fallback order":
+      let result = findNativeSystemTypefaceFile(
+        [
+          "FigDraw Font That Cannot Possibly Be Installed 3A916EC4", "DejaVu Sans",
+          "Noto Sans", "Liberation Sans", "Ubuntu",
+        ]
+      )
+      check result.available
+      check result.match.isSome
+
+    test "returns the requested explicit style":
+      let result = findNativeSystemTypefaceFile(
+        ["DejaVu Sans Bold", "Noto Sans Bold", "Liberation Sans Bold"]
+      )
+      check result.available
+      require result.match.isSome
+      let match = result.match.get()
+      check readTypefaceNameInfo(readFile(match.path), Natural(match.faceIndex)).bold
+
+    test "rejects Fontconfig's closest match":
+      let result = findNativeSystemTypefaceFile(
+        ["FigDraw Font That Cannot Possibly Be Installed 9E548A3C"]
+      )
+      check result.available
+      check result.match.isNone
+else:
+  suite "Fontconfig system-font provider":
+    test "is only exercised on Fontconfig platforms":
+      check true

--- a/tests/tsystemfonts_macos.nim
+++ b/tests/tsystemfonts_macos.nim
@@ -1,0 +1,35 @@
+import std/[options, os, unittest]
+
+when defined(macosx):
+  from figdraw/common/typefaceinfos import readTypefaceNameInfo
+  import figdraw/extras/systemfonts_macos
+
+  suite "Core Text system-font provider":
+    test "returns a local regular face with an exact face index":
+      let result = findNativeSystemTypefaceFile(["Helvetica"])
+      check result.available
+      require result.match.isSome
+      let match = result.match.get()
+      check match.path.fileExists()
+      check match.faceIndex >= 0
+
+    test "supports explicit full names and candidate fallback":
+      let explicitFace = findNativeSystemTypefaceFile(["Helvetica Bold"])
+      check explicitFace.available
+      require explicitFace.match.isSome
+      let boldMatch = explicitFace.match.get()
+      check readTypefaceNameInfo(readFile(boldMatch.path), Natural(boldMatch.faceIndex)).bold
+
+      let fallback =
+        findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4", "Helvetica"])
+      check fallback.available
+      check fallback.match.isSome
+
+    test "does not accept an unrelated Core Text fallback":
+      let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
+      check result.available
+      check result.match.isNone
+else:
+  suite "Core Text system-font provider":
+    test "is only exercised on macOS":
+      check true

--- a/tests/tsystemfonts_macos.nim
+++ b/tests/tsystemfonts_macos.nim
@@ -34,13 +34,20 @@ when defined(macosx):
       var
         available = false
         identities = initHashSet[(string, int)]()
+        checkedCollectionFace = false
       for info in nativeSystemTypefaces(available):
         let identity = (info.file.path, info.file.faceIndex)
         check info.file.path.fileExists()
         check identity notin identities
         identities.incl(identity)
+        if not checkedCollectionFace and info.file.faceIndex > 0:
+          let parsed =
+            readTypefaceNameInfo(readFile(info.file.path), Natural(info.file.faceIndex))
+          check parsed.postScriptName == info.postScriptName
+          checkedCollectionFace = true
       check available
       check identities.len > 0
+      check checkedCollectionFace
 else:
   suite "Core Text system-font provider":
     test "is only exercised on macOS":

--- a/tests/tsystemfonts_macos.nim
+++ b/tests/tsystemfonts_macos.nim
@@ -2,52 +2,70 @@ import std/[options, os, sets, unittest]
 
 when defined(macosx):
   from figdraw/common/typefaceinfos import readTypefaceNameInfo
+  from figdraw/extras/systemfonttypes import SystemTypeface, SystemTypefaceInfo
   import figdraw/extras/systemfonts_macos
 
   suite "Core Text system-font provider":
     test "returns a local regular face with an exact face index":
-      let result = findNativeSystemTypefaceFile(["Helvetica"])
+      let result = findNativeSystemTypeface(["Helvetica"])
       check result.available
       require result.match.isSome
       let match = result.match.get()
-      check match.path.fileExists()
-      check match.faceIndex >= 0
+      check match.file.path.fileExists()
+      check match.file.faceIndex >= 0
 
     test "supports explicit full names and candidate fallback":
-      let explicitFace = findNativeSystemTypefaceFile(["Helvetica Bold"])
+      let explicitFace = findNativeSystemTypeface(["Helvetica Bold"])
       check explicitFace.available
       require explicitFace.match.isSome
       let boldMatch = explicitFace.match.get()
-      check readTypefaceNameInfo(readFile(boldMatch.path), Natural(boldMatch.faceIndex)).bold
+      check readTypefaceNameInfo(
+        readFile(boldMatch.file.path), Natural(boldMatch.file.faceIndex)
+      ).bold
 
       let fallback =
-        findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4", "Helvetica"])
+        findNativeSystemTypeface(["FigDraw Missing Font 8E5269A4", "Helvetica"])
       check fallback.available
       check fallback.match.isSome
 
     test "does not accept an unrelated Core Text fallback":
-      let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
+      let result = findNativeSystemTypeface(["FigDraw Missing Font 8E5269A4"])
       check result.available
       check result.match.isNone
 
     test "enumerates owned local faces with unique identities":
       var
         available = false
-        identities = initHashSet[(string, int)]()
+        identities = initHashSet[SystemTypeface]()
         checkedCollectionFace = false
       for info in nativeSystemTypefaces(available):
-        let identity = (info.file.path, info.file.faceIndex)
-        check info.file.path.fileExists()
-        check identity notin identities
-        identities.incl(identity)
-        if not checkedCollectionFace and info.file.faceIndex > 0:
-          let parsed =
-            readTypefaceNameInfo(readFile(info.file.path), Natural(info.file.faceIndex))
+        check info.typeface.file.path.fileExists()
+        check info.typeface notin identities
+        identities.incl(info.typeface)
+        if not checkedCollectionFace and info.typeface.file.faceIndex > 0:
+          let parsed = readTypefaceNameInfo(
+            readFile(info.typeface.file.path), Natural(info.typeface.file.faceIndex)
+          )
           check parsed.postScriptName == info.postScriptName
           checkedCollectionFace = true
       check available
       check identities.len > 0
       check checkedCollectionFace
+
+    test "named variable instances round-trip through exact lookup":
+      var
+        available = false
+        namedInstance: SystemTypefaceInfo
+      for info in nativeSystemTypefaces(available):
+        if info.typeface.variations.len > 0 and info.postScriptName.len > 0:
+          namedInstance = info
+          break
+      check available
+      if namedInstance.postScriptName.len > 0:
+        let result = findNativeSystemTypeface([namedInstance.postScriptName])
+        check result.available
+        require result.match.isSome
+        check result.match.get() == namedInstance.typeface
 else:
   suite "Core Text system-font provider":
     test "is only exercised on macOS":

--- a/tests/tsystemfonts_macos.nim
+++ b/tests/tsystemfonts_macos.nim
@@ -1,4 +1,4 @@
-import std/[options, os, unittest]
+import std/[options, os, sets, unittest]
 
 when defined(macosx):
   from figdraw/common/typefaceinfos import readTypefaceNameInfo
@@ -29,6 +29,18 @@ when defined(macosx):
       let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
       check result.available
       check result.match.isNone
+
+    test "enumerates owned local faces with unique identities":
+      var
+        available = false
+        identities = initHashSet[(string, int)]()
+      for info in nativeSystemTypefaces(available):
+        let identity = (info.file.path, info.file.faceIndex)
+        check info.file.path.fileExists()
+        check identity notin identities
+        identities.incl(identity)
+      check available
+      check identities.len > 0
 else:
   suite "Core Text system-font provider":
     test "is only exercised on macOS":

--- a/tests/tsystemfonts_windows.nim
+++ b/tests/tsystemfonts_windows.nim
@@ -1,0 +1,41 @@
+import std/[options, os, unittest]
+
+from figdraw/common/typefaceinfos import readTypefaceNameInfo
+import figdraw/extras/systemfonts_windows
+
+suite "DirectWrite system-font provider":
+  when defined(windows):
+    const
+      sansCandidates = ["Arial", "Liberation Sans", "DejaVu Sans"]
+      boldCandidates = ["Arial Bold", "Liberation Sans Bold", "DejaVu Sans Bold"]
+
+    test "returns a local regular face with an exact face index":
+      let result = findNativeSystemTypefaceFile(sansCandidates)
+      check result.available
+      require result.match.isSome
+      let match = result.match.get()
+      check match.path.fileExists()
+      check match.faceIndex >= 0
+
+    test "supports explicit full names and candidate fallback":
+      let explicitFace = findNativeSystemTypefaceFile(boldCandidates)
+      check explicitFace.available
+      require explicitFace.match.isSome
+      let boldMatch = explicitFace.match.get()
+      check readTypefaceNameInfo(readFile(boldMatch.path), Natural(boldMatch.faceIndex)).bold
+
+      let fallback = findNativeSystemTypefaceFile(
+        ["FigDraw Missing Font 8E5269A4", "Arial", "Liberation Sans", "DejaVu Sans"]
+      )
+      check fallback.available
+      check fallback.match.isSome
+
+    test "does not accept an unrelated closest family":
+      let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
+      check result.available
+      check result.match.isNone
+  else:
+    test "is unavailable off Windows":
+      let result = findNativeSystemTypefaceFile(["Arial"])
+      check not result.available
+      check result.match.isNone

--- a/tests/tsystemfonts_windows.nim
+++ b/tests/tsystemfonts_windows.nim
@@ -1,6 +1,7 @@
 import std/[options, os, sets, unittest]
 
 from figdraw/common/typefaceinfos import readTypefaceNameInfo
+from figdraw/extras/systemfonttypes import SystemTypeface
 import figdraw/extras/systemfonts_windows
 
 suite "DirectWrite system-font provider":
@@ -10,46 +11,47 @@ suite "DirectWrite system-font provider":
       boldCandidates = ["Arial Bold", "Liberation Sans Bold", "DejaVu Sans Bold"]
 
     test "returns a local regular face with an exact face index":
-      let result = findNativeSystemTypefaceFile(sansCandidates)
+      let result = findNativeSystemTypeface(sansCandidates)
       check result.available
       require result.match.isSome
       let match = result.match.get()
-      check match.path.fileExists()
-      check match.faceIndex >= 0
+      check match.file.path.fileExists()
+      check match.file.faceIndex >= 0
 
     test "supports explicit full names and candidate fallback":
-      let explicitFace = findNativeSystemTypefaceFile(boldCandidates)
+      let explicitFace = findNativeSystemTypeface(boldCandidates)
       check explicitFace.available
       require explicitFace.match.isSome
       let boldMatch = explicitFace.match.get()
-      check readTypefaceNameInfo(readFile(boldMatch.path), Natural(boldMatch.faceIndex)).bold
+      check readTypefaceNameInfo(
+        readFile(boldMatch.file.path), Natural(boldMatch.file.faceIndex)
+      ).bold
 
-      let fallback = findNativeSystemTypefaceFile(
+      let fallback = findNativeSystemTypeface(
         ["FigDraw Missing Font 8E5269A4", "Arial", "Liberation Sans", "DejaVu Sans"]
       )
       check fallback.available
       check fallback.match.isSome
 
     test "does not accept an unrelated closest family":
-      let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
+      let result = findNativeSystemTypeface(["FigDraw Missing Font 8E5269A4"])
       check result.available
       check result.match.isNone
 
     test "enumerates locally readable nonsimulated faces":
       var
         available = false
-        identities = initHashSet[(string, int)]()
+        identities = initHashSet[SystemTypeface]()
       for info in nativeSystemTypefaces(available):
-        let identity = (info.file.path, info.file.faceIndex)
-        check info.file.path.isAbsolute()
-        check info.file.path.fileExists()
-        check identity notin identities
-        identities.incl(identity)
+        check info.typeface.file.path.isAbsolute()
+        check info.typeface.file.path.fileExists()
+        check info.typeface notin identities
+        identities.incl(info.typeface)
       check available
       check identities.len > 0
   else:
     test "is unavailable off Windows":
-      let result = findNativeSystemTypefaceFile(["Arial"])
+      let result = findNativeSystemTypeface(["Arial"])
       check not result.available
       check result.match.isNone
 

--- a/tests/tsystemfonts_windows.nim
+++ b/tests/tsystemfonts_windows.nim
@@ -1,4 +1,4 @@
-import std/[options, os, unittest]
+import std/[options, os, sets, unittest]
 
 from figdraw/common/typefaceinfos import readTypefaceNameInfo
 import figdraw/extras/systemfonts_windows
@@ -34,8 +34,28 @@ suite "DirectWrite system-font provider":
       let result = findNativeSystemTypefaceFile(["FigDraw Missing Font 8E5269A4"])
       check result.available
       check result.match.isNone
+
+    test "enumerates locally readable nonsimulated faces":
+      var
+        available = false
+        identities = initHashSet[(string, int)]()
+      for info in nativeSystemTypefaces(available):
+        let identity = (info.file.path, info.file.faceIndex)
+        check info.file.path.isAbsolute()
+        check info.file.path.fileExists()
+        check identity notin identities
+        identities.incl(identity)
+      check available
+      check identities.len > 0
   else:
     test "is unavailable off Windows":
       let result = findNativeSystemTypefaceFile(["Arial"])
       check not result.available
       check result.match.isNone
+
+    test "enumeration is unavailable off Windows":
+      var available = true
+      for info in nativeSystemTypefaces(available):
+        discard info
+        check false
+      check not available

--- a/tests/ttext_backend_info.nim
+++ b/tests/ttext_backend_info.nim
@@ -26,4 +26,4 @@ suite "text backend information":
       discard
 
   test "reports supported typeface file extensions":
-    check supportedFontFileExtensions() == @[".ttf", ".otf", ".ttc", ".svg"]
+    check supportedFontFileExtensions() == @[".ttf", ".otf", ".ttc", ".svg", ".otc"]

--- a/tools/test-windows-wine.sh
+++ b/tools/test-windows-wine.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+figdrawRoot=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+figdrawDockerContext=${FIGDRAW_DOCKER_CONTEXT:-docker1}
+figdrawImage=${FIGDRAW_WINDOWS_WINE_IMAGE:-figdraw/windows-wine-test:debian13}
+figdrawContainer=
+
+cleanup() {
+  if [ -n "$figdrawContainer" ]; then
+    docker --context "$figdrawDockerContext" rm -f "$figdrawContainer" >/dev/null 2>&1 || true
+    figdrawContainer=
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+docker context inspect "$figdrawDockerContext" >/dev/null
+docker --context "$figdrawDockerContext" build \
+  --tag "$figdrawImage" \
+  "$figdrawRoot/tools/windows-wine"
+
+figdrawContainer=$(docker --context "$figdrawDockerContext" create "$figdrawImage")
+docker --context "$figdrawDockerContext" cp \
+  "$figdrawRoot/src" "$figdrawContainer:/work/src"
+docker --context "$figdrawDockerContext" cp \
+  "$figdrawRoot/tests/tsystemfonts_windows.nim" \
+  "$figdrawContainer:/work/tests/tsystemfonts_windows.nim"
+docker --context "$figdrawDockerContext" start --attach "$figdrawContainer"

--- a/tools/windows-wine/Dockerfile
+++ b/tools/windows-wine/Dockerfile
@@ -1,0 +1,23 @@
+FROM nimlang/nim:2.2.4 AS nim
+
+FROM debian:13-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/nim/bin:${PATH}"
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    fonts-dejavu-core \
+    fonts-liberation \
+    gcc-mingw-w64-x86-64 \
+    wine \
+    wine64 \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=nim /opt/nim /opt/nim
+COPY run.sh /usr/local/bin/figdraw-windows-wine-test
+
+WORKDIR /work
+RUN mkdir -p /work/tests
+ENTRYPOINT ["/usr/local/bin/figdraw-windows-wine-test"]

--- a/tools/windows-wine/README.md
+++ b/tools/windows-wine/README.md
@@ -1,0 +1,34 @@
+# Windows provider smoke test with Wine
+
+This harness cross-compiles the DirectWrite provider test with MinGW and runs
+the resulting Windows executable under Wine on an AMD64 Linux Docker host. It
+exercises the Windows-only Nim code, COM ABI calls, `dwrite.dll` loading, system
+font matching, path extraction, and collection face indices.
+
+The Debian 13 image copies the pinned Nim 2.2.4 toolchain from the official
+`nimlang/nim` image because Debian 13 does not package Nim. It installs Debian's
+64-bit Wine and MinGW packages, together with Liberation and DejaVu fonts used
+as portable test candidates. The test's import closure only needs the Nim
+standard library and `src/`, so the harness does not install project packages.
+
+From the repository root, run:
+
+```sh
+tools/test-windows-wine.sh
+```
+
+The runner uses the `docker1` context by default, which points at the `dockerxx`
+host in the FigDraw development environment. Override the context or cached
+image name when needed:
+
+```sh
+FIGDRAW_DOCKER_CONTEXT=my-context \
+  FIGDRAW_WINDOWS_WINE_IMAGE=figdraw/windows-wine-test:local \
+  tools/test-windows-wine.sh
+```
+
+Wine implements DirectWrite rather than executing Microsoft's implementation.
+This is therefore a local ABI and behavior smoke test, not a replacement for
+running the same test on Windows. A harmless `syswow64/rundll32.exe` warning may
+appear while a fresh 64-bit-only Wine prefix is initialized; the tested binary
+and all installed packages are 64-bit.

--- a/tools/windows-wine/run.sh
+++ b/tools/windows-wine/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+export WINEARCH=win64
+export WINEDEBUG=-all
+export WINEDLLOVERRIDES="mscoree,mshtml="
+export WINEPREFIX=/tmp/figdraw-wine
+export XDG_RUNTIME_DIR=/tmp/figdraw-xdg
+
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+test -f /work/tests/tsystemfonts_windows.nim
+test -d /work/src
+
+nim c \
+  --os:windows \
+  --cpu:amd64 \
+  --cc:gcc \
+  --gcc.exe:x86_64-w64-mingw32-gcc \
+  --gcc.linkerexe:x86_64-w64-mingw32-gcc \
+  --mm:arc \
+  --threads:on \
+  --path:/work/src \
+  --nimcache:/tmp/figdraw-windows-nimcache \
+  --out:/tmp/tsystemfonts_windows.exe \
+  /work/tests/tsystemfonts_windows.nim
+
+wineboot --init
+wineserver --wait
+wine /tmp/tsystemfonts_windows.exe
+wineserver --wait


### PR DESCRIPTION
## Summary

- discover and match installed fonts through DirectWrite on Windows, Core Text on macOS, and Fontconfig on Linux and FreeBSD
- separate physical font files from exact installed typefaces: `SystemTypefaceFile` carries path/index, while `SystemTypeface` adds canonical variation coordinates
- return exact identities from installed-font queries and the `systemFontFaces` iterator without allocating a catalog sequence
- preserve ordered fallbacks and return concrete local files, collection indices, and representable named-instance coordinates
- load exact faces through `fontWithSize(SystemTypeface, size)` and log the selected path/index for unambiguous verification
- retain OpenType metadata support for loaded, embedded, in-memory, and caller-supplied font files
- bump FigDraw to 0.37.0 and track Siwin `master`, which contains merged commit `5bc4ce6`

This branch includes the OpenType metadata work from #75 and supersedes that PR.

## API

- `SystemTypefaceFile(path, faceIndex)` identifies one physical OpenType face
- `SystemTypeface(file, variations)` identifies an exact selectable instance
- `SystemTypefaceInfo.typeface` pairs that identity with provider display names
- `SystemTypefaceQuery` supports exact family/subfamily filters
- `findSystemTypeface` returns an exact identity
- `systemFontFaces(query)` lazily iterates exact identities
- constructors validate nonnegative indices, four-byte printable axis tags, unique tags, finite values, and canonical axis ordering

## Platform behavior

- Windows: runtime-loaded DirectWrite with COM ownership, UTF-16 names, exact face indices, and rejection of simulated, remote, multi-file, or otherwise unrepresentable faces
- macOS: Core Text descriptor matching with explicit post-validation, local URL/index extraction, atomic named-instance variation extraction, and collection-header sniffing
- Linux/FreeBSD: runtime-loaded Fontconfig with exact post-validation; packed named-instance indices are omitted until their coordinates can be represented
- providers omit instances they cannot describe exactly instead of returning misleading identities

## Validation

- `atlas install -tuk` resolves Siwin `master` successfully through an Atlas-clean-compatible branch ref
- focused system-font and font-utils tests — 5/5 passed after the 0.37.0/Siwin update
- prior full run: `atlas-run tests` — 38/38 test files passed on macOS
- `atlas-run tests dynlib_api -- -d:useNativeDynlib`
- `atlas-run tests --compile-only examples/windy_text.nim examples/windy_text_shaping_demo.nim`
- Windows and FreeBSD target checks
- Core Text tests verify named variable instances sharing one file/index round-trip with distinct coordinates
- `nph` and `git diff --check`

## Rendering note

Variation coordinates are consumed by HarfBuzz-capable text backends. The lightweight Pixie path retains the identity but does not currently apply variation axes.

## Deferred

No new metadata cache was added; consumers can add one later if profiling justifies it.

## GC and threading

No GC mode or threading behavior changes. Native libraries are loaded at runtime, and provider-owned OS objects are released within each lookup.
