### PR TITLE
Fix transformed Vulkan content clips

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.37.4
+
+- Transform Vulkan content-clip bounds into framebuffer coordinates so translated
+  views retain their text and decorations.
+
 ## 0.37.3
 
 - Select the owning OpenGL context before image preparation, atlas rebuilds,

--- a/figdraw.nimble
+++ b/figdraw.nimble
@@ -1,4 +1,4 @@
-version = "0.37.3"
+version = "0.37.4"
 author = "Jaremy Creechley"
 description = "UI Engine for Nim"
 license = "MIT"

--- a/src/figdraw/figrender.nim
+++ b/src/figdraw/figrender.nim
@@ -72,7 +72,7 @@ proc backendName*[BackendState](renderer: FigRenderer[BackendState]): string =
 
 proc activateContext*[BackendState](renderer: FigRenderer[BackendState]) =
   ## Make the renderer's OpenGL context current before using its GPU resources.
-  if renderer.backendKind() == rbOpenGL and not renderer.contextActivation.isNil:
+  if not renderer.contextActivation.isNil and renderer.backendKind() == rbOpenGL:
     renderer.contextActivation(renderer)
 
 proc atlasUsage*[BackendState](renderer: FigRenderer[BackendState]): AtlasUsage =

--- a/src/figdraw/vulkan/vulkan_context.nim
+++ b/src/figdraw/vulkan/vulkan_context.nim
@@ -3528,6 +3528,25 @@ proc intersectRects(a, b: Rect): Rect =
     return rect(0, 0, 0, 0)
   rect(x0, y0, x1 - x0, y1 - y0)
 
+proc transformedBounds(ctx: VulkanContext, source: Rect): Rect =
+  let corners = [
+    ctx.mat * source.xy,
+    ctx.mat * vec2(source.x + source.w, source.y),
+    ctx.mat * vec2(source.x, source.y + source.h),
+    ctx.mat * (source.xy + source.wh),
+  ]
+  var
+    minX = corners[0].x
+    minY = corners[0].y
+    maxX = corners[0].x
+    maxY = corners[0].y
+  for i in 1 ..< corners.len:
+    minX = min(minX, corners[i].x)
+    minY = min(minY, corners[i].y)
+    maxX = max(maxX, corners[i].x)
+    maxY = max(maxY, corners[i].y)
+  rect(minX, minY, maxX - minX, maxY - minY)
+
 proc clearMask*(ctx: VulkanContext) =
   assert ctx.frameBegun == true, "ctx.beginFrame has not been called."
   ctx.flush()
