### PR TITLE
Default Linux and x32 targets to OpenGL

### DIFF
--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -1,4 +1,4 @@
-version = "0.37.0"
+version = "0.37.1"
 author = "Jaremy Creechley"
 description = "UI Engine for Nim"
 license = "MIT"

--- a/src/figdraw/commons.nim
+++ b/src/figdraw/commons.nim
@@ -10,7 +10,10 @@ const WantVulkanBackend {.booldefine: "figdraw.vulkan".} =
 const UseVulkanReadback* {.booldefine: "figdraw.vulkanReadback".} = false
 const WantMetalBackend {.booldefine: "figdraw.metal".} = defined(macosx)
 const UseOpenGlBackend* {.booldefine: "figdraw.opengl".} =
-  not (WantMetalBackend or WantVulkanBackend)
+  when defined(linux) or defined(cpu32):
+    true
+  else:
+    not (WantMetalBackend or WantVulkanBackend)
 const UseVulkanBackend* = WantVulkanBackend and not UseOpenGlBackend
 const UseMetalBackend* =
   WantMetalBackend and not UseOpenGlBackend and not UseVulkanBackend

--- a/tests/tbackend_defaults.nim
+++ b/tests/tbackend_defaults.nim
@@ -1,0 +1,17 @@
+import std/unittest
+
+import figdraw/commons
+
+when (defined(linux) or defined(cpu32)) and not defined(figdraw.opengl):
+  static:
+    doAssert UseOpenGlBackend
+    doAssert not UseVulkanBackend
+    doAssert not UseMetalBackend
+
+suite "renderer backend defaults":
+  test "enables exactly one backend":
+    check ord(UseOpenGlBackend) + ord(UseVulkanBackend) + ord(UseMetalBackend) == 1
+
+  when (defined(linux) or defined(cpu32)) and not defined(figdraw.opengl):
+    test "prefers OpenGL on Linux and 32-bit targets":
+      check UseOpenGlBackend


### PR DESCRIPTION
## Summary

- default Linux and 32-bit targets to the OpenGL renderer using compile-time `defined(linux)` and `defined(cpu32)` checks
- preserve the existing Vulkan default on supported 64-bit non-Linux targets and explicit backend overrides
- add backend-selection regression coverage, including compile-time assertions for Linux and 32-bit targets
- bump the FigDraw package version to `0.37.1`

## Testing

- `atlas-run tests` (39/39 passed)
- compile-only checks for Linux amd64, Windows i386, Windows amd64, and an explicit Linux Vulkan selection

## Threading / GC

No threading or GC behavior changes.