@@ -3540,7 +3559,7 @@ method beginMask*(ctx: VulkanContext, clipRect: Rect, radii: CornerRadii2D[float
   ctx.maskBegun = true
   inc ctx.maskDepth
 
-  ctx.pendingMaskRect = clipRect
+  ctx.pendingMaskRect = ctx.transformedBounds(clipRect)
   ctx.pendingMaskValid = true
 
 method endMask*(ctx: VulkanContext) =

--- a/tests/tfigrender_env_override.nim
+++ b/tests/tfigrender_env_override.nim
@@ -183,3 +183,7 @@ suite "figrender env overrides":
     check renderer.textLcdFiltering() == false
     check renderer.textSubpixelPositioning() == false
     check renderer.textSubpixelGlyphVariants() == false
+
+  test "context activation is optional for backend-free renderers":
+    let renderer = newFigRenderer(BackendContext())
+    renderer.activateContext()

--- a/tests/tsiwin_rect_mask_vulkan.nim
+++ b/tests/tsiwin_rect_mask_vulkan.nim
@@ -11,18 +11,11 @@ import ./siwin_test_utils
 proc maxChannelDelta(a: ColorRGBX, r, g, b: uint8): int =
   result = max(abs(a.r.int - r.int), max(abs(a.g.int - g.int), abs(a.b.int - b.int)))
 
-proc sampleLogical(img: Image, x, y: int, logicalW, logicalH: int): ColorRGBX =
-  let
-    sx = img.width.float32 / logicalW.float32
-    sy = img.height.float32 / logicalH.float32
-    px = clamp(round(x.float32 * sx).int, 0, img.width - 1)
-    py = clamp(round(y.float32 * sy).int, 0, img.height - 1)
-  img[px, py]
+proc sampleLogical(img: Image, x, y: int): ColorRGBX =
+  img[clamp(x, 0, img.width - 1), clamp(y, 0, img.height - 1)]
 
-template assertLogicalColor(
-    img: Image, x, y, logicalW, logicalH: int, r, g, b: uint8, tol: int = 12
-) =
-  let px = img.sampleLogical(x, y, logicalW, logicalH)
+template assertLogicalColor(img: Image, x, y: int, r, g, b: uint8, tol: int = 12) =
+  let px = img.sampleLogical(x, y)
   check px.maxChannelDelta(r, g, b) <= tol
 
 proc addRect(
@@ -128,6 +121,34 @@ proc makeSmallClipRenderTree(w, h: float32): Renders =
   result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
   result.layers[0.ZLevel] = list
 
+proc makeTranslatedClipRenderTree(w, h: float32): Renders =
+  var list = RenderList()
+  discard list.addRootRect(rect(0, 0, w, h), rgba(255, 255, 255, 255), 0.ZLevel)
+
+  let transformIdx = list.addRoot(
+    Fig(
+      kind: nkTransform,
+      childCount: 0,
+      zlevel: 0.ZLevel,
+      transform: TransformStyle(translation: vec2(40.0'f32, 30.0'f32)),
+    )
+  )
+  let clipIdx = list.addChild(
+    transformIdx,
+    Fig(
+      kind: nkRectangle,
+      childCount: 0,
+      zlevel: 0.ZLevel,
+      screenBox: rect(0, 0, 100, 30),
+      fill: rgba(0, 0, 0, 0),
+      flags: {NfClipContent},
+    ),
+  )
+  list.addRect(clipIdx, rect(-15, -10, 130, 50), rgba(56, 168, 88, 255), 0.ZLevel)
+
+  result = Renders(layers: initOrderedTable[ZLevel, RenderList]())
+  result.layers[0.ZLevel] = list
+
 suite "siwin vulkan rect mask":
   test "keeps mixed masked and unmasked siblings in one batch":
     when UseVulkanBackend:
@@ -157,11 +178,11 @@ suite "siwin vulkan rect mask":
         check fileExists(outPath)
         check getFileSize(outPath) > 0
 
-        assertLogicalColor(rendered, 74, 88, windowW, windowH, 230, 70, 52)
-        assertLogicalColor(rendered, 160, 88, windowW, windowH, 255, 255, 255)
-        assertLogicalColor(rendered, 204, 88, windowW, windowH, 56, 168, 88)
-        assertLogicalColor(rendered, 276, 88, windowW, windowH, 255, 255, 255)
-        assertLogicalColor(rendered, 336, 88, windowW, windowH, 54, 118, 230)
+        assertLogicalColor(rendered, 74, 88, 230, 70, 52)
+        assertLogicalColor(rendered, 160, 88, 255, 255, 255)
+        assertLogicalColor(rendered, 204, 88, 56, 168, 88)
+        assertLogicalColor(rendered, 276, 88, 255, 255, 255)
+        assertLogicalColor(rendered, 336, 88, 54, 118, 230)
     else:
       skip()
 
@@ -193,9 +214,43 @@ suite "siwin vulkan rect mask":
         check fileExists(outPath)
         check getFileSize(outPath) > 0
 
-        assertLogicalColor(rendered, 64, 32, windowW, windowH, 220, 40, 40)
-        assertLogicalColor(rendered, 64, 68, windowW, windowH, 56, 168, 88)
-        assertLogicalColor(rendered, 64, 108, windowW, windowH, 54, 118, 230)
-        assertLogicalColor(rendered, 64, 152, windowW, windowH, 210, 170, 46)
+        assertLogicalColor(rendered, 64, 32, 220, 40, 40)
+        assertLogicalColor(rendered, 64, 68, 56, 168, 88)
+        assertLogicalColor(rendered, 64, 108, 54, 118, 230)
+        assertLogicalColor(rendered, 64, 152, 210, 170, 46)
+    else:
+      skip()
+
+  test "NfClipContent applies the active transform to its Vulkan scissor":
+    when UseVulkanBackend:
+      const
+        windowW = 180
+        windowH = 100
+      setFigUiScale(1.0)
+      let outDir = ensureTestOutputDir()
+      let outPath = outDir / "render_translated_clip_vulkan.png"
+      if fileExists(outPath):
+        removeFile(outPath)
+
+      block renderOnce:
+        var rendered: Image
+        try:
+          rendered = renderAndScreenshotOnce(
+            makeRenders = makeTranslatedClipRenderTree,
+            outputPath = outPath,
+            windowW = windowW,
+            windowH = windowH,
+            title = "figdraw test: vulkan translated clip",
+          )
+        except ValueError:
+          skip()
+          break renderOnce
+
+        check fileExists(outPath)
+        check getFileSize(outPath) > 0
+
+        assertLogicalColor(rendered, 60, 45, 56, 168, 88)
+        assertLogicalColor(rendered, 30, 45, 255, 255, 255)
+        assertLogicalColor(rendered, 150, 45, 255, 255, 255)
     else:
       skip()


### PR DESCRIPTION
## Summary

- Transform Vulkan content-clip bounds through the active render matrix before applying framebuffer scissors, so translated views retain text and decorations.
- Keep context activation optional for backend-free renderers after the OpenGL context-selection work in #79.
- Add real Vulkan screenshot coverage for translated clips.
- Bump FigDraw to 0.37.4 and document the fix.

This complements the Vulkan atlas lifetime fixes in #78 and the OpenGL multi-context atlas fix in #79.

## Verification

- GitHub Actions: 7/7 jobs passed across Linux X11/Wayland Vulkan and OpenGL, macOS native, and Windows Vulkan and OpenGL.
- `atlas-run tests`: 42/42 runners passed.
- Delegated exact X11/OpenGL workflow environment: 41/41 test files passed, all Windy/Siwin examples compiled, and the HarfBuzz font test passed.
- Delegated exact current-tip X11 Vulkan workflow with `-d:figdraw.vulkanValidation`: 41/41 test files passed, all Windy/Siwin examples compiled, and the HarfBuzz font test passed.
- The new transformed-scissor screenshot regression passed with no validation errors or VUID messages.
- Merenda full suite against this branch: 5/5 runners passed.
- `examples/all_compile.nim` compiled through the Merenda test runner.
- `controls_showcase.nim` rendered completely in repeated Vulkan and forced-OpenGL screenshot checks.